### PR TITLE
Indentation fix for config.json.example

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -3,11 +3,12 @@
     "username": "example@gmail.com",
     "password": "password11!!",
     "location": "New York",
-	"cp": "100",
-	"gmapkey": "None",
-	"maxsteps": "100",
-	"spinstop": "False",
-	"walk": "4.16",
-	"debug": "False",
-	"test": "False"
+    "cp": "100",
+    "gmapkey": "CHANGME",
+    "maxsteps": "100",
+    "spinstop": "False",
+    "walk": "4.16",
+    "debug": "False",
+    "test": "False"
 }
+


### PR DESCRIPTION
Small update since notepad++ messed up some of the indentation (replaced by tabs were the original was with spaces)