### PR TITLE
Add Mr. Mime to config.json.pokemons.example

### DIFF
--- a/configs/config.json.pokemons.example
+++ b/configs/config.json.pokemons.example
@@ -272,6 +272,7 @@
       "Venomoth": { "release_below_cp": 660, "release_below_iv": 0.8, "logic": "and" },
       "Golbat": { "release_below_cp": 672, "release_below_iv": 0.8, "logic": "and" },
       "Raichu": { "release_below_cp": 708, "release_below_iv": 0.8, "logic": "and" },
-      "Cloyster": { "release_below_cp": 717, "release_below_iv": 0.8, "logic": "and"}
+      "Cloyster": { "release_below_cp": 717, "release_below_iv": 0.8, "logic": "and"},
+      "Mr. Mime": { "release_below_cp": 650, "release_below_iv": 0.8, "logic": "and" }
     }
 }


### PR DESCRIPTION
Short Description: 
Add Mr. Mime to configs/config.json.pokemons.example
Fixes:
- Missing Mr. Mime from configs/config.json.pokemons.example
- Issue #1347
