### PR TITLE
Adding initial REST Framework; Adding method to get user stats

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -39,6 +39,7 @@ if sys.version_info >= (2, 7, 9):
     ssl._create_default_https_context = ssl._create_unverified_context
 
 from pokemongo_bot import PokemonGoBot
+from server import PokemonGoServer
 
 def init_config():
     parser = argparse.ArgumentParser()
@@ -96,8 +97,14 @@ def main():
     bot = PokemonGoBot(config)
     bot.start()
 
-    while(True):
-        bot.take_step()
+    pid = os.fork()
+
+    if pid == 0:
+        server = PokemonGoServer(bot, 5000)
+        server.start()
+    else:
+        while(True):
+            bot.take_step()
 
 if __name__ == '__main__':
     main()

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -11,6 +11,7 @@ from cell_workers.utils import distance
 from stepper import Stepper
 from geopy.geocoders import GoogleV3
 from math import radians, sqrt, sin, cos, atan2
+from collections import OrderedDict
 
 class PokemonGoBot(object):
 
@@ -248,7 +249,10 @@ class PokemonGoBot(object):
             return itemcount
         return '0'
 
-    def get_player_info(self):
+    def get_player_info(self, print_stats=True):
+        player_stats = stats = OrderedDict()
+
+        # Get contents of inventory
         self.api.get_inventory()
         response_dict = self.api.call()
         if 'responses' in response_dict:
@@ -266,14 +270,19 @@ class PokemonGoBot(object):
                                     nextlvlxp = (int(playerdata['next_level_xp']) - int(playerdata['experience']))
 
                                     if 'level' in playerdata:
-                                        print('[#] -- Level: {level}'.format(**playerdata))
+                                        player_stats['Level'] = playerdata['level']
 
                                     if 'experience' in playerdata:
-                                        print('[#] -- Experience: {experience}'.format(**playerdata))
-                                        print('[#] -- Experience until next level: {}'.format(nextlvlxp))
+                                        player_stats['Experience'] = playerdata['experience']
+                                        player_stats['Experience until next level'] = nextlvlxp
 
                                     if 'pokemons_captured' in playerdata:
-                                        print('[#] -- Pokemon Captured: {pokemons_captured}'.format(**playerdata))
+                                        player_stats['Pokemon Captured'] = playerdata['pokemons_captured']
 
                                     if 'poke_stop_visits' in playerdata:
-                                        print('[#] -- Pokestops Visited: {poke_stop_visits}'.format(**playerdata))
+                                        player_stats['Pokestops Visited'] = playerdata['poke_stop_visits']
+
+        if print_stats:
+            for key in player_stats:
+                 print("[#] -- %s: %s" % (key, player_stats[key]))
+        return json.dumps(player_stats, indent=4)

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -284,5 +284,5 @@ class PokemonGoBot(object):
 
         if print_stats:
             for key in player_stats:
-                 print("[#] -- %s: %s" % (key, player_stats[key]))
+                 print('[#] -- {}: {}'.format(key, player_stats[key]))
         return json.dumps(player_stats, indent=4)

--- a/server.py
+++ b/server.py
@@ -1,0 +1,30 @@
+import json 
+
+from flask import Flask
+from flask.ext.classy import FlaskView, route
+#from bot import PokemonGoBot
+
+from pgoapi import PGoApi
+
+app = Flask(__name__)
+
+global global_bot
+
+class PokemonGoServer(object):
+    def __init__(self, bot, port=5000):
+        api_view = ApiView()
+        api_view.set_bot(bot)
+        api_view.register(app)
+        self.port = port
+
+    def start(self):
+        app.run(host='0.0.0.0', port=self.port)
+
+class ApiView(FlaskView):
+    def set_bot(self, bot):
+        global global_bot
+        global_bot = bot
+
+    @route("/player_info")
+    def get_player_info(self):
+        return global_bot.get_player_info(False)


### PR DESCRIPTION
Right now there isn't a way for a developer to get information on the bot while the bot is running.  Sure, you can check information by logging into the app or debugging, but there is no way to query the bot for various statistics.  I added a REST Framework to the bot so that a user can retrieve this information by accessing various endpoints.

Some use cases:

- Developers trying to gather information/test methods

- Developers wanting to write other applications that interact with the bot, such as web views or chat commands

- A way to access the bot without logging in; very useful for people with multiple accounts (or a bot test account)


When the bot is started, it starts to listen on port 5000 for any requests.  This runs in parallel to the main bot via a fork.  As of this PR, there is only one method (more will be added once the Framework is approved):

`/api/player_info`  - Returns the results of the `bot.get_player_info()` method

Example:

`bstascav@kefka:~/pgoapi# curl -XGET localhost:5000/api/player_info
{
    "Level": 7,
    "Experience": 26465,
    "Experience until next level": 1535,
    "Pokemon Captured": 73,
    "Pokestops Visited": 34
}`