### PR TITLE
Fixes UnicodeEncodeError on initial location

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -205,7 +205,7 @@ class PokemonGoBot(object):
         self.position = self._get_pos_by_name(self.config.location)
         self.api.set_position(*self.position)
         print('')
-        print('[x] Address found: {}'.format(self.config.location.decode('utf-8')))
+        print(u'[x] Address found: {}'.format(self.config.location.decode('utf-8')))
         print('[x] Position in-game set as: {}'.format(self.position))
         print('')
 


### PR DESCRIPTION
Short Description: 
When initial location has special characters the current version crashes with a UnicodeEncodeError: 'ascii' codec can't encode character u'\xe7' in position 14: ordinal not in range(128).
Will close #213 in favour of this. Sorry I couldn't rebase, I am not at home right now.

Fixes:
- UnicodeEncodeError when initial location has special characters, e.g. "Paço"