### PR TITLE
Only catch Exception subclasses

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -379,7 +379,7 @@ class PokemonGoBot(object):
 
                 if item_id in items_stock:
                     items_stock[item_id] = item_count
-            except:
+            except Exception:
                 continue
         return items_stock
 
@@ -433,7 +433,7 @@ class PokemonGoBot(object):
                 logger.log('GeoPosition: {}'.format(self.position))
                 logger.log('')
                 has_position = True
-            except:
+            except Exception:
                 logger.log('[x] The location given in the config could not be parsed. Checking for a cached location.')
                 pass
 
@@ -461,12 +461,11 @@ class PokemonGoBot(object):
 
                     has_position = True
                     return
-            except:
+            except Exception:
                 if(has_position == False):
                     sys.exit(
                         "No cached Location. Please specify initial location.")
                 logger.log('[x] Parsing cached location failed, try to use the initial location...')
-                pass
 
     def _get_pos_by_name(self, location_name):
         # Check if the given location is already a coordinate.

--- a/pokemongo_bot/cell_workers/evolve_all_worker.py
+++ b/pokemongo_bot/cell_workers/evolve_all_worker.py
@@ -40,7 +40,7 @@ class EvolveAllWorker(object):
             for pokemon in evolve_list:
                 try:
                     self._execute_pokemon_evolve(pokemon, cache)
-                except:
+                except Exception:
                     pass
             id_list2 = self.count_pokemon_inventory()
             release_cand_list_ids = list(Set(id_list2) - Set(id_list1))
@@ -133,7 +133,7 @@ class EvolveAllWorker(object):
                         pokemons1.append(v)
                     else:
                         pokemons2.append(v)
-                except:
+                except Exception:
                     pass
 
         ## Sort larger CP pokemons by IV, tie breaking by CP
@@ -285,7 +285,7 @@ class EvolveAllWorker(object):
         for individual_stat in iv_stats:
             try:
                 total_IV += pokemon[individual_stat]
-            except:
+            except Exception:
                 pokemon[individual_stat] = 0
                 continue
         pokemon_potential = round((total_IV / 45.0), 2)

--- a/pokemongo_bot/cell_workers/initial_transfer_worker.py
+++ b/pokemongo_bot/cell_workers/initial_transfer_worker.py
@@ -75,7 +75,7 @@ class InitialTransferWorker(object):
         for individual_stat in iv_stats:
             try:
                 total_iv += pokemon_data[individual_stat]
-            except:
+            except Exception:
                 continue
         return round((total_iv / 45.0), 2)
 

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -78,7 +78,7 @@ class PokemonCatchWorker(object):
                                 for individual_stat in iv_stats:
                                     try:
                                         total_IV += pokemon['pokemon_data'][individual_stat]
-                                    except:
+                                    except Exception:
                                         pokemon['pokemon_data'][individual_stat] = 0
                                         continue
 

--- a/pokemongo_bot/logger.py
+++ b/pokemongo_bot/logger.py
@@ -4,7 +4,7 @@ try:
     lcd = lcd.lcd()
     # Change this to your i2c address
     lcd.set_addr(0x23)
-except:
+except Exception:
     lcd = False
 
 def log(string, color = 'white'):


### PR DESCRIPTION
Do not use "except:" as this is unlikely to always behave as desired!

Fixes:
- Catch "Exception"s and let things like SystemExit, KeyboardInterrupt bubble up

