### PR TITLE
Fixing evolve worker being skipped problem

### DIFF
--- a/pokemongo_bot/cell_workers/evolve_all_worker.py
+++ b/pokemongo_bot/cell_workers/evolve_all_worker.py
@@ -53,17 +53,19 @@ class EvolveAllWorker(object):
 
     def _should_run(self):
         # Will skip evolving if user wants to use an egg and there is none
-        skip_evolves = False
 
-        if self.config.evolve_all:
-            return skip_evolves
+        if not self.config.evolve_all:
+            return False
 
         # Pop lucky egg before evolving to maximize xp gain
         use_lucky_egg = self.config.use_lucky_egg
         lucky_egg_count = self.bot.item_inventory_count(Item.ITEM_LUCKY_EGG.value)
 
-        if use_lucky_egg and lucky_egg_count > 0:
-            logger.log('Using lucky egg ... you have {}'
+        if not use_lucky_egg: # If not using lucky eggs, skipping checks below
+            return True
+
+        if lucky_egg_count > 0:
+            logger.log('Using lucky egg... you have {}'
                        .format(lucky_egg_count))
             response_dict_lucky_egg = self.bot.use_lucky_egg()
             if response_dict_lucky_egg and 'responses' in response_dict_lucky_egg and \
@@ -75,13 +77,12 @@ class EvolveAllWorker(object):
                                .format(lucky_egg_count-1), 'green')
                 else:
                     logger.log('Failed to use lucky egg!', 'red')
-                    skip_evolves = True
-        elif use_lucky_egg: #lucky_egg_count is 0
-            # Skipping evolve so they aren't wasted
-            logger.log('No lucky eggs... skipping evolve!', 'yellow')
-            skip_evolves = True
+                    return False
 
-        return skip_evolves
+        else: # lucky_egg_count is 0
+            # Skipping evolve so pokemon aren't wasted
+            logger.log('No lucky eggs... skipping evolve!', 'yellow')
+            return False
 
     def _release_evolved(self, release_cand_list_ids):
         response_dict = self.bot.get_inventory()


### PR DESCRIPTION
Short Description: 
`EvolveAllWorker._should_run()` logic was wrong, causing evolve worker not running at startup.

Fixes:
- Fixed `EvolveAllWorker._should_run()`


