### PR TITLE
Walk within range of stops rather than the center

### DIFF
--- a/pokemongo_bot/cell_workers/move_to_fort_worker.py
+++ b/pokemongo_bot/cell_workers/move_to_fort_worker.py
@@ -1,4 +1,4 @@
-from utils import distance, format_dist
+from utils import distance, format_dist, i2f
 from pokemongo_bot.human_behaviour import sleep
 from pokemongo_bot import logger
 from pokemongo_bot.step_walker import StepWalker
@@ -38,7 +38,7 @@ class MoveToFortWorker(object):
                     position[1]
                 )
 
-                while True:
+                while distance(i2f(self.api._position_lat), i2f(self.api._position_lng), lat, lng) > 10:
                     if step_walker.step():
                         break
 


### PR DESCRIPTION
Used the same range of 10 that the stepper uses to deem when it’s close
enough.

This should fix #1018