### PR TITLE
Low CP Pokemon transfer fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ To install the pgoapi use `pip install -e git://github.com/tejado/pgoapi.git#egg
  * CapCap
  * mzupan
  * namlehong
+ * gnekic(GeXx)
 
 ## Credits
 ### The works are based on the Pokemon Go API

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -104,7 +104,8 @@ class PokemonCatchWorker(object):
                                         id_list2 = self.count_pokemon_inventory()
                                         # Transfering Pokemon
                                         pokemon_to_transfer = list(Set(id_list2) - Set(id_list1))
-                                        print_red('DEBUG: '.pokemon_to_transfer)
+                                        print_red('DEBUG: ')
+                                        print(pokemon_to_transfer)
                                         if len(pokemon_to_transfer) == 0:
                                             raise RuntimeError('Trying to transfer 0 pokemons!')
                                         self.transfer_pokemon(pokemon_to_transfer)

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -104,6 +104,7 @@ class PokemonCatchWorker(object):
                                         id_list2 = self.count_pokemon_inventory()
                                         # Transfering Pokemon
                                         pokemon_to_transfer = list(Set(id_list2) - Set(id_list1))
+                                        print_red('DEBUG: '.pokemon_to_transfer)
                                         if len(pokemon_to_transfer) == 0:
                                             raise RuntimeError('Trying to transfer 0 pokemons!')
                                         self.transfer_pokemon(pokemon_to_transfer)

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -104,11 +104,9 @@ class PokemonCatchWorker(object):
                                         id_list2 = self.count_pokemon_inventory()
                                         # Transfering Pokemon
                                         pokemon_to_transfer = list(Set(id_list2) - Set(id_list1))
-                                        print_red('DEBUG: ')
-                                        print(pokemon_to_transfer)
                                         if len(pokemon_to_transfer) == 0:
                                             raise RuntimeError('Trying to transfer 0 pokemons!')
-                                        self.transfer_pokemon(pokemon_to_transfer)
+                                        self.transfer_pokemon(pokemon_to_transfer[0])
                                         print_green('[#] {} has been exchanged for candy!'.format(pokemon_name))
                                     else:
                                         print_green('[x] Captured {}! [CP {}]'.format(pokemon_name, cp))


### PR DESCRIPTION
Short Description: 
Pokemons didn't transfer after catching them for candy, even thou message was shown.

Fixes:
- Low CP pokemons now transfer after catching them.

