### PR TITLE
Avoid crash while writing location

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ To install the pgoapi use `pip install -e git://github.com/tejado/pgoapi.git#egg
  * rarshonsky
  * earthchie
  * haykuro
+ * sinistance
 
 ## Credits
 ### The works are based on the Pokemon Go API

--- a/pokemongo_bot/stepper.py
+++ b/pokemongo_bot/stepper.py
@@ -85,8 +85,11 @@ class Stepper(object):
 
         response_dict = self.api.call()
         # Passing Variables through a file
-        with open('web/location.json', 'w') as outfile:
-            json.dump({'lat': lat, 'lng': lng,'cells':response_dict['responses']['GET_MAP_OBJECTS']['map_cells']}, outfile)
+        if response_dict and 'responses' in response_dict and \
+            'GET_MAP_OBJECTS' in response_dict['responses'] and \
+            'map_cells' in response_dict['responses']['GET_MAP_OBJECTS']:
+            with open('web/location.json', 'w') as outfile:
+                json.dump({'lat': lat, 'lng': lng,'cells':response_dict['responses']['GET_MAP_OBJECTS']['map_cells']}, outfile)
         if response_dict and 'responses' in response_dict and \
             'GET_MAP_OBJECTS' in response_dict['responses'] and \
             'status' in response_dict['responses']['GET_MAP_OBJECTS'] and \


### PR DESCRIPTION
Short Description: 
```
Traceback (most recent call last):
  File "pokecli.py", line 120, in <module>
    main()
  File "pokecli.py", line 113, in main
    bot.take_step()
  File "/Users/sinistance/Documents/pokemon/PokemonGo-Bot-dev/pokemongo_bot/__init__.py", line 31, in take_step
    self.stepper.take_step()
  File "/Users/sinistance/Documents/pokemon/PokemonGo-Bot-dev/pokemongo_bot/stepper.py", line 56, in take_step
    self._work_at_position(position[0], position[1], position[2], True)
  File "/Users/sinistance/Documents/pokemon/PokemonGo-Bot-dev/pokemongo_bot/stepper.py", line 97, in _work_at_position
    self.bot.work_on_cell(cell, position, pokemon_only)
  File "/Users/sinistance/Documents/pokemon/PokemonGo-Bot-dev/pokemongo_bot/__init__.py", line 56, in work_on_cell
    hack_chain = worker.work()
  File "/Users/sinistance/Documents/pokemon/PokemonGo-Bot-dev/pokemongo_bot/cell_workers/seen_fort_worker.py", line 35, in work
    self.stepper._walk_to(self.config.walk, *position)
  File "/Users/sinistance/Documents/pokemon/PokemonGo-Bot-dev/pokemongo_bot/stepper.py", line 75, in _walk_to
    self._work_at_position(i2f(self.api._position_lat), i2f(self.api._position_lng), alt, False)
  File "/Users/sinistance/Documents/pokemon/PokemonGo-Bot-dev/pokemongo_bot/stepper.py", line 89, in _work_at_position
    json.dump({'lat': lat, 'lng': lng,'cells':response_dict['responses']['GET_MAP_OBJECTS']['map_cells']}, outfile)
KeyError: 'GET_MAP_OBJECTS'
```

Fixes:
- Put conditional check before writing `map_cells` to `web/location.json`

