### PR TITLE
Dump cells to enable custom front-end functionalities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ src/
 web/
 data/last-location*.json
 data/catch-ignore.yml
+data/cells-*.json
 
 #Multiple config
 configs/*

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -101,6 +101,11 @@ class PokemonGoBot(object):
                             response_gym_details = self.api.call()
                             fort['gym_details'] = response_gym_details['responses']['GET_GYM_DETAILS']
 
+        user_data_cells = "data/cells-%s.json" % (self.config.username)
+        with open(user_data_cells, 'w') as outfile:
+            outfile.truncate()
+            json.dump(cells, outfile)
+
         user_web_location = os.path.join('web', 'location-%s.json' % (self.config.username))
         # alt is unused atm but makes using *location easier
         try:


### PR DESCRIPTION
Fixed merge issues for #1019

It now dumps the cell list as a json into data/cells-$username.json, so
that more front-ends can use this information (I'm working on a
Kivy-based one).