### PR TITLE
fixed a bug with zero values in release_config causing bot to crash

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -225,6 +225,8 @@ class PokemonCatchWorker(object):
             'iv':               False,
         }
 
+        min_cp = 0
+        min_iv = 0
         if release_config.get('min_cp'):
             min_cp = release_config['min_cp']
             if cp < min_cp:


### PR DESCRIPTION
Short Description: 

Fixes:
- Setting min_cp or min_iv to zero does not crash the bot anymore


