### PR TITLE
Fix no attribute error on calling item_inventory_count()

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -265,6 +265,9 @@ class PokemonGoBot(object):
         self.api.get_player().get_inventory()
 
         inventory_req = self.api.call()
+        if inventory_req is None:
+            return None
+
         inventory_dict = inventory_req['responses'][
             'GET_INVENTORY']['inventory_delta']['inventory_items']
 


### PR DESCRIPTION
Short Description: 

When API returned None value, bot crashed.  I added a guard to check `None` response.

Fixes:
- Consider that API may return `None` response

The original error fixed by this PR was:

> Traceback (most recent call last):
>   File "./pokecli.py", line 220, in <module>
>     main()
>   File "./pokecli.py", line 211, in main
>     bot.take_step()
>   File "/path/to/PokemonGoF/PokemonGo-Bot/pokemongo_bot/__init__.py", line 36, in take_step
>     self.stepper.take_step()
>   File "/path/to/PokemonGoF/PokemonGo-Bot/pokemongo_bot/stepper.py", line 62, in take_step
>     self._work_at_position(position[0], position[1], position[2], True)
>   File "/path/to/PokemonGoF/PokemonGo-Bot/pokemongo_bot/stepper.py", line 139, in _work_at_position
>     self.bot.work_on_cell(cell, position, pokemon_only)
>   File "/path/to/PokemonGoF/PokemonGo-Bot/pokemongo_bot/__init__.py", line 96, in work_on_cell
>     hack_chain = worker.work()
>   File "/path/to/PokemonGoF/PokemonGo-Bot/pokemongo_bot/cell_workers/seen_fort_worker.py", line 74, in work
>     " (Total: " + str(self.bot.item_inventory_count(item_id)) + ")", 'green')
>   File "/path/to/PokemonGoF/PokemonGo-Bot/pokemongo_bot/__init__.py", line 268, in item_inventory_count
>     inventory_dict = inventory_req['responses'][
> TypeError: 'NoneType' object has no attribute '__getitem__'