### PR TITLE
TypeError: argument of type 'NoneType' is not iterable

### DIFF
--- a/pokemongo_bot/cell_workers/seen_fort_worker.py
+++ b/pokemongo_bot/cell_workers/seen_fort_worker.py
@@ -28,7 +28,7 @@ class SeenFortWorker(object):
                               latitude=lat,
                               longitude=lng)
         response_dict = self.api.call()
-        if 'responses' in response_dict \
+        if response_dict and 'responses' in response_dict \
                 and'FORT_DETAILS' in response_dict['responses'] \
                 and 'name' in response_dict['responses']['FORT_DETAILS']:
             fort_details = response_dict['responses']['FORT_DETAILS']


### PR DESCRIPTION
Short Description: 
'NoneType' error occured when 'response_dict' is received as none from api call.

Fixes:
- TypeError: argument of type 'NoneType' is not iterable (line 31)
- 
- 


