### PR TITLE
Updated initial_transfer, show names of releases

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -215,14 +215,14 @@ class PokemonGoBot(object):
                     if self.config.cp and group_cp[x] > self.config.cp:
                         continue
 
-                    print('[x] Releasing Pokemon #{} and CP {}'.format(
-                        id, group_cp[x]))
+                    print('[x] Transferring {} with CP {}'.format(
+                        self.pokemon_list[id-1]['Name'], group_cp[x]))
                     self.api.release_pokemon(
                         pokemon_id=pokemon_groups[id][group_cp[x]])
                     response_dict = self.api.call()
                     sleep(2)
 
-        print('[x] Transfering Done.')
+        print('[x] Transferring Done.')
 
     def _initial_transfer_get_groups(self):
         pokemon_groups = {}


### PR DESCRIPTION
Short Description: 

Fixes:
- Showing the name of released Pokemon: `[x] Releasing Rattata with CP 169`
- Typo: `"print('[x] Transferring Done.')"`


Now shows "[x] Releasing Rattata with CP 169" instead of "[x] Releasing Pokemon #19 and CP 169"
Also changed typo in "print('[x] Transferring Done.')"