### PR TITLE
Key error being thrown on 'new_count'

### DIFF
--- a/pokemongo_bot/cell_workers/seen_fort_worker.py
+++ b/pokemongo_bot/cell_workers/seen_fort_worker.py
@@ -106,7 +106,7 @@ class SeenFortWorker(object):
                                     'result' in response_dict_recycle['responses']['RECYCLE_INVENTORY_ITEM']:
                                 result = response_dict_recycle['responses']['RECYCLE_INVENTORY_ITEM']['result']
                             if result is 1: # Request success
-                                logger.log("[+] Recycling success, count of " + item_name + "s kept at : " + str(response_dict_recycle['responses']['RECYCLE_INVENTORY_ITEM']['new_count']), 'green')
+                                logger.log("[+] Recycling success", 'green')
                             else:
                                 logger.log("[+] Recycling failed!", 'red')
                 else:


### PR DESCRIPTION
Short Description: 

Traceback (most recent call last):
  File "pokecli.py", line 187, in <module>
    main()
  File "pokecli.py", line 178, in main
    bot.take_step()
  File "/Users/jamesle/Documents/PokemonGo-Bot/pokemongo_bot/__init__.py", line 35, in take_step
    self.stepper.take_step()
  File "/Users/jamesle/Documents/PokemonGo-Bot/pokemongo_bot/stepper.py", line 61, in take_step
    self._work_at_position(position[0], position[1], position[2], True)
  File "/Users/jamesle/Documents/PokemonGo-Bot/pokemongo_bot/stepper.py", line 134, in _work_at_position
    self.bot.work_on_cell(cell, position, pokemon_only)
  File "/Users/jamesle/Documents/PokemonGo-Bot/pokemongo_bot/__init__.py", line 120, in work_on_cell
    hack_chain = worker.work()
  File "/Users/jamesle/Documents/PokemonGo-Bot/pokemongo_bot/cell_workers/seen_fort_worker.py", line 109, in work
    logger.log("[+] Recycling success, count of " + item_name + "s kept at : " + str(response_dict_recycle['responses']['RECYCLE_INVENTORY_ITEM']['new_count']), 'green')
KeyError: 'new_count'


Fixes:
- Recycling works. Just this log output causing a keyerror so i just discarded it.


