### PR TITLE
Use entrypoint instead of ENV variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,3 @@
 FROM python:2.7-onbuild
-ENV AUTH_SERVICE ""
-ENV USERNAME ""
-ENV PASSWORD ""
-ENV LOCATION ""
-ENV WALK ""
-ENV CP ""
 
-CMD python pokecli.py -a $AUTH_SERVICE -u $USERNAME -p $PASSWORD -l $LOCATION -w $WALK -s -c $CP
-
+ENTRYPOINT ["python", "pokecli.py"]


### PR DESCRIPTION
The use of entrypoint instead of ENV variables allows the container to be run like an executable. This way everything remains uniform, in my opinion.

I would also suggest this repository to be auto build on the docker hub: https://docs.docker.com/docker-hub/builds/