### PR TITLE
Randomize `normalized_reticle_size` and `spin_modifier` parameter

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -42,3 +42,4 @@
  * SpaceWhale
  * klingan
  * reddivision
+ * kbinani

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -37,6 +37,8 @@
     "longer_eggs_first": true,
     "evolve_captured": false,
     "release_pokemon": true,
+    "catch_randomize_reticle_factor": 1.0,
+    "catch_randomize_spin_factor": 1.0,
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -36,6 +36,8 @@
     "longer_eggs_first": true,
     "evolve_captured": false,
     "release_pokemon": true,
+    "catch_randomize_reticle_factor": 1.0,
+    "catch_randomize_spin_factor": 1.0,
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or" },
 

--- a/pokecli.py
+++ b/pokecli.py
@@ -324,6 +324,22 @@ def init_config():
         type=int,
         default=10,
     )
+    add_config(
+        parser,
+        load,
+        long_flag="--catch_randomize_reticle_factor",
+        help="Randomize factor for pokeball throwing accuracy (DEFAULT 1.0 means no randomize: always 'Excellent' throw. 0.0 randomizes between normal and 'Excellent' throw)",
+        type=float,
+        default=1.0
+    )
+    add_config(
+        parser,
+        load,
+        long_flag="--catch_randomize_spin_factor",
+        help="Randomize factor for pokeball curve throwing (DEFAULT 1.0 means no randomize: always perfect 'Super Spin' curve ball. 0.0 randomizes between normal and 'Super Spin' curve ball)",
+        type=float,
+        default=1.0
+    )
 
     # Start to parse other attrs
     config = parser.parse_args()
@@ -352,6 +368,14 @@ def init_config():
 
     if not (config.location or config.location_cache):
         parser.error("Needs either --use-location-cache or --location.")
+        return None
+
+    if config.catch_randomize_reticle_factor < 0 or 1 < config.catch_randomize_reticle_factor:
+        parser.error("--catch_randomize_reticle_factor is out of range! (should be 0 <= catch_randomize_reticle_factor <= 1)")
+        return None
+
+    if config.catch_randomize_spin_factor < 0 or 1 < config.catch_randomize_spin_factor:
+        parser.error("--catch_randomize_spin_factor is out of range! (should be 0 <= catch_randomize_spin_factor <= 1)")
         return None
 
     # create web dir if not exists

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -4,8 +4,7 @@ import time
 from sets import Set
 
 from pokemongo_bot import logger
-from pokemongo_bot.human_behaviour import sleep
-
+from pokemongo_bot.human_behaviour import sleep, normalized_reticle_size, spin_modifier
 
 class PokemonCatchWorker(object):
 
@@ -146,12 +145,15 @@ class PokemonCatchWorker(object):
 
                             id_list1 = self.count_pokemon_inventory()
 
+                            reticle_size_parameter = normalized_reticle_size(self.config.catch_randomize_reticle_factor)
+                            spin_modifier_parameter = spin_modifier(self.config.catch_randomize_spin_factor)
+
                             self.api.catch_pokemon(encounter_id=encounter_id,
                                                    pokeball=pokeball,
-                                                   normalized_reticle_size=1.950,
+                                                   normalized_reticle_size=reticle_size_parameter,
                                                    spawn_point_id=self.spawn_point_guid,
                                                    hit_pokemon=1,
-                                                   spin_modifier=1,
+                                                   spin_modifier=spin_modifier_parameter,
                                                    NormalizedHitPosition=1)
                             response_dict = self.api.call()
 

--- a/pokemongo_bot/human_behaviour.py
+++ b/pokemongo_bot/human_behaviour.py
@@ -21,3 +21,21 @@ def random_lat_long_delta():
     # Return random value from [-.000025, .000025]. Since 364,000 feet is equivalent to one degree of latitude, this
     # should be 364,000 * .000025 = 9.1. So it returns between [-9.1, 9.1]
     return ((random() * 0.00001) - 0.000005) * 5
+
+# Humanized `normalized_reticle_size` parameter for `catch_pokemon` API.
+# 1.0 => normal, 1.950 => excellent
+def normalized_reticle_size(factor):
+    minimum = 1.0
+    maximum = 1.950
+    return uniform(
+        minimum + (maximum - minimum) * factor,
+        maximum)
+
+# Humanized `spin_modifier` parameter for `catch_pokemon` API.
+# 0.0 => normal ball, 1.0 => super spin curve ball
+def spin_modifier(factor):
+    minimum = 0.0
+    maximum = 1.0
+    return uniform(
+        minimum + (maximum - minimum) * factor,
+        maximum)


### PR DESCRIPTION
Short Description: 
---
When calling `catch_pokemon` API, parameter `normalized_reticle_size` is fixed to `1.950` and also `spin_modifier` is fixed to `1`.

This PR makes them random.

Fixes:
---
- `normalized_reticle_sizes` and `spin_modifier` are fixed to constant values
