### PR TITLE
Script to convert ods file to release_config + example ods file

### DIFF
--- a/ods_to_release_config.py
+++ b/ods_to_release_config.py
@@ -1,0 +1,86 @@
+'''
+INSALLATION:
+
+use: 
+	$ pip install pyexcel-ods
+
+	or
+
+	$ git clone http://github.com/pyexcel/pyexcel-ods.git
+	$ cd pyexcel-ods
+	$ python setup.py install
+
+
+
+
+USAGE:
+
+edit release_config.ods file to ur custom needs
+run      $ python ods_to_release_config.py
+enjoy ur custom release_config.json file
+
+'''
+
+from pyexcel_ods import get_data
+
+data = get_data("release_config.ods")
+catchlist = data['Sheet1']
+configfile = open('release_config.json', 'w')
+
+
+def initConfig():
+    #writing standard stuff from example to config
+    configfile.write(''+
+    '{\n'+
+    '    "any": {\n'+
+    '        "release_under_cp": 500,\n'+
+    '        "release_under_iv": 0,\n'+
+    '        "cp_iv_logic": "or"\n'+
+    '    },\n'+
+    '\n'+
+    '    "My Pokemon": {\n'+
+    '        "release_under_cp": 0,\n'+
+    '        "release_under_iv": 0,\n'+
+    '        "cp_iv_logic": "or"\n'+
+    '    },\n\n')
+
+def finishConfig():
+    configfile.write(''+
+    '    "exceptions": {\n'
+    '            "always_capture": [\n'+
+    '                "Arcanine",\n'+
+    '                "Lapras",\n'+
+    '                "Dragonite",\n'+
+    '                "Snorlax",\n'+
+    '                "Blastoise",\n'+
+    '                "Moltres",\n'+
+    '                "Articuno",\n'+
+    '                "Zapdos",\n'+
+    '                "Mew",\n'+
+    '                "Mewtwo"\n'+
+    '            ]\n'+
+    '        }\n'+
+    '    }')
+
+def appendConfig(Pokemon, cp):
+    #appending config with pokemon and CP, IV is always 0
+    configfile.write(''+
+    '    "%s":{\n' % Pokemon+
+    '        "release_under_cp": %i,\n' % cp+
+    '        "release_under_iv": 0,\n' +
+    '        "cp_iv_logic": "or"},\n\n' ) #needed since IV=0
+
+
+def main():
+    initConfig()
+
+    for line in catchlist[2:]:
+        appendConfig(line[1], int(line[2]))
+        line[1]
+        print int(line[2])
+
+    finishConfig()
+
+
+if __name__ == "__main__":
+    main()

--- a/ods_to_release_config.py
+++ b/ods_to_release_config.py
@@ -1,3 +1,5 @@
+#v1.0 Witzbold script to configure release_config. 
+
 from pyexcel_ods import get_data
 
 data = get_data("release_config.ods")

--- a/ods_to_release_config.py
+++ b/ods_to_release_config.py
@@ -12,7 +12,7 @@ def initConfig():
     configfile.write(''+
     '{\n'+
     '    "any": {\n'+
-    '        "release_under_cp": 500,\n'+
+    '        "release_under_cp": 0,\n'+
     '        "release_under_iv": 0,\n'+
     '        "cp_iv_logic": "or"\n'+
     '    },\n'+

--- a/ods_to_release_config.py
+++ b/ods_to_release_config.py
@@ -1,26 +1,3 @@
-'''
-INSALLATION:
-
-use: 
-	$ pip install pyexcel-ods
-
-	or
-
-	$ git clone http://github.com/pyexcel/pyexcel-ods.git
-	$ cd pyexcel-ods
-	$ python setup.py install
-
-
-
-
-USAGE:
-
-edit release_config.ods file to ur custom needs
-run      $ python ods_to_release_config.py
-enjoy ur custom release_config.json file
-
-'''
-
 from pyexcel_ods import get_data
 
 data = get_data("release_config.ods")


### PR DESCRIPTION
Short Description: 

Fixes:
- 
- 
- 
I created a script which allows the user to insert values into an ods (excel/calc) file and transfer it into the json file.
I would like to use a new folder for it but since I'm new to github, I don't know how to create one. 
The example release file is in ods format and needs to be added. I can only add it as a zip file. 
[release_config.ods.zip](https://github.com/PokemonGoF/PokemonGo-Bot/files/380248/release_config.ods.zip)

To test the script one would need to download and extract the zip file and put it into the same directory as the python script.
