### PR TITLE
Use type unicode for argument location

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -151,7 +151,7 @@ def init_config():
         short_flag="-l",
         long_flag="--location",
         help="Location",
-        type=unicode,
+        type=parse_str,
         default=''
     )
     add_config(
@@ -351,6 +351,12 @@ def add_config(parser, json_config, short_flag=None, long_flag=None, **kwargs):
     else:
         args = (long_flag,)
     parser.add_argument(*args, **kwargs)
+    
+def parse_str(string):
+    try:
+        return string.decode('utf8')
+    except UnicodeEncodeError:
+        return string
 
     
 if __name__ == '__main__':

--- a/pokecli.py
+++ b/pokecli.py
@@ -151,7 +151,7 @@ def init_config():
         short_flag="-l",
         long_flag="--location",
         help="Location",
-        type=lambda s: not isinstance(s, unicode) and unicode(s, 'utf8') or str(s),
+        type=unicode,
         default=''
     )
     add_config(

--- a/pokecli.py
+++ b/pokecli.py
@@ -151,7 +151,7 @@ def init_config():
         short_flag="-l",
         long_flag="--location",
         help="Location",
-        type=parse_str,
+        type=parse_unicode_str,
         default=''
     )
     add_config(
@@ -352,7 +352,7 @@ def add_config(parser, json_config, short_flag=None, long_flag=None, **kwargs):
         args = (long_flag,)
     parser.add_argument(*args, **kwargs)
     
-def parse_str(string):
+def parse_unicode_str(string):
     try:
         return string.decode('utf8')
     except UnicodeEncodeError:


### PR DESCRIPTION
Short Description: 
Fix for issue with invalid <lambda> value for location argument, e.g.: invalid <lambda> value: u'Pra\xe7a' when it contains special characters like "ç".

Fixes:
- issue with invalid <lambda> value for location argument with special chars, e.g. "ç"


