### PR TITLE
Make initial_transfer use release config

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,3 +34,4 @@
  * pulgalipe
  * BartKoppelmans
  * VictorChen
+ * AlvaroGzP

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Option | Meaning
 `walk` | 		Set the walking speed in kilometers per hour.(14km/h is the maximum speed for egg hatching)
 `debug` | 		Let the default value here except if you are developer
 `test` | 		Let the default value here except if you are developer
-`initial_transfer` | 	Set this to an upper bound of the cp level which you want to transfer at the beginning of the run. For example, set the value to 0 to disable the initial transfer, set it to 100 to enable initial transfer for cp levels 0-99. It will still transfer pokémon during your exploration, depending on how your release_config.json is setup.
+`initial_transfer` | 	Set this to true to transfer your pokemons at the beginning of the run based on the release config (currently only takes CP into account).
 `location_cache` | Bot will start at last known location if you do not have location set in the config
 `distance_unit` | 	Set the unit to display distance in (e.g, km for kilometers, mi for miles, ft for feet)
 `item_filter` | 	Pass a list of unwanted items (in CSV format) to recycle when collected at a Pokestop (e.g, "101,102,103,104" to recycle potions when collected)

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Option | Meaning
 `walk` | 		Set the walking speed in kilometers per hour.(14km/h is the maximum speed for egg hatching)
 `debug` | 		Let the default value here except if you are developer
 `test` | 		Let the default value here except if you are developer
-`initial_transfer` | 	Set this to true to transfer your pokemons at the beginning of the run based on the release config (currently only takes CP into account).
+`initial_transfer` | 	Set this to true to transfer your pokemons at the beginning of the run based on your release config.
 `location_cache` | Bot will start at last known location if you do not have location set in the config
 `distance_unit` | 	Set the unit to display distance in (e.g, km for kilometers, mi for miles, ft for feet)
 `item_filter` | 	Pass a list of unwanted items (in CSV format) to recycle when collected at a Pokestop (e.g, "101,102,103,104" to recycle potions when collected)

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -9,7 +9,7 @@
     "walk": 4.16,
     "debug": false,
     "test": false,
