### PR TITLE
Fixed unit error

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Option | Meaning
 ------ | -------
 `max_steps` |		The steps around your initial location (DEFAULT 5 mean 25 cells around your location) that will be explored
 `mode` |  		Set farming Mode for the bot ('all', 'poke', 'farm'). 'all' means both spinning pokéstops and catching pokémon; 'poke'means only catching pokémon and 'farm' means only spinning pokéstops
-`walk` | Walk with the given speed (meters per second max 4.16 because of walking end on 15km/h)
+`walk` | 		Set the walking speed in kilometers per hour.(30km/h is the maximum speed for egg hatching)
 `debug` | 		Let the default value here except if you are developer
 `test` | 		Let the default value here except if you are developer
 `initial_transfer` | 	Set this to an upper bound of the cp level which you want to transfer at the beginning of the run. For example, set the value to 0 to disable the initial transfer, set it to 100 to enable initial transfer for cp levels 0-99. It will still transfer pokémon during your exploration, depending on how your release_config.json is setup.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Option | Meaning
 ------ | -------
 `max_steps` |		The steps around your initial location (DEFAULT 5 mean 25 cells around your location) that will be explored
 `mode` |  		Set farming Mode for the bot ('all', 'poke', 'farm'). 'all' means both spinning pokéstops and catching pokémon; 'poke'means only catching pokémon and 'farm' means only spinning pokéstops
-`walk` | 		Set the walking speed in kilometers per hour.(30km/h is the maximum speed for egg hatching)
+`walk` | 		Set the walking speed in kilometers per hour.(14km/h is the maximum speed for egg hatching)
 `debug` | 		Let the default value here except if you are developer
 `test` | 		Let the default value here except if you are developer
 `initial_transfer` | 	Set this to an upper bound of the cp level which you want to transfer at the beginning of the run. For example, set the value to 0 to disable the initial transfer, set it to 100 to enable initial transfer for cp levels 0-99. It will still transfer pokémon during your exploration, depending on how your release_config.json is setup.


### PR DESCRIPTION
Short Description:   
The "walk" option in the config file uses km/h as unit,not m/s as written in the README file
I enclosed few proving screenshots.  

Fixes:
- Fixed the readme file   


![1](https://cloud.githubusercontent.com/assets/17828142/17143495/bd44194c-5353-11e6-9e37-00b262a6252f.png)
![2](https://cloud.githubusercontent.com/assets/17828142/17143496/bd640c7a-5353-11e6-8a4a-ea74f62ff0cb.png)
![3](https://cloud.githubusercontent.com/assets/17828142/17143497/bd6817de-5353-11e6-883a-8e4ae5df69f6.png)


