### PR TITLE
Adding initial REST Framework; Adding method to get user stats

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -41,6 +41,7 @@ if sys.version_info >= (2, 7, 9):
 
 from pokemongo_bot import PokemonGoBot
 from pokemongo_bot.cell_workers.utils import print_green, print_yellow, print_red
+from server import PokemonGoServer
 
 def init_config():
     parser = argparse.ArgumentParser()
@@ -66,6 +67,7 @@ def init_config():
     parser.add_argument("--maxsteps",help="Set the steps around your initial location(DEFAULT 5 mean 25 cells around your location)",type=int,default=5)
     parser.add_argument("-d", "--debug", help="Debug Mode", action='store_true')
     parser.add_argument("-t", "--test", help="Only parse the specified location", action='store_true')
+    parser.add_argument("-o", "--port", help="Port to run the server on(DEFAULT 5000)", type=int,default=5000)
     parser.set_defaults(DEBUG=False, TEST=False)
     config = parser.parse_args()
 
@@ -100,8 +102,15 @@ def main():
 
     print_green('[x] Starting PokemonGo Bot....')
 
-    while(True):
-        bot.take_step()
+    pid = os.fork()
+
+    if pid == 0:
+        server = PokemonGoServer(bot, config, config.port)
+        server.start()
+    else:
+        while(True):
+            bot.take_step()
+
 
 if __name__ == '__main__':
     main()

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -13,6 +13,7 @@ from cell_workers.utils import distance
 from stepper import Stepper
 from geopy.geocoders import GoogleV3
 from math import radians, sqrt, sin, cos, atan2
+from collections import OrderedDict
 
 class PokemonGoBot(object):
 
@@ -251,7 +252,10 @@ class PokemonGoBot(object):
             return itemcount
         return '0'
 
-    def get_player_info(self):
+    def get_player_info(self, print_stats=True):
+        player_stats = stats = OrderedDict()
+
+        # Get contents of inventory
         self.api.get_inventory()
         response_dict = self.api.call()
         if 'responses' in response_dict:
@@ -269,14 +273,19 @@ class PokemonGoBot(object):
                                     nextlvlxp = (int(playerdata['next_level_xp']) - int(playerdata['experience']))
 
                                     if 'level' in playerdata:
-                                        print('[#] -- Level: {level}'.format(**playerdata))
+                                        player_stats['Level'] = playerdata['level']
 
                                     if 'experience' in playerdata:
-                                        print('[#] -- Experience: {experience}'.format(**playerdata))
-                                        print('[#] -- Experience until next level: {}'.format(nextlvlxp))
+                                        player_stats['Experience'] = playerdata['experience']
+                                        player_stats['Experience until next level'] = nextlvlxp
 
                                     if 'pokemons_captured' in playerdata:
-                                        print('[#] -- Pokemon Captured: {pokemons_captured}'.format(**playerdata))
+                                        player_stats['Pokemon Captured'] = playerdata['pokemons_captured']
 
                                     if 'poke_stop_visits' in playerdata:
-                                        print('[#] -- Pokestops Visited: {poke_stop_visits}'.format(**playerdata))
+                                        player_stats['Pokestops Visited'] = playerdata['poke_stop_visits']
+
+        if print_stats:
+            for key in player_stats:
+                 print("[#] -- %s: %s" % (key, player_stats[key]))
+        return json.dumps(player_stats, indent=4)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git://github.com/tejado/pgoapi.git@1f25e907f3e5f1b603330e71041e1ad7bee7580f#egg=pgoapi
+#-e git://github.com/tejado/pgoapi.git@1f25e907f3e5f1b603330e71041e1ad7bee7580f#egg=pgoapi
 geopy==1.11.0
 protobuf==3.0.0b4
 requests==2.10.0
@@ -6,3 +6,5 @@ s2sphere==0.2.4
 gpsoauth==0.3.0
 protobuf-to-dict==0.1.0
 googlemaps==2.4.4
+Flask==0.11.1
+Flask-Classy==0.6.10

--- a/server.py
+++ b/server.py
@@ -1,0 +1,37 @@
+import json 
+import logging 
+
+from flask import Flask
+from flask_classy import FlaskView, route
+from pokemongo_bot import PokemonGoBot
+
+app = Flask(__name__)
+
+global global_bot
+
+class PokemonGoServer(object):
+    def __init__(self, bot, config, port=5000):
+        api_view = ApiView()
+        api_view.set_bot(bot)
+        api_view.register(app)
+        self.port = port
+
+	# Setting the Flask app's log level
+	log = logging.getLogger('werkzeug')
+
+	if config.debug:
+	    log.setLevel(logging.DEBUG)
+	else:
+	    log.setLevel(logging.ERROR)
+
+    def start(self):
+        app.run(host='127.0.0.1', port=self.port)
+
+class ApiView(FlaskView):
+    def set_bot(self, bot):
+        global global_bot
+        global_bot = bot
+
+    @route("/player_info")
+    def get_player_info(self):
+        return global_bot.get_player_info(False)


### PR DESCRIPTION
Short Description: 
Right now there isn't a way for a developer to get information on the bot while the bot is running. Sure, you can check information by logging into the app or debugging, but there is no way to query the bot for various statistics. I added a REST Framework to the bot so that a user can retrieve this information by accessing various endpoints.

Some use cases:

- Developers trying to gather information/test methods
- Developers wanting to write other applications that interact with the bot, such as web views or chat commands
- A way to access the bot without logging in; very useful for people with multiple accounts (or a bot test account)


Once the framework is approved, more accessor REST methods can be implemented.  These can be used by the new `web` section for displaying stats on the map or for any other utilities. 


This PR fixes the issues raised by @jtdroste in #212 .

Fixes:
- Flask and Flask-Classy are added to `requirements.txt`
- `flask.ext.classy` is updated to `flask_classy`
- Server now binds to `127.0.0.1` instead of `0.0.0.0`
- Flask's request logging now defaults to WARNING; HTTP requests will only be logged when `config.debug`
- Port defaults to 5000, can be set via config/commandline




