### PR TITLE
Location already decoded when logging starts

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -321,8 +321,7 @@ class PokemonGoBot(object):
         self.position = self._get_pos_by_name(self.config.location)
         self.api.set_position(*self.position)
         logger.log('')
-        logger.log(u'[x] Address found: {}'.format(self.config.location.decode(
-            'utf-8')))
+        logger.log(u'[x] Address found: {}'.format(self.config.location))
         logger.log('[x] Position in-game set as: {}'.format(self.position))
         logger.log('')
 


### PR DESCRIPTION
Short Description: 
With the new way of getting arguments from json file, when logging starts, self.config.location is already decoded.

Fixes:
- When initial location contains special characters, e.g., "ç" - UnicodeEncodeError: 'ascii' codec can't encode character u'\xe7' in position 3: ordinal not in range(128)

```
  File "/tmp/PokemonGo-Bot/pokemongo_bot/__init__.py", line 325, in _set_starting_position
    'utf-8')))
  File "/usr/lib/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe7' in position 3: ordinal not in range(128)
```