### PR TITLE
Transfer Pokemon New Implementation.

### DIFF
--- a/web/catchable.json
+++ b/web/catchable.json
@@ -1,0 +1,1 @@
+{"pokemon_id": 140, "spawnpoint_id": "390cfd43c81", "longitude": 77.21038092441601, "expiration_timestamp_ms": 1469222884644, "latitude": 28.64209507917361, "encounter_id": 4539054479870578557}


### PR DESCRIPTION
Short Description: Transfer Pokemon while farming. 

Fixes:
- Takes consideration of cp set by user. Only transfer less than set cp.
- Leaves 1 unique highest CP pokemon of its category
- Showing information of pokemon which is being transferred using different color prints.
- Also shows how many total pokemon is transferred


