### PR TITLE
Fixed logic problem when both CP and IV are specified

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -124,7 +124,7 @@ class PokemonCatchWorker(object):
                                         '[x] Oh no! {} vanished! :('.format(
                                             pokemon_name), 'red')
                                 if status is 1:
-                                    if cp < self.config.cp or pokemon_potential < self.config.pokemon_potential:
+                                    if cp < self.config.cp and pokemon_potential < self.config.pokemon_potential:
                                         logger.log(
                                             '[x] Captured {}! [CP {}] [IV {}] - exchanging for candy'.format(
                                                 pokemon_name, cp,


### PR DESCRIPTION
Short Description: 
If both CP and IV are specified, it will throw out Pokemons even when one of the conditions doesn't match.

Fixes:
- If both CP and IV are specified, it will throw out Pokemons even when one of the conditions doesn't match.