### PR TITLE
fix json comments so it's a valid json file

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -33,3 +33,4 @@
  * steffwiz
  * pulgalipe
  * BartKoppelmans
+ * VictorChen

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -19,10 +19,12 @@
     "evolve_captured": false,
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
-      // "Rattata": { "always_catch" : true }
+      "// Example of always catching Rattata:": {},
+      "// Rattata": { "always_catch" : true }
     },
     "release": {
       "any": {"release_below_cp": 0, "release_below_iv": 0, "logic": "or"},
-      // "Rattata": { "always_release" : true }
+      "// Example of always releasing Rattata:": {},
+      "// Rattata": { "always_release" : true }
     }
 }


### PR DESCRIPTION
Use proper (more or less...) json comments. This way it won't break when users copy the json file.

Fix #1007 