### PR TITLE
Update _get_catch_config in pokemon_catch_worker

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -333,8 +333,6 @@ class PokemonCatchWorker(object):
         catch_config = self.config.catch.get(pokemon)
         if not catch_config:
             catch_config = self.config.catch.get('any')
-        if not catch_config:
-            catch_config = {}
         return catch_config
 
     def should_release_pokemon(self, pokemon_name, cp, iv, response_dict):


### PR DESCRIPTION
Short Description: 

It should return the setting given by "any" in the catch_config file, instead of return {} for a "unspecified" pokemon.

Fixes:
delete the second  if condition


