### PR TITLE
Adding Dockerfile to dockerize project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:2.7-onbuild
+ENV AUTH_SERVICE ""
+ENV USERNAME ""
+ENV PASSWORD ""
+ENV LOCATION ""
+ENV CP ""
+
+CMD python pokecli.py -a $AUTH_SERVICE -u $USERNAME -p $PASSWORD -l $LOCATION -s -c $CP
+


### PR DESCRIPTION
Create a dockerfile to avoid installing dependencias.

Usage:

docker build -t pokemon .

docker run -e AUTH_SERVICE=google -e USERNAME=user -e PASSWORD=pass -e LOCATION=Spain -e CP=10 pokemon

I already pushed the docker image to dockerhub so alternative you can do this:


docker run -e AUTH_SERVICE=google -e USERNAME=user -e PASSWORD=pass -e LOCATION=Spain -e CP=10 mercuriete/pokemongo-bot


The Dockerfile is selfexplanatory. pulls python 2.7 image, then do a pip requeriments.txt and then pass some enviroment variables to the container and then run pokecli.

I hope you merge this pull request :smile: 

Thanks in advance.
