### PR TITLE
[Untested] Increases fort movement efficiency

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -100,17 +100,20 @@ class PokemonGoBot(object):
                 # Only include those with a lat/long
                 forts = [fort for fort in cell['forts']
                          if 'latitude' in fort and 'type' in fort]
-
-                # Sort all by distance from current pos- eventually this should
-                # build graph & A* it
-                forts.sort(key=lambda x: distance(self.position[
-                           0], self.position[1], x['latitude'], x['longitude']))
-                for fort in cell['forts']:
+           
+                while len(forts) > 0:
+					# Sort all by distance from current pos- eventually this should
+					# build graph & A* it
+					forts.sort(key=lambda x: distance(self.position[
+                               0], self.position[1], x['latitude'], x['longitude']))
+					fort = forts[0]
                     worker = SeenFortWorker(fort, self)
                     hack_chain = worker.work()
-                    if hack_chain > 10:
+					if fort in forts:
+						fort.remove(fort)
+                    if hack_chain > 10: 
                         #print('need a rest')
-                        break
+                        sleep(10) # Changed to avoid an infinite loop, will now just move on to next location
 
     def _setup_logging(self):
         self.log = logging.getLogger(__name__)


### PR DESCRIPTION
Makes it so distance tracking is done after every fort, instead of just
at the beginning of the fort movement. This should make walking times between pokestops much
less in certain cases. (For example, on the old loop, if fort a was
2.5mi north, fort b was 2.7 mi north, and fort c was 2.6mi south, the
program would go a->c->b, which is insanely inefficient)

Note, unsure of the change on line 116. Without that change the current
code will get in an infinite loop once it goes through all forts it
knows, but might undo whatever that line was trying to do. Instead of
breaking, it just moves on to the next fort.