### PR TITLE
Transfer Pomemon if bag is full instead of flooding "Something rustles nearby!"

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,26 +129,27 @@ Quick Tip: When using this script, use a Lucky egg to double the XP for 30 mins.
  * s2sphere
  * googlemaps
  * pgoapi
+ * haykuro
 To install the pgoapi use `pip install -e git://github.com/tejado/pgoapi.git#egg=pgoapi`
 
 
 ## Contributors (Don't forget add yours here when you create PR:)
-eggins -- The first pull request :)  
-crack00r  
-ethervoid  
-Bashin  
-tstumm  
-TheGoldenXY  
+eggins -- The first pull request :)
+crack00r
+ethervoid
+Bashin
+tstumm
+TheGoldenXY
 Reaver01
 rarshonsky
 earthchie
 
 ## Credits
 ### The works are based on the Pokemon Go API
-[tejado](https://github.com/tejado) many thanks for the API  
-[Mila432](https://github.com/Mila432/Pokemon_Go_API) for the login secrets  
-[elliottcarlson](https://github.com/elliottcarlson) for the Google Auth PR  
-[AeonLucid](https://github.com/AeonLucid/POGOProtos) for improved protos  
+[tejado](https://github.com/tejado) many thanks for the API
+[Mila432](https://github.com/Mila432/Pokemon_Go_API) for the login secrets
+[elliottcarlson](https://github.com/elliottcarlson) for the Google Auth PR
+[AeonLucid](https://github.com/AeonLucid/POGOProtos) for improved protos
 [AHAAAAAAA](https://github.com/AHAAAAAAA/PokemonGo-Map) for parts of the s2sphere stuff
 
 

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -30,8 +30,8 @@ class PokemonCatchWorker(object):
                 if 'status' in response_dict['responses']['ENCOUNTER']:
                     if response_dict['responses']['ENCOUNTER']['status'] is 7:
                         print '[x] Pokemon Bag is full!'
-                        ## TODO: begin transfer logic to free some space
-                    elif response_dict['responses']['ENCOUNTER']['status'] is 1:
+                        self.bot.initial_transfer()
+                    if response_dict['responses']['ENCOUNTER']['status'] is 1:
                         cp=0
                         if 'wild_pokemon' in response_dict['responses']['ENCOUNTER']:
                             pokemon=response_dict['responses']['ENCOUNTER']['wild_pokemon']
@@ -46,15 +46,15 @@ class PokemonCatchWorker(object):
                         balls_stock = self.bot.pokeball_inventory();
                         while(True):
                             pokeball = 0
-                            
+
                             if balls_stock[1] > 0:
                                 #print 'use Poke Ball'
                                 pokeball = 1
-                                
+
                             if cp > 300 and balls_stock[2] > 0:
                                 #print 'use Great Ball'
                                 pokeball = 2
-                                
+
                             if cp > 700 and balls_stock[3] > 0:
                                 #print 'use Utra Ball'
                                 pokeball = 3
@@ -63,9 +63,9 @@ class PokemonCatchWorker(object):
                                 print_red('[x] Out of pokeballs...')
                                 # TODO: Begin searching for pokestops.
                                 break
-                            
+
                             print('[x] Using {}...'.format(self.item_list[str(pokeball)]))
-                            
+
                             balls_stock[pokeball] = balls_stock[pokeball] - 1
                             id_list1 = self.count_pokemon_inventory()
                             self.api.catch_pokemon(encounter_id = encounter_id,

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -28,7 +28,10 @@ class PokemonCatchWorker(object):
         if response_dict and 'responses' in response_dict:
             if 'ENCOUNTER' in response_dict['responses']:
                 if 'status' in response_dict['responses']['ENCOUNTER']:
-                    if response_dict['responses']['ENCOUNTER']['status'] is 1:
+                    if response_dict['responses']['ENCOUNTER']['status'] is 7:
+                        print '[x] Pokemon Bag is full!'
+                        ## TODO: begin transfer logic to free some space
+                    elif response_dict['responses']['ENCOUNTER']['status'] is 1:
                         cp=0
                         if 'wild_pokemon' in response_dict['responses']['ENCOUNTER']:
                             pokemon=response_dict['responses']['ENCOUNTER']['wild_pokemon']


### PR DESCRIPTION
Short Description: Adds a "[x] Pokemon Bag is full!" message if you encounter a pokemon but can't catch it because your pokemon bag is full. (a.k.a. status 7 is returned when encounter is sent)


Fixes:
```
[#] Walking from (34.0092419, -118.4976037) to (34.013523, -118.492144) for approx. 278.0 seconds
[#] Something rustles nearby!
[#] Something rustles nearby!
[#] Something rustles nearby!
[#] Something rustles nearby!
[#] Something rustles nearby!
[#] Something rustles nearby!
...
```

Will instead do:
```
[#] Walking from (34.0092419, -118.4976037) to (34.013523, -118.492144) for approx. 278.0 seconds
[#] Something rustles nearby!
[x] Pokemon Bag is full!
[x] Initial Transfer.
[x] Preparing to transfer all Pokemon duplicates, keeping the highest CP of each one type.
[x] Releasing Pokemon #129 and CP 28
[x] Releasing Pokemon #129 and CP 23
[x] Releasing Pokemon #129 and CP 10
[x] Releasing Pokemon #140 and CP 48
[x] Releasing Pokemon #21 and CP 10
...
```