### PR TITLE
Avoid problems with SSL and versions prior to 2.7.9

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -34,8 +34,10 @@ import argparse
 import working
 import time
 import ssl
+import sys
 
-ssl._create_default_https_context = ssl._create_unverified_context
+if sys.version_info >= (2, 7, 9):
+    ssl._create_default_https_context = ssl._create_unverified_context
 
 from pgoapi import PGoApi
 from pgoapi.utilities import f2i, h2f


### PR DESCRIPTION
https://github.com/PokemonGoF/PokemonGo-Bot/blob/master/pokecli.py#L38 this part is only for python 2.7.9 or above