### PR TITLE
Fixed tab/space issue and optimized imports

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -25,20 +25,17 @@ OR OTHER DEALINGS IN THE SOFTWARE.
 Author: tjado <https://github.com/tejado>
 """
 
-import os
-import re
-import json
 import argparse
-import time
+import codecs
+import json
+import logging
+import os
 import ssl
 import sys
-import codecs
 from getpass import getpass
-import logging
-import requests
-from pokemongo_bot import logger
+
 from pokemongo_bot import PokemonGoBot
-from pokemongo_bot.cell_workers.utils import print_green, print_yellow, print_red
+from pokemongo_bot import logger
 
 if sys.version_info >= (2, 7, 9):
     ssl._create_default_https_context = ssl._create_unverified_context

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -1,24 +1,23 @@
 # -*- coding: utf-8 -*-
 
-import logging
-import googlemaps
-import json
-import random
-import threading
-import time
 import datetime
-import sys
-import logger
+import json
+import logging
+import random
 import re
+import sys
+import time
+
+from geopy.geocoders import GoogleV3
 from pgoapi import PGoApi
-from pgoapi.utilities import f2i, h2f
+from pgoapi.utilities import f2i
+
+import logger
 from cell_workers import PokemonCatchWorker, SeenFortWorker, MoveToFortWorker, InitialTransferWorker, EvolveAllWorker
 from cell_workers.utils import distance, get_cellid, encode
 from human_behaviour import sleep
-from spiral_navigator import SpiralNavigator
-from geopy.geocoders import GoogleV3
-from math import radians, sqrt, sin, cos, atan2
 from item_list import Item
+from spiral_navigator import SpiralNavigator
 
 
 class PokemonGoBot(object):

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -183,7 +183,7 @@ class PokemonGoBot(object):
                 forts = [fort
                          for fort in cell['forts']
                          if 'latitude' in fort and 'type' in fort]
-		gyms = [gym for gym in cell['forts'] if 'gym_points' in gym]
+                gyms = [gym for gym in cell['forts'] if 'gym_points' in gym]
 
                 # Sort all by distance from current pos- eventually this should
                 # build graph & A* it

--- a/pokemongo_bot/cell_workers/evolve_all_worker.py
+++ b/pokemongo_bot/cell_workers/evolve_all_worker.py
@@ -1,7 +1,8 @@
-from utils import distance, format_dist
-from pokemongo_bot.human_behaviour import sleep
-from pokemongo_bot import logger
 from sets import Set
+
+from pokemongo_bot import logger
+from pokemongo_bot.human_behaviour import sleep
+
 
 class EvolveAllWorker(object):
     def __init__(self, bot):

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -2,9 +2,10 @@
 
 import time
 from sets import Set
-from utils import distance
-from pokemongo_bot.human_behaviour import sleep
+
 from pokemongo_bot import logger
+from pokemongo_bot.human_behaviour import sleep
+
 
 class PokemonCatchWorker(object):
     BAG_FULL = 'bag_full'

--- a/pokemongo_bot/cell_workers/seen_fort_worker.py
+++ b/pokemongo_bot/cell_workers/seen_fort_worker.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
-import json
 import time
-from math import radians, sqrt, sin, cos, atan2
-from pgoapi.utilities import f2i, h2f
-from utils import print_green, print_yellow, print_red, format_time
-from pokemongo_bot.human_behaviour import sleep
+
+from pgoapi.utilities import f2i
+
 from pokemongo_bot import logger
+from pokemongo_bot.human_behaviour import sleep
+from utils import format_time
 
 
 class SeenFortWorker(object):

--- a/pokemongo_bot/polyline_stepper.py
+++ b/pokemongo_bot/polyline_stepper.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
-from polyline_walker import PolylineWalker
-from stepper import Stepper
 from math import ceil
-from human_behaviour import sleep
-from cell_workers.utils import i2f
+
+from stepper import Stepper
 
 import logger
+from cell_workers.utils import i2f
+from human_behaviour import sleep
+from polyline_walker import PolylineWalker
+
 
 class PolylineStepper(Stepper):
 

--- a/pokemongo_bot/polyline_walker/polyline_tester.py
+++ b/pokemongo_bot/polyline_walker/polyline_tester.py
@@ -1,8 +1,11 @@
 import time
+from math import ceil
+
 import haversine
 import polyline
-from math import ceil
+
 from polyline_walker import PolylineWalker
+
 a = PolylineWalker('Poststrasse+20,Zug,CH', 'Guggiweg+7,Zug,CH', 100)
 print('Walking polyline: ', a.polyline)
 print('Encoded level: ','B'*len(a.points))

--- a/pokemongo_bot/polyline_walker/polyline_walker.py
+++ b/pokemongo_bot/polyline_walker/polyline_walker.py
@@ -1,9 +1,11 @@
-import requests
-import polyline
-import haversine
 import time
-from itertools import  chain
+from itertools import chain
 from math import ceil
+
+import haversine
+import polyline
+import requests
+
 
 class PolylineWalker(object):
 

--- a/pokemongo_bot/spiral_navigator.py
+++ b/pokemongo_bot/spiral_navigator.py
@@ -1,20 +1,8 @@
 # -*- coding: utf-8 -*-
-
-import os
-import json
-import time
-import pprint
-
-from math import ceil
-from s2sphere import CellId, LatLng
-from google.protobuf.internal import encoder
-
-from human_behaviour import sleep, random_lat_long_delta
-from cell_workers.utils import distance, i2f, format_time, format_dist
-from step_walker import StepWalker
-
-from pgoapi.utilities import f2i, h2f
 import logger
+from cell_workers.utils import distance, i2f, format_dist
+from human_behaviour import sleep
+from step_walker import StepWalker
 
 
 class SpiralNavigator(object):

--- a/pokemongo_bot/step_walker.py
+++ b/pokemongo_bot/step_walker.py
@@ -1,8 +1,7 @@
-import logger
+from math import sqrt
 
-from cell_workers.utils import distance, i2f, format_time, format_dist
+from cell_workers.utils import distance, i2f
 from human_behaviour import random_lat_long_delta, sleep
-from math import ceil, sqrt
 
 
 class StepWalker(object):


### PR DESCRIPTION
Can’t mix tabs and spaces in python.
Removed unused imports and moved library imports above local imports.

Fixes:
- Fixed python TabError by replacing tabs with spaces.