### PR TITLE
Support for non unicode location

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -40,6 +40,7 @@ from pokemongo_bot import logger
 if sys.version_info >= (2, 7, 9):
     ssl._create_default_https_context = ssl._create_unverified_context
 
+
 def init_config():
     parser = argparse.ArgumentParser()
     config_file = "configs/config.json"
@@ -50,7 +51,7 @@ def init_config():
 
     # Select a config file code
     parser.add_argument("-cf", "--config", help="Config File to use")
-    config_arg = unicode(parser.parse_args().config)
+    config_arg = parser.parse_known_args() and parser.parse_known_args()[0].config or None
     if os.path.isfile(config_arg):
         with open(config_arg) as data:
             load.update(json.load(data))
@@ -61,103 +62,119 @@ def init_config():
     else:
         logger.log('Error: No /configs/config.json or specified config', 'red')
 
-
     # Read passed in Arguments
     required = lambda x: not x in load
-    parser.add_argument("-a",
-                        "--auth_service",
-                        help="Auth Service ('ptc' or 'google')",
-                        required=required("auth_service"))
+    parser.add_argument(
+        "-a",
+        "--auth_service",
+        help="Auth Service ('ptc' or 'google')",
+        required=required("auth_service")
+    )
     parser.add_argument("-u", "--username", help="Username")
     parser.add_argument("-p", "--password", help="Password")
-    parser.add_argument("-l", "--location", help="Location")
-    parser.add_argument("-lc",
-                        "--location_cache",
-                        help="Bot will start at last known location",
-                        type=bool,
-                        default=False)
-    parser.add_argument("-m",
-                        "--mode",
-                        help="Farming Mode",
-                        type=str,
-                        default="all")
+    parser.add_argument("-l", "--location", help="Location", type=lambda s: unicode(s, 'utf8'))
+    parser.add_argument(
+        "-lc",
+        "--location_cache",
+        help="Bot will start at last known location",
+        type=bool,
+        default=False
+    )
+    parser.add_argument(
+        "-m",
+        "--mode",
+        help="Farming Mode",
+        type=str,
+        default="all"
+    )
     parser.add_argument(
         "-w",
         "--walk",
         help=
         "Walk instead of teleport with given speed (meters per second, e.g. 2.5)",
         type=float,
-        default=2.5)
-    parser.add_argument("-k",
-                        "--gmapkey",
-                        help="Set Google Maps API KEY",
-                        type=str,
-                        default=None)
+        default=2.5
+    )
+    parser.add_argument(
+        "-k",
+        "--gmapkey",
+        help="Set Google Maps API KEY",
+        type=str,
+        default=None
+    )
     parser.add_argument(
         "-ms",
         "--max_steps",
         help=
         "Set the steps around your initial location(DEFAULT 5 mean 25 cells around your location)",
         type=int,
-        default=50)
+        default=50
+    )
     parser.add_argument(
         "-it",
         "--initial_transfer",
-        help=
-        "Transfer all duplicate pokemon with same ID on bot start, except pokemon with highest CP. Accepts a number to prevent transferring pokemon with a CP above the provided value.  Default is 0 (aka transfer none).",
+        help="Transfer all duplicate pokemon with same ID on bot start, except pokemon with highest CP. Accepts a number to prevent transferring pokemon with a CP above the provided value.  Default is 0 (aka transfer none).",
         type=int,
-        default=0)
-    parser.add_argument("-d",
-                        "--debug",
-                        help="Debug Mode",
-                        type=bool,
-                        default=False)
-    parser.add_argument("-t",
-                        "--test",
-                        help="Only parse the specified location",
-                        type=bool,
-                        default=False)
+        default=0
+    )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        help="Debug Mode",
+        type=bool,
+        default=False
+    )
+    parser.add_argument(
+        "-t",
+        "--test",
+        help="Only parse the specified location",
+        type=bool,
+        default=False
+    )
     parser.add_argument(
         "-du",
         "--distance_unit",
-        help=
-        "Set the unit to display distance in (e.g, km for kilometers, mi for miles, ft for feet)",
+        help="Set the unit to display distance in (e.g, km for kilometers, mi for miles, ft for feet)",
         type=str,
-        default="km")
-
+        default="km"
+    )
     parser.add_argument(
         "-if",
         "--item_filter",
-        help=
-        "Pass a list of unwanted items to recycle when collected at a Pokestop (e.g, SYNTAX FOR CONFIG.JSON : [\"101\",\"102\",\"103\",\"104\"] to recycle potions when collected, SYNTAX FOR CONSOLE ARGUMENT : \"101\",\"102\",\"103\",\"104\")",
+        help="Pass a list of unwanted items to recycle when collected at a Pokestop (e.g, SYNTAX FOR CONFIG.JSON : [\"101\",\"102\",\"103\",\"104\"] to recycle potions when collected, SYNTAX FOR CONSOLE ARGUMENT : \"101\",\"102\",\"103\",\"104\")",
         type=list,
-        default=[])
-
-    parser.add_argument("-ev",
-                        "--evolve_all",
-                        help="(Batch mode) Pass \"all\" or a list of pokemons to evolve (e.g., \"Pidgey,Weedle,Caterpie\"). Bot will start by attempting to evolve all pokemons. Great after popping a lucky egg!",
-                        type=str,
-                        default=[])
-
+        default=[]
+    )
+    parser.add_argument(
+        "-ev",
+        "--evolve_all",
+        help="(Batch mode) Pass \"all\" or a list of pokemons to evolve (e.g., \"Pidgey,Weedle,Caterpie\"). Bot will start by attempting to evolve all pokemons. Great after popping a lucky egg!",
+        type=str,
+        default=[]
+    )
     parser.add_argument(
         "-cm",
         "--cp_min",
-        help=
-        "Minimum CP for evolve all. Bot will attempt to first evolve highest IV pokemons with CP larger than this.",
+        help="Minimum CP for evolve all. Bot will attempt to first evolve highest IV pokemons with CP larger than this.",
         type=int,
-        default=300)
+        default=300
+    )
+    parser.add_argument(
+        "-ec",
+        "--evolve_captured",
+        help="(Ad-hoc mode) Bot will attempt to evolve all the pokemons captured!",
+        type=bool,
+        default=False
+    )
+    parser.add_argument(
+        "-le",
+        "--use_lucky_egg",
+        help="Uses lucky egg when using evolve_all",
+        type=bool,
+        default=False
+    )
 
