### PR TITLE
Simple Timeout-Event to prevent Timeout-Exceptions

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -52,7 +52,7 @@ global config
 
 def get_pos_by_name(location_name):
     geolocator = GoogleV3()
-    loc = geolocator.geocode(location_name)
+    loc = geolocator.geocode(location_name, timeout=10)
 
     log.info('Your given location: %s', loc.address.encode('utf-8'))
     log.info('lat/long/alt: %s %s %s', loc.latitude, loc.longitude, loc.altitude)


### PR DESCRIPTION
Simple Timeout-Event to prevent Timeout-Exceptions

Just give the Programm some time to get the Coords perfectly 🎉 

My Exception without Timeout Event:

```
Traceback (most recent call last):
  File "pokecli.py", line 251, in <module>
    main()
  File "pokecli.py", line 144, in main
    position = get_pos_by_name(config.location)
  File "pokecli.py", line 59, in get_pos_by_name
    loc = geolocator.geocode(location_name)
  File "/Library/Python/2.7/site-packages/geopy/geocoders/googlev3.py", line 217, in geocode
    self._call_geocoder(url, timeout=timeout), exactly_one
  File "/Library/Python/2.7/site-packages/geopy/geocoders/base.py", line 163, in _call_geocoder
    raise GeocoderTimedOut('Service timed out')
geopy.exc.GeocoderTimedOut: Service timed out
```