### PR TITLE
Avoid trying to catch multiple pokemons while out of pokeballs

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -76,7 +76,8 @@ class PokemonGoBot(object):
                 with open('web/catchable-%s.json' % (self.config.username), 'w') as outfile:
                     json.dump(pokemon, outfile)
                 worker = PokemonCatchWorker(pokemon, self)
-                worker.work()
+                if worker.work() == -1:
+                    break;
                 with open('web/catchable-%s.json' % (self.config.username), 'w') as outfile:
                     json.dump({}, outfile)
         if (self.config.mode == "all" or self.config.mode == "poke") and 'wild_pokemons' in cell and len(cell['wild_pokemons']) > 0:
@@ -84,7 +85,8 @@ class PokemonGoBot(object):
             cell['wild_pokemons'].sort(key=lambda x: distance(self.position[0], self.position[1], x['latitude'], x['longitude']))
             for pokemon in cell['wild_pokemons']:
                 worker = PokemonCatchWorker(pokemon, self)
-                worker.work()
+                if worker.work() == -1:
+                    break;
         if (self.config.mode == "all" or self.config.mode == "farm") and include_fort_on_path:
             if 'forts' in cell:
                 # Only include those with a lat/long

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -72,7 +72,7 @@ class PokemonCatchWorker(object):
                                 print_red('[x] Out of pokeballs, switching to farming mode...')
                                 # Begin searching for pokestops.
                                 self.config.mode='farm'
-                                break
+                                return -1
 
                             print('[x] Using {}...'.format(self.item_list[str(pokeball)]))
 


### PR DESCRIPTION
Short Description: 
If you've run out of pokeballs for a given pokemons level, the bot will switch to farming mode, however it'll still try to fight all pokemons in the cell before stopping. This fixes it, and causes the bot to stop after just one fight. 

I'm not sure if this way of doing it is any good/pythonesque.

Fixes:
- Havn't made an issue, just based on a comment here: https://github.com/PokemonGoF/PokemonGo-Bot/pull/333#issuecomment-234695196


