### PR TITLE
Update SimpleHTTPServer example with port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,9 @@ slow down leveling but you won't fill up either.
 ### How do I use the map??
 You can either view the map via opening the html file, or by serving it with SimpleHTTPServer (runs on localhost:8000)  
 To use SimpleHTTPServer:  
-```$ python -m SimpleHTTPServer```  
+```$ python -m SimpleHTTPServer [port]``` 
+The default port is 8080, you can change that by giving a port number.
+Anything above port 1000 does not require root.
 You will need to set your username(s) in the userdata.js file before opening:  
 Open userdata.js with your favorite text editor.  
 put your username in the quotes instead of "username"


### PR DESCRIPTION
Short Description: 
`python -m SimpleHTTPServer` does allow a custom port.
eg: `python -m SimpleHTTPServer 8181` 
Fixes:
- 
- 
- 


