### PR TITLE
Magikarp twice in release block config.json.pokemon.example

### DIFF
--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -182,7 +182,6 @@
       "Koffing": { "release_below_cp": 403, "release_below_iv": 0.8, "logic": "and" },
 
       "// Below is B-tier and lower pokemons": {},
-      "Magikarp": { "release_below_cp": 91, "release_below_iv": 0.8, "logic": "and" },
       "Caterpie": { "release_below_cp": 156, "release_below_iv": 0.8, "logic": "and" },
       "Weedle": { "release_below_cp": 156, "release_below_iv": 0.8, "logic": "and" },
       "Diglett": { "release_below_cp": 158, "release_below_iv": 0.8, "logic": "and" },


### PR DESCRIPTION
Short Description: 

Fixes:
- 
- 
- 


