### PR TITLE
only_track_filter: whitelist of pokemon ids to track and catch

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -126,6 +126,14 @@ def init_config():
         default="km")
 
     parser.add_argument(
+        "-otf",
+        "--only_track_filter",
+        help=
+        "Pass in a comma separated list of pokemon ids that you wish to track and capture (defaults to all)",
+        type=str,
+        default=False)
+
+    parser.add_argument(
         "-if",
         "--item_filter",
         help=
@@ -166,6 +174,9 @@ def init_config():
 
     if config.item_filter:
         config.item_filter = [str(item_id) for item_id in config.item_filter.split(',')]
+
+    if config.only_track_filter:
+        config.only_track_filter = [int(id) for id in config.only_track_filter.split(',')]
 
     config.release_config = {}
     if os.path.isfile(release_config_json):

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -387,6 +387,17 @@ class PokemonGoBot(object):
         return (loc.latitude, loc.longitude, loc.altitude)
 
     def _filter_ignored_pokemons(self, cell):
+        # remove all pokemon EXCEPT those with ids from only_track_filter
+        if self.config.only_track_filter:
+            try:
+                cell['wild_pokemons'] = filter(lambda x: x['pokemon_data']['pokemon_id'] in self.config.only_track_filter, cell['wild_pokemons'])
+            except KeyError:
+                pass
+            try:
+                cell['catchable_pokemons'] = filter(lambda x: x['pokemon_id'] in self.config.only_track_filter, cell['catchable_pokemons'])
+            except KeyError:
+                pass
+
         process_ignore = False
         try:
             with open("./data/catch-ignore.yml", 'r') as y:


### PR DESCRIPTION
defaults to normal tracking/catching behavior. when list of ids is supplied, only those corresponding pokemon will be tracked.

uses:
- drop bot in abra nest with `"only_track_filter": "63,64,65"` and everything other than abra, kadabra, and alakazam will be ignored
- when completing pokedex, insert ids of missing pokemon