### PR TITLE
Automatically inject Google API_KEY into the index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ If using multiple usernames format like this:
  * msoedov
  * Grace
  * Calcyfer
+ * asaf400
 
 -------
 ## Credits

--- a/pokecli.py
+++ b/pokecli.py
@@ -35,7 +35,6 @@ import ssl
 import logging
 import sys
 import codecs
-import fileinput
 from pokemongo_bot import logger
 if sys.version_info >= (2, 7, 9):
     ssl._create_default_https_context = ssl._create_unverified_context

--- a/pokecli.py
+++ b/pokecli.py
@@ -35,6 +35,7 @@ import ssl
 import logging
 import sys
 import codecs
+import fileinput
 from pokemongo_bot import logger
 if sys.version_info >= (2, 7, 9):
     ssl._create_default_https_context = ssl._create_unverified_context
@@ -149,6 +150,16 @@ def init_config():
     if os.path.isfile(release_config_json):
         with open(release_config_json) as data:
             config.release_config.update(json.load(data))
+            
+    if config.gmapkey:
+        find_url = 'https:\/\/maps.googleapis.com\/maps\/api\/js\?key=\S*'
+        replace_url = "https://maps.googleapis.com/maps/api/js?key=%s&callback=initMap\""
+        #Someone make this pretty! (Efficient)
+        with open("web/index.html", "r") as sources:
+            lines = sources.readlines()
+        with open("web/index.html", "w") as sources:
+            for line in lines:
+                sources.write(re.sub(r"%s" % find_url, replace_url % config.gmapkey, line))
 
     return config
 

--- a/web/index.html
+++ b/web/index.html
@@ -94,7 +94,7 @@
     <div id="map"></div>
     <script type="text/javascript" src="userdata.js"></script>
     <script type="text/javascript" src="main.js"></script>
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBWa0ZYeH6RBZnNTAIj30FyDIVnXV74D9o&callback=initMap"
+    <script src="https://maps.googleapis.com/maps/api/js?key=API_KEY_AUTO_FILLEDcallback=initMap"
     async defer></script>
   </body>
 </html>


### PR DESCRIPTION
Short Description: 
Automatically inject Google API_KEY into the index.html, by using cheap regex syntax to replace the whole line
Fixes:
- Google API Key not updated in index.html

