### PR TITLE
Increases pokestop movement efficiency

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -191,12 +191,19 @@ class PokemonGoBot(object):
                 forts.sort(key=lambda x: distance(self.position[
                            0], self.position[1], x['latitude'], x['longitude']))
 
-                for fort in forts:
+                while len(forts) > 0:
+                    # Sort all by distance from current pos- eventually this should
+                    # build graph & A* it
+                    forts.sort(key=lambda x: distance(self.position[
+                            0], self.position[1], x['latitude'], x['longitude']))
+                    fort = forts[0]
                     worker = MoveToFortWorker(fort, self)
                     worker.work()
-
+                    if fort in forts:
+                        forts.remove(fort)
                     worker = SeenFortWorker(fort, self)
                     hack_chain = worker.work()
+                    self.position = worker.position #Update our position to the bots position
                     if hack_chain > 10:
                         #print('need a rest')
                         break

--- a/pokemongo_bot/cell_workers/seen_fort_worker.py
+++ b/pokemongo_bot/cell_workers/seen_fort_worker.py
@@ -36,6 +36,7 @@ class SeenFortWorker(object):
             fort_name = 'Unknown'
         logger.log('Now at Pokestop: ' + fort_name + ' - Spinning...',
                    'cyan')
+        self.position = [self.fort['latitude'], self.fort['longitude']]
         sleep(2)
         self.api.fort_search(fort_id=self.fort['id'],
                              fort_latitude=lat,


### PR DESCRIPTION
Short Description: Makes the program move less distance while using pokestops, cutting down time

Makes it so distance tracking is done after every fort, instead of just
at the beginning. This should make walking times between pokestops much
less in certain cases. (For example, on the old loop, if fort A was
2.5mi North, fort B was 2.7 mi North, and fort C was 2.6mi South, the
program would go A->C->B, which is insanely inefficient)

Also, the self.position in __init__.py now stays up-to-date with the
actual current position. This was needed to allow for the more real-time
location checking.