### PR TITLE
Remove unused 'origin' submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "origin"]
-	path = web
-	url = https://github.com/OpenPoGo/OpenPoGoWeb.git
 [submodule "web"]
 	path = web
 	url = git@github.com:OpenPoGo/OpenPoGoWeb.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "web"]
 	path = web
-	url = git@github.com:OpenPoGo/OpenPoGoWeb.git
+	url = https://github.com/OpenPoGo/OpenPoGoWeb.git


### PR DESCRIPTION
As it is causing `git submodule init` and `git submodule update` to fail, because both origin and web submodules point to the same 'web' folder.