### PR TITLE
find_close_cells incorrectly receives target position instead of current one

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -39,7 +39,7 @@ class PokemonGoBot(object):
 
     def take_step(self):
         location = self.navigator.take_step()
-        cells = self.find_close_cells(*location[0:2])
+        cells = self.find_close_cells(*self.position[0:2])
 
         for cell in cells:
             self.work_on_cell(cell, location)


### PR DESCRIPTION
The call to SpiralNavigator.take_step() is returning the next target position, and take_step in PokemonGoBot is using it to call find_close_cells.

Instead, find_close_cells should be called with self.position, that is, the current position.