### PR TITLE
Added retries for get_inventory if no GET_INVENTORY in response.

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -302,8 +302,16 @@ class PokemonGoBot(object):
 
     def get_inventory(self):
         if self.latest_inventory is None:
-            self.api.get_inventory()
-            response = self.api.call()
+            retries = 0
+            while True:
+                time.sleep((2**retries * 100) / 1000.0)
+                self.api.get_inventory()
+                response = self.api.call()
+                try:
+                    get_inventory = response['responses']['GET_INVENTORY']
+                    break
+                except:
+                    retries += 1
             self.latest_inventory = response
         return self.latest_inventory
 

--- a/pokemongo_bot/cell_workers/pokemon_transfer_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_transfer_worker.py
@@ -64,8 +64,7 @@ class PokemonTransferWorker(object):
 
     def _release_pokemon_get_groups(self):
         pokemon_groups = {}
-        self.api.get_player().get_inventory()
-        inventory_req = self.api.call()
+        inventory_req = self.bot.get_inventory()
 
         if inventory_req.get('responses', False) is False:
             return pokemon_groups


### PR DESCRIPTION
Short Description: Performs an exponential backoff retry on api.get_inventory() if response['responses']['GET_INVENTORY'] doesn't exist. Should clear up most KeyError: 'GET_INVENTORY' issues.

Also fixed pokemon_transfer_worker.py to use the bot.get_inventory() (thus using this code) instead of a direct api get_inventory().

Fixes: #1491
- 
- 
- 


