### PR TITLE
[Bugfix: Strange Location] Pins the pgoapi pip to v1.1.0 tag to fix f2i/i2f bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/tejado/pgoapi.git#egg=pgoapi
+-e git+https://github.com/tejado/pgoapi.git@v1.1.0#egg=pgoapi
 geopy==1.11.0
 protobuf==3.0.0b4
 requests==2.10.0


### PR DESCRIPTION
Short Description: 
Due to an update in the pgoapi the f2i and i2f functions are not needed anymore. To fix this in the current code the fastest solution is to pin the pgoapi pip ti the v1.1.0 tag.
After this PR the users have to `pip install -r requirements.txt` again.

Fixes:
- Strange locations due to update in the pgoapi


