### PR TITLE
Reduce number of inventory calls

### DIFF
--- a/pokemongo_bot/cell_workers/evolve_all_worker.py
+++ b/pokemongo_bot/cell_workers/evolve_all_worker.py
@@ -16,8 +16,7 @@ class EvolveAllWorker(object):
         if not self._should_run():
             return
 
-        self.api.get_inventory()
-        response_dict = self.api.call()
+        response_dict = self.bot.get_inventory()
         cache = {}
 
         try:
@@ -85,8 +84,7 @@ class EvolveAllWorker(object):
         return skip_evolves
 
     def _release_evolved(self, release_cand_list_ids):
-        self.api.get_inventory()
-        response_dict = self.api.call()
+        response_dict = self.bot.get_inventory()
         cache = {}
 
         try:
@@ -180,8 +178,7 @@ class EvolveAllWorker(object):
         response_dict = self.api.call()
 
     def count_pokemon_inventory(self):
-        self.api.get_inventory()
-        response_dict = self.api.call()
+        response_dict = self.bot.get_inventory()
         id_list = []
         return self.counting_pokemon(response_dict, id_list)
 

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -225,8 +225,7 @@ class PokemonCatchWorker(object):
         time.sleep(5)
 
     def _transfer_low_cp_pokemon(self, value):
-        self.api.get_inventory()
-        response_dict = self.api.call()
+        response_dict = self.bot.get_inventory()
         self._transfer_all_low_cp_pokemon(value, response_dict)
 
     def _transfer_all_low_cp_pokemon(self, value, response_dict):
@@ -257,8 +256,8 @@ class PokemonCatchWorker(object):
         response_dict = self.api.call()
 
     def count_pokemon_inventory(self):
-        self.api.get_inventory()
-        response_dict = self.api.call()
+        self.bot.latest_inventory = None  # Need accurate count of balls/berries/pokemons
+        response_dict = self.bot.get_inventory()
         id_list = []
         return self.counting_pokemon(response_dict, id_list)
 

--- a/pokemongo_bot/cell_workers/seen_fort_worker.py
+++ b/pokemongo_bot/cell_workers/seen_fort_worker.py
@@ -58,6 +58,7 @@ class SeenFortWorker(object):
 
                 items_awarded = spin_details.get('items_awarded', False)
                 if items_awarded:
+                    self.bot.latest_inventory = None
                     tmp_count_items = {}
                     for item in items_awarded:
                         item_id = item['item_id']


### PR DESCRIPTION
There’s way too many API calls for the inventory, so I added a cached
response that’s used until someone invalidates it (like when
catching/throwing and spinning stops).

I also removed the calls to get_player that were completely unused and the useless get_inventory in the heartbeat.