### PR TITLE
optimize docker usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.idea
+.git*
+configs/config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
 FROM python:2.7-onbuild
 
+RUN apt-get update \
+    && apt-get install -y python-protobuf
+
 ENTRYPOINT ["python", "pokecli.py"]
+CMD ["-cf", "configs/config.json"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,3 @@ RUN apt-get update \
     && apt-get install -y python-protobuf
 
 ENTRYPOINT ["python", "pokecli.py"]
-CMD ["-cf", "configs/config.json"]


### PR DESCRIPTION
Short Description: possibility to mount (-v) the config.json file into the container. It keeps the configuration file out of the docker image.

Usage: Somewhere on your host create the config-account1.json file and then run the container:

`docker run --name=pokegobot1 --rm -it -v $(pwd)/config-account1.json:/usr/src/app/configs/config.json pokemongo-bot`

Fixes Dockerfile:
- add .dockerignore file for slim down the docker image
- add python-protobuf deb package install (not installed per default)
- add CMD as a way of defining default arguments for the ENTRYPOINT

