### PR TITLE
Hotfix api_wraper.py responed server error msg for the first try| Optimized the berry_inventory function called times

### DIFF
--- a/pokemongo_bot/api_wrapper.py
+++ b/pokemongo_bot/api_wrapper.py
@@ -3,6 +3,7 @@
 from pgoapi import PGoApi
 from pgoapi.exceptions import NotLoggedInException
 from human_behaviour import sleep
+import time
 import logger
 
 class ApiWrapper(object):
@@ -31,6 +32,7 @@ class ApiWrapper(object):
         return [i.upper() for i in r]
 
     def _is_response_valid(self, result, request_callers):
+     
         if not result or result is None or not isinstance(result, dict):
             return False
 
@@ -60,6 +62,8 @@ class ApiWrapper(object):
         while True:
             self._api._req_method_list = [req_method for req_method in api_req_method_list] # api internally clear this field after a call
             result = self._api.call()
+            time.sleep(0.2)  #This solves a null response porlbem at first try.
+            
             if not self._is_response_valid(result, request_callers):
                 try_cnt += 1
                 logger.log('Server seems to be busy or offline - try again - {}/{}'.format(try_cnt, max_retry), 'red')

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -78,6 +78,9 @@ class PokemonCatchWorker(object):
                             return False
 
                         items_stock = self.bot.current_inventory()
+                        berry_id = 701 # @ TODO: use better berries if possible
+                        berries_count = self.bot.item_inventory_count(berry_id)
+                        
                         while True:
                             ## pick the most simple ball from stock
                             pokeball = 1 # start from 1 - PokeBalls
@@ -97,8 +100,7 @@ class PokemonCatchWorker(object):
                                 return PokemonCatchWorker.NO_POKEBALLS
 
                             # Use berry to increase success chance.
-                            berry_id = 701 # @ TODO: use better berries if possible
-                            berries_count = self.bot.item_inventory_count(berry_id)
+
                             if catch_rate[pokeball-1] < 0.5 and berries_count > 0: # and berry is in stock
                                 success_percentage = '{0:.2f}'.format(catch_rate[pokeball-1]*100)
                                 logger.log('Catch Rate with normal Pokeball is low ({}%). Throwing {}... ({} left!)'.format(success_percentage,self.item_list[str(berry_id)],berries_count-1))
@@ -119,6 +121,7 @@ class PokemonCatchWorker(object):
                                             catch_rate[i] = catch_rate[i] * response_dict['responses']['USE_ITEM_CAPTURE']['item_capture_mult']
 
                                     success_percentage = '{0:.2f}'.format(catch_rate[pokeball-1]*100)
+                                    berries_count = berries_count -1
                                     logger.log('Catch Rate with normal Pokeball has increased to {}%'.format(success_percentage))
                                 else:
                                     if response_dict['status_code'] is 1:


### PR DESCRIPTION
Short Description: 

*************************************This is wrong guess but a quite close fix **********************
Some time, the `result = self._api.call()` is getting response but not filled with full response msg. Then the check begins,

**************************************The True may be ************************************
We believe that server now detects massive requests, so we put a force sleep after an API call. 

So the speed of making api request is reduced to hot fix this problem
*********************************************************************************************

This makes the every first response check failed (because it's still point to empty) and second response succeed. 

Fixes:
Add a wait time to "wait" the result to be "fully filled" solve this problem for me.



