### PR TITLE
Fix circle_avoidance

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -32,10 +32,10 @@
     "longer_eggs_first": true,
     "evolve_captured": false,
     "release_pokemon": true,
-    "spin_forts": {
-      "avoid_circles": false,
-      "max_circle_size": 10
-    },
+
+    "avoid_circles": false,
+    "max_circle_size": 10,
+
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -32,10 +32,10 @@
     "longer_eggs_first": true,
     "evolve_captured": false,
     "release_pokemon": true,
-    "spin_forts": {
-      "avoid_circles": false,
-      "max_circle_size": 10
-    },
+
+
+    "avoid_circles": false,
+    "max_circle_size": 10,
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or" },
 


### PR DESCRIPTION
PR #1553 offers the same fix while keeping the possibility to have nested keywords
Short Description: 
spin_forts was assigned twice in config, removed nested keywords

Fixes:
#1544 
circle avoidance now works as intended