### PR TITLE
#848 [Suggestion] Make captured pokemon message a different color

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -138,7 +138,7 @@ class PokemonCatchWorker(object):
                                             pokemon_name,
                                             cp,
                                             pokemon_potential
-                                        ), 'green'
+                                        ), 'cyan'
                                     )
 
                                     id_list2 = self.count_pokemon_inventory()

--- a/pokemongo_bot/logger.py
+++ b/pokemongo_bot/logger.py
@@ -11,7 +11,8 @@ def log(string, color = 'white'):
     colorHex = {
         'green': '92m',
         'yellow': '93m',
-        'red': '91m'
+        'red': '91m',
+        'cyan': '96m'
     }
     if color not in colorHex:
         print('[' + time.strftime("%Y-%m-%d %H:%M:%S") + '] '+ string)


### PR DESCRIPTION
Short Description: As suggested:  Added Cyan to the logger.py  plus changed captured worker to log in cyan so that all captures are easier to notice when looking at the long

Fixes:
- 
- 
- 

