### PR TITLE
Fix pgoapi package repository hash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/tejado/pgoapi.git#egg=pgoapi
+-e git+https://github.com/tejado/pgoapi.git@3787ffbe2e80ebce8a02d48eebceb9edf40179c1#egg=pgoapi
 geopy==1.11.0
 protobuf==3.0.0b4
 requests==2.10.0


### PR DESCRIPTION
Short Description: 

Fix 'pgoapi' package repository hash because latest one broke this bot.  It seems that protobuf definition was updated.  I think it is better that update pgoapi version with confirming manually. 

Fixes:
- Fixed pgoapi package's commit hash to the one with which at least I confirmed this bot worked well.
