### PR TITLE
Added handling 'None' handling

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -100,7 +100,8 @@ class PokemonGoBot(object):
                                                      gym_latitude=fort.get('latitude'),
                                                      gym_longitude=fort.get('longitude'))
                             response_gym_details = self.api.call()
-                            fort['gym_details'] = response_gym_details['responses']['GET_GYM_DETAILS']
+                            if response_gym_details['responses'] is not None:
+                                fort['gym_details'] = response_gym_details['responses']['GET_GYM_DETAILS']
 
         user_data_cells = "data/cells-%s.json" % (self.config.username)
         with open(user_data_cells, 'w') as outfile:

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -100,8 +100,7 @@ class PokemonGoBot(object):
                                                      gym_latitude=fort.get('latitude'),
                                                      gym_longitude=fort.get('longitude'))
                             response_gym_details = self.api.call()
-                            if response_gym_details['responses'] is not None:
-                                fort['gym_details'] = response_gym_details['responses']['GET_GYM_DETAILS']
+                            fort['gym_details'] = response_gym_details.get('responses', {}).get('GET_GYM_DETAILS', None)
 
         user_data_cells = "data/cells-%s.json" % (self.config.username)
         with open(user_data_cells, 'w') as outfile:


### PR DESCRIPTION
Fixes:
- Some times response_gym_details['responses'] is empty and when this happens the bot would crap out. This defaults to an empty set instead and so avoids the failure.

Error experienced on and fix tested on OSX only.