### PR TITLE
Corrected pgoapi reference in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pip install -e git://github.com/tejado/pgoapi.git@1f25e907f3e5f1b603330e71041e1ad7bee7580f#egg=pgoapi
+-e git://github.com/tejado/pgoapi.git@1f25e907f3e5f1b603330e71041e1ad7bee7580f#egg=pgoapi
 geopy==1.11.0
 protobuf==3.0.0b4
 requests==2.10.0


### PR DESCRIPTION
Short Description: 
https://github.com/PokemonGoF/PokemonGo-Bot/commit/730534daf96c9b9bbf7989ef5b39da080b5c0839#diff-b4ef698db8ca845e5845c4618278f29aL1

Introduced a syntax error in requirements.txt which would yield the error: 

```
# pip install -r requirements.txt
Invalid requirement: 'pip install'
Traceback (most recent call last):
  File "/root/pokemon/GoF-PGo/local/lib/python2.7/site-packages/pip/req/req_install.py", line 78, in __init__
    req = Requirement(req)
  File "/root/pokemon/GoF-PGo/local/lib/python2.7/site-packages/pip/_vendor/packaging/requirements.py", line 96, in __init__
    requirement_string[e.loc:e.loc + 8]))
InvalidRequirement: Invalid requirement, parse error at "u'install'"
```
Fixes:
- Havn't made an issue for it. 


