### PR TITLE
Fix transfer condition to not transfer all pokemons

### DIFF
--- a/cell_workers/pokemon_catch_worker.py
+++ b/cell_workers/pokemon_catch_worker.py
@@ -128,7 +128,7 @@ class PokemonCatchWorker(object):
                                             if exchange_cp != 0 and exchange_pid != 0:
                                                 print('[x] Exchanging ' + str(pokemon_name) + ' from inventory with ! [CP' + str(exchange_cp) + ']')
                                                 self.transfer_pokemon(exchange_pid)
-                                    elif self.should_transfer(cp,str(pokemon_name)):
+                                    elif self.should_transfer(cp, str(pokemon_name)):
                                         print('[x] Captured ' + str(pokemon_name) + '! [CP' + str(cp) + '] - exchanging for candy')
                                         id_list2 = self.count_pokemon_inventory()
                                         try:
@@ -142,14 +142,14 @@ class PokemonCatchWorker(object):
                             break
         time.sleep(5)
 
-    def should_transfer(self, pokemon_cp,pokemon_name):
+    def should_transfer(self, pokemon_cp, pokemon_name):
          pokemon_name = pokemon_name.lower()
          transfer_list  = self.config.transfer_list.lower()
          try:
              int_cp = int(self.config.cp)
          except Exception, e:
              int_cp = 0
-         if pokemon_cp < self.config.cp or pokemon_name in transfer_list:
+         if pokemon_cp < int_cp or pokemon_name in transfer_list:
              return True
          else:
             return False


### PR DESCRIPTION
Short Description: 
I encountered an issue that all captured Pokemons are being transferred even though their CP is way over limit.
Example are logs of bot running with `--cp 50`

[#] A Wild Golbat appeared! [CP309]
[x] Using Greatball...
[x] Captured Golbat! [CP309] - exchanging for candy
[x] Exchanged successfully!

Fixes:
- Pokemon transfer condition