-    "initial_transfer": 0,
+    "initial_transfer": false,
     "location_cache": true,
     "distance_unit": "km",
     "item_filter": {

--- a/configs/config.json.pokemons.example
+++ b/configs/config.json.pokemons.example
@@ -9,7 +9,7 @@
     "walk": 4.16,
     "debug": false,
     "test": false,
-    "initial_transfer": 0,
+    "initial_transfer": false,
     "location_cache": true,
     "distance_unit": "km",
     "item_filter": {

--- a/pokemongo_bot/cell_workers/initial_transfer_worker.py
+++ b/pokemongo_bot/cell_workers/initial_transfer_worker.py
@@ -13,7 +13,7 @@ class InitialTransferWorker(object):
         if not self.config.initial_transfer:
             return
 
-        logger.log('Cleaning up Pokemon Bag using the release CP config', 'cyan')
+        logger.log('Cleaning up Pokemon Bag using the release config', 'cyan')
 
         pokemon_groups = self._initial_transfer_get_groups()
 

--- a/pokemongo_bot/cell_workers/initial_transfer_worker.py
+++ b/pokemongo_bot/cell_workers/initial_transfer_worker.py
@@ -28,11 +28,12 @@ class InitialTransferWorker(object):
 
                 for x in range(1, len(group_cp)):
                     pokemon_name = self.pokemon_list[id - 1]['Name']
-                    pokemon_data = pokemon_groups[id][group_cp[x]]
+                    pokemon_cp = group_cp[x]
+                    pokemon_data = pokemon_groups[id][pokemon_cp]
                     pokemon_potential = self.get_pokemon_potential(pokemon_data)
-                    if self.should_release_pokemon(pokemon_name, group_cp[x], pokemon_potential):
-                        logger.log('Exchanging {} with {} CP'.format(
-                            pokemon_name, group_cp[x]))
+                    if self.should_release_pokemon(pokemon_name, pokemon_cp, pokemon_potential):
+                        logger.log('Exchanging {} [CP {}] [Potential {}]'.format(
+                            pokemon_name, pokemon_cp, pokemon_potential))
                         self.api.release_pokemon(
                             pokemon_id=pokemon_data['id'])
                         response_dict = self.api.call()

--- a/pokemongo_bot/cell_workers/initial_transfer_worker.py
+++ b/pokemongo_bot/cell_workers/initial_transfer_worker.py
@@ -28,11 +28,13 @@ class InitialTransferWorker(object):
 
                 for x in range(1, len(group_cp)):
                     pokemon_name = self.pokemon_list[id - 1]['Name']
-                    if self.should_release_pokemon(pokemon_name, group_cp[x]):
+                    pokemon_data = pokemon_groups[id][group_cp[x]]
+                    pokemon_potential = self.get_pokemon_potential(pokemon_data)
+                    if self.should_release_pokemon(pokemon_name, group_cp[x], pokemon_potential):
                         logger.log('Exchanging {} with {} CP'.format(
                             pokemon_name, group_cp[x]))
                         self.api.release_pokemon(
-                            pokemon_id=pokemon_groups[id][group_cp[x]])
+                            pokemon_id=pokemon_data['id'])
                         response_dict = self.api.call()
                         sleep(2)
 
@@ -57,21 +59,36 @@ class InitialTransferWorker(object):
             except KeyError:
                 continue
 
-            group_id = pokemon['inventory_item_data'][
-                'pokemon_data']['pokemon_id']
-            group_pokemon = pokemon['inventory_item_data'][
-                'pokemon_data']['id']
-            group_pokemon_cp = pokemon[
-                'inventory_item_data']['pokemon_data']['cp']
+            pokemon_data = pokemon['inventory_item_data']['pokemon_data']
+            group_id = pokemon_data['pokemon_id']
+            group_pokemon_cp = pokemon_data['cp']
 
             if group_id not in pokemon_groups:
                 pokemon_groups[group_id] = {}
 
-            pokemon_groups[group_id].update({group_pokemon_cp: group_pokemon})
+            pokemon_groups[group_id].update({group_pokemon_cp: pokemon_data})
         return pokemon_groups
 
-    def should_release_pokemon(self, pokemon_name, cp):
+    def get_pokemon_potential(self, pokemon_data):
+        total_iv = 0
+        iv_stats = ['individual_attack', 'individual_defense', 'individual_stamina']
+        for individual_stat in iv_stats:
+            try:
+                total_iv += pokemon_data[individual_stat]
+            except:
+                continue
+        return round((total_iv / 45.0), 2)
+
+    def should_release_pokemon(self, pokemon_name, cp, iv):
         release_config = self._get_release_config_for(pokemon_name)
+        cp_iv_logic = release_config.get('logic')
+        if not cp_iv_logic:
+            cp_iv_logic = self._get_release_config_for('any').get('logic', 'and')
+
+        release_results = {
+            'cp': False,
+            'iv': False,
+        }
 
         if release_config.get('never_release', False):
             return False
@@ -80,7 +97,28 @@ class InitialTransferWorker(object):
             return True
 
         release_cp = release_config.get('release_below_cp', 0)
-        return cp < release_cp
+        if cp < release_cp:
+            release_results['cp'] = True
+
+        release_iv = release_config.get('release_below_iv', 0)
+        if iv < release_iv:
+            release_results['iv'] = True
+
+        logic_to_function = {
+            'or': lambda x, y: x or y,
+            'and': lambda x, y: x and y
+        }
+
+        #logger.log(
+        #    "Release config for {}: CP {} {} IV {}".format(
+        #        pokemon_name,
+        #        min_cp,
+        #        cp_iv_logic,
+        #        min_iv
+        #    ), 'yellow'
+        #)
+
+        return logic_to_function[cp_iv_logic](*release_results.values())
 
     def _get_release_config_for(self, pokemon):
         release_config = self.config.release.get(pokemon)


### PR DESCRIPTION
Modify the initial_transfer feature so that instead of releasing all pokemons below a certain CP, use the release config to decide whether release the pokemon or not.