### PR TITLE
Customize how to display distance in the output with --distance_unit

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -66,6 +66,7 @@ def init_config():
     parser.add_argument("--maxsteps",help="Set the steps around your initial location(DEFAULT 5 mean 25 cells around your location)",type=int,default=5)
     parser.add_argument("-d", "--debug", help="Debug Mode", action='store_true')
     parser.add_argument("-t", "--test", help="Only parse the specified location", action='store_true')
+    parser.add_argument("--distance_unit", help="Set the unit to display distance in", type=str, default="m")
     parser.set_defaults(DEBUG=False, TEST=False)
     config = parser.parse_args()
 
@@ -75,8 +76,8 @@ def init_config():
             config.__dict__[key] = load[key]
 
     if config.auth_service not in ['ptc', 'google']:
-      log.error("Invalid Auth service specified! ('ptc' or 'google')")
-      return None
+        log.error("Invalid Auth service specified! ('ptc' or 'google')")
+        return None
 
     return config
 

--- a/pokemongo_bot/cell_workers/seen_fort_worker.py
+++ b/pokemongo_bot/cell_workers/seen_fort_worker.py
@@ -4,7 +4,7 @@ import json
 import time
 from math import radians, sqrt, sin, cos, atan2
 from pgoapi.utilities import f2i, h2f
-from utils import distance, print_green, print_yellow, print_red
+from utils import distance, print_green, print_yellow, print_red, format_dist
 from pokemongo_bot.human_behaviour import sleep
 
 
@@ -22,11 +22,14 @@ class SeenFortWorker(object):
     def work(self):
         lat = self.fort['latitude']
         lng = self.fort['longitude']
+        unit = self.config.distance_unit # Unit to use when printing formatted distance
 
         fortID = self.fort['id']
         dist = distance(self.position[0], self.position[1], lat, lng)
 
-        print('[#] Found fort {} at distance {}m'.format(fortID, dist))
+        #print('[#] Found fort {} at distance {}m'.format(fortID, dist))
+        print(' [#] Found fort {} at distance {}'.format(fortID, format_dist(dist, unit)))
+
         if dist > 10:
             print('[#] Need to move closer to Pokestop')
             position = (lat, lng, 0.0)

--- a/pokemongo_bot/cell_workers/utils.py
+++ b/pokemongo_bot/cell_workers/utils.py
@@ -10,8 +10,10 @@ def distance(lat1, lon1, lat2, lon2):
     a = 0.5 - cos((lat2 - lat1) * p)/2 + cos(lat1 * p) * cos(lat2 * p) * (1 - cos((lon2 - lon1) * p)) / 2
     return 12742 * asin(sqrt(a)) * 1000
 
+
+
 def convert(distance, from_unit, to_unit): # Converts units
-    # Ex: Convert distance from meters to feet
+    # Example of converting distance from meters to feet:
     # convert(100.0,"m","ft")
     conversions = {
         "mm": {"mm": 1.0, "cm": 1.0 / 10.0, "m": 1.0 / 1000.0, "km": 1.0 / 1000000, "ft": 0.00328084, "yd": 0.00109361, "mi": 1.0 / 1609340.0007802},
@@ -26,6 +28,11 @@ def convert(distance, from_unit, to_unit): # Converts units
 
 def dist_to_str(distance, unit):
     return '{}{}'.format(distance, unit)
+
+def format_dist(distance, unit):
+    # Assumes that distance is in meters and converts it to the given unit, then a formatted string is returned
+    # Ex: format_dist(1500, 'km') returns the string "1.5km"
+    return dist_to_str(convert(distance, 'm', unit), unit)
 
 def i2f(int):
     return struct.unpack('<d', struct.pack('<Q', int))[0]

--- a/pokemongo_bot/cell_workers/utils.py
+++ b/pokemongo_bot/cell_workers/utils.py
@@ -10,6 +10,23 @@ def distance(lat1, lon1, lat2, lon2):
     a = 0.5 - cos((lat2 - lat1) * p)/2 + cos(lat1 * p) * cos(lat2 * p) * (1 - cos((lon2 - lon1) * p)) / 2
     return 12742 * asin(sqrt(a)) * 1000
 
+def convert(distance, from_unit, to_unit): # Converts units
+    # Ex: Convert distance from meters to feet
+    # convert(100.0,"m","ft")
+    conversions = {
+        "mm": {"mm": 1.0, "cm": 1.0 / 10.0, "m": 1.0 / 1000.0, "km": 1.0 / 1000000, "ft": 0.00328084, "yd": 0.00109361, "mi": 1.0 / 1609340.0007802},
+        "cm": {"mm": 10.0, "cm": 1.0, "m": 1.0 / 100, "km": 1.0 / 100000, "ft": 0.0328084, "yd": 0.0109361, "mi": 1.0 / 160934.0},
+        "m": {"mm": 1000, "cm": 100.0, "m": 1.0, "km": 1.0 / 1000.0, "ft": 3.28084, "yd": 1.09361, "mi": 1.0 / 1609.34},
+        "km": {"mm": 100000, "cm": 10000.0, "m": 1000.0, "km": 1.0, "ft": 3280.84, "yd": 1093.61, "mi": 1.0 / 1.60934},
+        "ft": {"mm": 1.0 / 328.084, "cm": 1.0 /32.8084, "m": 1.0 / 3.28084, "km": 1 / 3280.84, "ft": 1.0, "yd": 1.0 / 3.0, "mi": 1.0 / 5280.0},
+        "yd": {"mm": 1.0 / 328.084, "cm": 1.0 /32.8084, "m": 1.0 / 3.28084, "km": 1 / 1093.61, "ft": 3.0, "yd": 1.0, "mi": 1.0 / 1760.0},
+        "mi": {"mm": 1609340.0007802, "cm": 160934.0, "m": 1609.34, "km": 1.60934, "ft": 5280.0, "yd": 1760.0, "mi": 1.0}
+    }
+    return distance * conversions[from_unit][to_unit]
+
+def dist_to_str(distance, unit):
+    return '{}{}'.format(distance, unit)
+
 def i2f(int):
     return struct.unpack('<d', struct.pack('<Q', int))[0]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/tejado/pgoapi.git#egg=pgoapi
+-e git://github.com/tejado/pgoapi.git@1f25e907f3e5f1b603330e71041e1ad7bee7580f#egg=pgoapi
 geopy==1.11.0
 protobuf==3.0.0b4
 requests==2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git://github.com/tejado/pgoapi.git@1f25e907f3e5f1b603330e71041e1ad7bee7580f#egg=pgoapi
+-e git+https://github.com/tejado/pgoapi.git#egg=pgoapi
 geopy==1.11.0
 protobuf==3.0.0b4
 requests==2.10.0


### PR DESCRIPTION
**Short Description:** 
Added the argument option --distance_unit to customize how to display distance in the output. E.g., km instead of meters, miles instead of meters.

**How to Use:**
- Use kilometers (km) for distance output
`python pokecli.py -a 'google' -u [user_email] -p [password] -l [location] -w 5 --distance_unit km`
- Use miles (mi) for distance output
`python pokecli.py -a 'google' -u [user_email] -p [password] -l [location] -w 5 --distance_unit mi`
- Use feet (ft) for distance output
`python pokecli.py -a 'google' -u [user_email] -p [password] -l [location] -w 5 --distance_unit ft`

**Fixes:**
- Implemented the argument option --distance_unit to customize how to display distance in the output. 
- The first line of requirements.txt to install pgoapi was changed to `-e git+https://github.com/tejado/pgoapi.git#egg=pgoapi` to correct a "branch not found" error when running `pip install -r requirements.txt`.

