### PR TITLE
Fix "NameError: global name 'log' is not defined"

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -84,7 +84,7 @@ def init_config():
             config.__dict__[key] = load[key]
 
     if config.auth_service not in ['ptc', 'google']:
-        log.error("Invalid Auth service specified! ('ptc' or 'google')")
+        logging.error("Invalid Auth service specified! ('ptc' or 'google')")
         return None
 
     return config


### PR DESCRIPTION
Fixes:
```
Traceback (most recent call last):
  File "pokecli.py", line 121, in <module>
    main()
  File "pokecli.py", line 100, in main
    config = init_config()
  File "pokecli.py", line 87, in init_config
    log.error("Invalid Auth service specified! ('ptc' or 'google')")
NameError: global name 'log' is not defined
```

Instead, it properly calls `logging.log`:

```
ERROR:root:Invalid Auth service specified! ('ptc' or 'google')
```
