### PR TITLE
Missing "catch" and "release" config settings no longer crash the bot.

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -138,7 +138,7 @@ def init_config():
                         help="(Batch mode) Pass \"all\" or a list of pokemons to evolve (e.g., \"Pidgey,Weedle,Caterpie\"). Bot will start by attempting to evolve all pokemons. Great after popping a lucky egg!",
                         type=str,
                         default=[])
-    
+
     parser.add_argument(
         "-cm",
         "--cp_min",
@@ -168,12 +168,16 @@ def init_config():
     for key in config.__dict__:
         if key in load:
             config.__dict__[key] = load[key]
-            
+
     if 'catch' in load:
         config.catch = load['catch']
+    else:
+        config.catch = {}
 
     if 'release' in load:
         config.release = load['release']
+    else:
+        config.release = {}
 
     if config.auth_service not in ['ptc', 'google']:
         logging.error("Invalid Auth service specified! ('ptc' or 'google')")
@@ -188,7 +192,7 @@ def init_config():
         config.item_filter= config.item_filter.split(",")
 
     # create web dir if not exists
-    try: 
+    try:
         os.makedirs(web_dir)
     except OSError:
         if not os.path.isdir(web_dir):

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -319,7 +319,9 @@ class PokemonCatchWorker(object):
     def _get_catch_config_for(self, pokemon):
         catch_config = self.config.catch.get(pokemon)
         if not catch_config:
-            catch_config = self.config.catch['any']
+            catch_config = self.config.catch.get('any')
+        if not catch_config:
+            catch_config = {}
         return catch_config
 
     def should_release_pokemon(self, pokemon_name, cp, iv, response_dict):
@@ -366,5 +368,7 @@ class PokemonCatchWorker(object):
     def _get_release_config_for(self, pokemon):
         release_config = self.config.release.get(pokemon)
         if not release_config:
-            release_config = self.config.release['any']
+            release_config = self.config.release.get('any')
+        if not release_config:
+            release_config = {}
         return release_config


### PR DESCRIPTION
The default values are the as if the settings were empty (so, "catch all" and "release none")