### PR TITLE
Fixes UnicodeEncodeError on initial location

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -203,7 +203,7 @@ class PokemonGoBot(object):
         self.position = self._get_pos_by_name(self.config.location)
         self.api.set_position(*self.position)
 
-        print('[x] Address found: {}'.format(self.config.location.decode('utf-8')))
+        print(u'[x] Address found: {}'.format(self.config.location.decode('utf-8')))
         print('[x] Position in-game set as: {}'.format(self.position))
 
         if self.config.test:


### PR DESCRIPTION
Short Description: 
When initial location has special characters the current version crashes with a UnicodeEncodeError: 'ascii' codec can't encode character u'\xe7' in position 14: ordinal not in range(128).

Fixes:
- UnicodeEncodeError when initial location has special characters, e.g. "Paço"