### PR TITLE
Fix missing comma in config.json.example

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -12,6 +12,6 @@
     "initial_transfer": 0,
     "location_cache": true,
     "distance_unit": "km",
-    "item_filter": "101,102,103,104"
+    "item_filter": "101,102,103,104",
     "evolve_all": "NONE"
 }


### PR DESCRIPTION
Short Description: There was a missing comma in the config.json.example file.

Fixes:
- missing comma in config.json.example


