### PR TITLE
Added multiaccount automation scripts

### DIFF
--- a/multiaccount_tools/how_to_configure
+++ b/multiaccount_tools/how_to_configure
@@ -1,0 +1,40 @@
+How to configure the multibot scripts
+
+first you need to install screen.
+how to depends on your package manager (assuming you are running linux).
+
+then change the parameters in EACH file to suit your preferences
+the names you choose MUST be coherent between file
+(i.e. confiName1 in start_pokego must be the same as configName1 in status/restart/stop_pokego)
+
+- screenName is the name of the screen that will be created
+- configName is the config file for that account (must be placed in configs folder and named configName.config
+- username.. well its your username (doesnt need to be tho)
+
+note: you can also leave the parameters like this and just call your config file "configName1",
+but its really ugly.
+TODO: autoconfig script
+
+to run:
+./start_pokego.sh 
+#will kill and restart all bots and web server if already running. (killing the screens)
+
+to stop:
+./stop_pokego.sh 
+#will stop all bot and the web server. (killing the screens)
+
+note: all bots are started in a loop so if they crash they will restart automatically.
+
+if you stop some of them manually and dont remember which one you can check which bot is currently running with:
+./status_pokego.sh
+
+you can restart only currently running bots with:
+./restart_pokego.sh
+#will kill the bot process but neither the loop nor the screen, so the bot will restart.
+
+you can also interact with screen directly using:
+
+screen -r screenName #to attach to a screen
+C-a d to detach
+screen -list #to check a list of the running screens
+(checkout the manual for screen running "man screen" for more info)

--- a/multiaccount_tools/loop.sh
+++ b/multiaccount_tools/loop.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+cd ..
+while true
+do
+  ./pokecli.py -cf $1
+  echo ">pokecli exited... restarting...";
+  sleep 5;
+done

--- a/multiaccount_tools/restart_pokego.sh
+++ b/multiaccount_tools/restart_pokego.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+ps -C python -o pid,args | grep pokecli | grep configName1 | sed -n 's/ *\([0-9][0-9]*\).*/\1/p' | xargs kill 2> /dev/null && echo configName1 killed
+ps -C python -o pid,args | grep pokecli | grep configName2 | sed -n 's/ *\([0-9][0-9]*\).*/\1/p' | xargs kill 2> /dev/null && echo configName2 killed
+ps -C python -o pid,args | grep pokecli | grep configName3 | sed -n 's/ *\([0-9][0-9]*\).*/\1/p' | xargs kill 2> /dev/null && echo configName3 killed
+ps -C python -o pid,args | grep SimpleHTTP | sed -n 's/ *\([0-9][0-9]*\).*/\1/p' | xargs kill 2> /dev/null && echo http server killed

--- a/multiaccount_tools/start_pokego.sh
+++ b/multiaccount_tools/start_pokego.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+
+echo 'killing all running bots(just in case)...'
+echo 
+./stop_pokego.sh
+
+
+echo
+echo 'starting bots in separate screen sessions...'
+echo
+screen -dmS screenName1 ./loop.sh configs/configName1.config && echo username1 started
+screen -dmS screenName2 ./loop.sh configs/configName2.config && echo username2 started
+screen -dmS screenName3 ./loop.sh configs/configName3.config && echo username3 started
+#copy/remove the line above to add/remove bots
+
+
+#start http server on localhost:8080
+
+cd ../web
+screen -dmS server_pokemon python -m SimpleHTTPServer 8080 && echo server http started

--- a/multiaccount_tools/status_pokego.sh
+++ b/multiaccount_tools/status_pokego.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+ps -C python -o pid,args | grep pokecli | grep configName1 > /dev/null && echo configName1 is running || echo configName1 is stopped
+ps -C python -o pid,args | grep pokecli | grep configName2 > /dev/null && echo configName2 is running || echo configName2 is stopped
+ps -C python -o pid,args | grep pokecli | grep configName3 > /dev/null && echo configName3 is running || echo configName3 is stopped

--- a/multiaccount_tools/stop_pokego.sh
+++ b/multiaccount_tools/stop_pokego.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+ps -C screen -o pid,args | grep loop | grep configName1 | sed -n 's/ *\([0-9][0-9]*\).*/\1/p' | xargs kill 2> /dev/null && echo configName1 killed
+ps -C screen -o pid,args | grep loop | grep configName2 | sed -n 's/ *\([0-9][0-9]*\).*/\1/p' | xargs kill 2> /dev/null && echo configName2 killed
+ps -C screen -o pid,args | grep loop | grep configName3 | sed -n 's/ *\([0-9][0-9]*\).*/\1/p' | xargs kill 2> /dev/null && echo configName3 killed
+ps -C screen -o pid,args | grep SimpleHTTP | sed -n 's/ *\([0-9][0-9]*\).*/\1/p' | xargs kill 2> /dev/null && echo http server killed


### PR DESCRIPTION
I wrote a couple of bash scripts to automate multiaccount botting with screen.
Although totally not well written i found them really handy, expecially when running the bot on a vps.

Basically this adds the ability to start and stop multiple bots at a time in separate screen sessions (and with separate configs).
detailed features are described in the how to file.

I'm not sure if this file hierarchy is correct and if the how to should go into the readme or not, please let me know.

The loop feature is taken from #948, i know the relogin issue and other crashes were solved in recent commits but still i think its handy for unexpected crashes when the bot is left unattended.