### PR TITLE
Set evolve speed in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Option | Meaning
 `distance_unit` | 	Set the unit to display distance in (e.g, km for kilometers, mi for miles, ft for feet)
 `item_filter` | 	Pass a list of unwanted items (in CSV format) to recycle when collected at a Pokestop (e.g, "101,102,103,104" to recycle potions when collected)
 `evolve_all` | 	Set to true to evolve pokemon if possible, takes pokémon as an argument as well.
+`evolve_speed` | 	Set the speed between each evolves in seconds. (Defaults to 3.7 seconds if not set)
 
 ## Catch Configuration
 Default configuration will capture all Pokemon.

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -22,6 +22,7 @@
       "701": { "keep" : 100 }
     },
     "evolve_all": "NONE",
+    "evolve_speed": 20,
     "cp_min": 300,
     "use_lucky_egg": false,
     "evolve_captured": false,

--- a/configs/config.json.pokemons.example
+++ b/configs/config.json.pokemons.example
@@ -21,6 +21,7 @@
       "701": { "keep" : 100 }
     },
     "evolve_all": "NONE",
+    "evolve_speed": 20,
     "use_lucky_egg": false,
     "evolve_captured": false,
     "catch": {

--- a/pokemongo_bot/cell_workers/evolve_all_worker.py
+++ b/pokemongo_bot/cell_workers/evolve_all_worker.py
@@ -126,7 +126,12 @@ class EvolveAllWorker(object):
             print('[#] Successfully evolved {} with {} CP and {} IV!'.format(
                 pokemon_name, pokemon_cp, pokemon_iv
             ))
-            sleep(3.7)
+            
+            if self.config.evolve_speed:
+                sleep(self.config.evolve_speed)
+            else:
+                sleep(3.7)
+            
         else:
             # cache pokemons we can't evolve. Less server calls
             cache[pokemon_name] = 1


### PR DESCRIPTION
Short Description:  Allows the users to set the amount of time between evolves to simulate evolving on the app.

Fixes:
- Added `evolve_speed` to **config.json.example** and **config.json.pokemons.example**
- Added in to **evolve_all_worker.py**

If `evolve_speed` isn't in the config, it'll default to 3.7 (which is what it's set at right now)