### PR TITLE
Do not encode received string

### DIFF
--- a/pokemongo_bot/cell_workers/seen_fort_worker.py
+++ b/pokemongo_bot/cell_workers/seen_fort_worker.py
@@ -43,7 +43,7 @@ class SeenFortWorker(object):
         self.api.fort_details(fort_id=self.fort['id'], latitude=position[0], longitude=position[1])
         response_dict = self.api.call()
         fort_details = response_dict['responses']['FORT_DETAILS']
-        fort_name = fort_details['name'].encode('utf8', 'replace')
+        fort_name = fort_details['name']
         print_yellow('Now at Pokestop: ' + fort_name + ' - Spinning...')
         sleep(2)
         self.api.fort_search(fort_id=self.fort['id'], fort_latitude=lat, fort_longitude=lng, player_latitude=f2i(position[0]), player_longitude=f2i(position[1]))


### PR DESCRIPTION
Otherwise the following print instruction will fail with a
UnicodeDecodeError when there are non-ASCII characters in the
Pokestop name.