### PR TITLE
Fix encoding error when printing messages

### DIFF
--- a/pokemongo_bot/cell_workers/utils.py
+++ b/pokemongo_bot/cell_workers/utils.py
@@ -12,10 +12,10 @@ def i2f(int):
     return struct.unpack('<d', struct.pack('<Q', int))[0]
 
 def print_green(message):
-    print('\033[92m' + message + '\033[0m');
+    print(u'\033[92m' + message.decode('utf-8') + '\033[0m');
 
 def print_yellow(message):
-    print('\033[93m' + message + '\033[0m');
+    print(u'\033[93m' + message.decode('utf-8') + '\033[0m');
 
 def print_red(message):
-    print('\033[91m' + message + '\033[0m');
+    print(u'\033[91m' + message.decode('utf-8') + '\033[0m');


### PR DESCRIPTION
Short Description: 
Some messages that will be printed will contain utf-8 chars, e.g. Pokestops in European locations.

Fixes:
- Printing messages that contain special chars, e.g. Pokestops in Europe.