-    parser.add_argument("-ec",
-                        "--evolve_captured",
-                        help="(Ad-hoc mode) Bot will attempt to evolve all the pokemons captured!",
-                        type=bool,
-                        default=False)
-    parser.add_argument("-le",
-                        "--use_lucky_egg",
-                        help="Uses lucky egg when using evolve_all",
-                        type=bool,
-                        default=False)
-
+    # Start to parse other attrs
     config = parser.parse_args()
     if not config.username and 'username' not in load:
         config.username = raw_input("Username: ")
@@ -166,7 +183,7 @@ def init_config():
 
     # Passed in arguments should trump
     for key in config.__dict__:
-        if key in load:
+        if key in load and load[key]:
             config.__dict__[key] = load[key]
 
     if 'catch' in load:
@@ -203,12 +220,9 @@ def init_config():
 
     return config
 
-def main():
 
+def main():
     logger.log('PokemonGO Bot v1.0', 'green')
-    # log settings
-    # log format
-    #logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(module)10s] [%(levelname)5s] %(message)s')
     sys.stdout = codecs.getwriter('utf8')(sys.stdout)
     sys.stderr = codecs.getwriter('utf8')(sys.stderr)
 

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -426,13 +426,12 @@ class PokemonGoBot(object):
 
         if self.config.location:
             try:
-                location_str = str(self.config.location)
+                location_str = u'{}'.format(self.config.location)
                 location = (self._get_pos_by_name(location_str.replace(" ", "")))
                 self.position = location
                 self.api.set_position(*self.position)
                 logger.log('')
-                logger.log(u'Location Found: {}'.format(self.config.location.decode(
-                    'utf-8')))
+                logger.log(u'Location Found: {}'.format(location_str))
                 logger.log('GeoPosition: {}'.format(self.position))
                 logger.log('')
                 has_position = True


### PR DESCRIPTION
Short Description: 	Allow to set non unicode location, both as command argument and config value.

Fixes:
- Fixes for config file parsing and non unicode location
- Fixes for `-l` command argument and non unicode location
- Small style formatting changes in `pokecli.py`

How to reproduce crash on previous version?

Just try to set `-l "Красная площадь, Москва, город Москва"` or add same value to `location` in config.

