### PR TITLE
Dont try to recycle 0 items

### DIFF
--- a/pokemongo_bot/cell_workers/seen_fort_worker.py
+++ b/pokemongo_bot/cell_workers/seen_fort_worker.py
@@ -77,7 +77,7 @@ class SeenFortWorker(object):
                         if id_filter is not 0:
                             id_filter_keep = id_filter.get('keep',20)
                         new_bag_count = self.bot.item_inventory_count(item_id)
-                        if str(item_id) in self.config.item_filter and new_bag_count >= id_filter_keep:
+                        if str(item_id) in self.config.item_filter and new_bag_count > id_filter_keep:
                             #RECYCLE_INVENTORY_ITEM
                             items_recycle_count = new_bag_count - id_filter_keep
                             logger.log("-- Recycling " + str(items_recycle_count) + "x " + item_name + " to match filter "+ str(id_filter_keep) +"...", 'green')


### PR DESCRIPTION
Short Description: Assuming a max count of 100 of an item, picking up the 100th of that item will try to recycle 0 of that item.  Don't try to recycle 0 of an item.

Fixes:
- 
- 
- 


