### PR TITLE
Correct maxsteps option in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This project uses Google Maps. There's one map coupled with the project, but as 
       -lc, --use-location-cache                     Bot will start at last known location
       -w SPEED,  --walk SPEED                       Walk instead of teleport with given speed (meters per second max 4.16 because of walking end on 15km/h)
       -m MODE, --mode MODE                          Set farming Mode for the bot ('all', 'poke', 'farm')
-      --maxstep MAX_STEP                            Set the steps around your initial location(DEFAULT 5 mean 25 cells around
+      --maxsteps MAX_STEP                            Set the steps around your initial location(DEFAULT 5 mean 25 cells around
       your location)
       --initial-transfer                            Start the bot with a pokemon clean up, keeping only the higher CP of each pokemon. It respects -c as upper limit to release.
       -c CP, --cp                                   Set the CP to transfer or lower (eg. 100 will transfer CP0-99)


### PR DESCRIPTION
The Readme says the option is called --maxstep but it is actually --maxsteps
meaning anybody trying the option based off the Readme is just getting
the default value of 5