### PR TITLE
Fix circle_avoidance

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -7,7 +7,6 @@
     "max_steps": 5,
     "catch_pokemon": true,
     "websocket_server": false,
-    "spin_forts": true,
     "walk": 4.16,
     "action_wait_min": 1,
     "action_wait_max": 4,
@@ -33,9 +32,10 @@
     "longer_eggs_first": true,
     "evolve_captured": false,
     "release_pokemon": true,
-    "spin_forts": {
-      "avoid_circles": false,
-      "max_circle_size": 10
+    "forts": {
+      "spin_forts": true,
+      "avoid_circles": true,
+      "max_circle_size": 100
     },
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -6,7 +6,6 @@
     "gmapkey": "GOOGLE_MAPS_API_KEY",
     "max_steps": 5,
     "catch_pokemon": true,
-    "spin_forts": true,
     "walk": 4.16,
     "action_wait_min": 1,
     "action_wait_max": 4,
@@ -32,9 +31,10 @@
     "longer_eggs_first": true,
     "evolve_captured": false,
     "release_pokemon": true,
-    "spin_forts": {
-      "avoid_circles": false,
-      "max_circle_size": 10
+    "forts": {
+      "spin_forts": true,
+      "avoid_circles": true,
+      "max_circle_size": 100
     },
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or" },

--- a/pokecli.py
+++ b/pokecli.py
@@ -373,7 +373,7 @@ def add_config(parser, json_config, short_flag=None, long_flag=None, embedded_in
         raise Exception('add_config calls requires long_flag parameter!')
     if 'default' in kwargs:
         attribute_name = long_flag.split('--')[1]
-        if embedded_in:
+        if embedded_in is not None:
             kwargs['default'] = json_config.get(embedded_in).get(attribute_name, kwargs['default'])
         else:
             kwargs['default'] = json_config.get(attribute_name, kwargs['default'])

--- a/pokecli.py
+++ b/pokecli.py
@@ -311,6 +311,7 @@ def init_config():
         load,
         short_flag="-ac",
         long_flag="--avoid_circles",
+        embedded_in="forts",
         help="Avoids circles (pokestops) of the max size set in max_circle_size flag",
         type=bool,
         default=False
@@ -320,6 +321,7 @@ def init_config():
         load,
         short_flag="-mcs",
         long_flag="--max_circle_size",
+        embedded_in="forts",
         help="If avoid_circles flag is set, this flag specifies the maximum size of circles (pokestops) avoided",
         type=int,
         default=10
@@ -366,12 +368,15 @@ def init_config():
 
     return config
 
-def add_config(parser, json_config, short_flag=None, long_flag=None, **kwargs):
+def add_config(parser, json_config, short_flag=None, long_flag=None, embedded_in=None, **kwargs):
     if not long_flag:
         raise Exception('add_config calls requires long_flag parameter!')
     if 'default' in kwargs:
         attribute_name = long_flag.split('--')[1]
-        kwargs['default'] = json_config.get(attribute_name, kwargs['default'])
+        if embedded_in:
+            kwargs['default'] = json_config.get(embedded_in).get(attribute_name, kwargs['default'])
+        else:
+            kwargs['default'] = json_config.get(attribute_name, kwargs['default'])
     if short_flag:
         args = (short_flag, long_flag)
     else:

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -71,7 +71,6 @@ class PokemonGoBot(object):
         # self.event_manager.emit('location', 'level'='info', data={'lat': 1, 'lng':1}),
 
     def tick(self):
-        logger.log(str(self.recent_forts))
         self.cell = self.get_meta_cell()
 
         # Check if session token has expired

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -71,6 +71,7 @@ class PokemonGoBot(object):
         # self.event_manager.emit('location', 'level'='info', data={'lat': 1, 'lng':1}),
 
     def tick(self):
+        logger.log(str(self.recent_forts))
         self.cell = self.get_meta_cell()
 
         # Check if session token has expired


### PR DESCRIPTION
Short Description: 

- spin_forts was assigned twice in config

- fort related arguments are now embedded in `fort` keyword

- added `embedded` flag for parser, in order to handle nested keywords

Fixes:
#1544 
circle avoidance now works as intended


