### PR TITLE
Fix: response_dict received as none from api

### DIFF
--- a/pokemongo_bot/cell_workers/seen_fort_worker.py
+++ b/pokemongo_bot/cell_workers/seen_fort_worker.py
@@ -43,7 +43,7 @@ class SeenFortWorker(object):
                              player_latitude=f2i(self.position[0]),
                              player_longitude=f2i(self.position[1]))
         response_dict = self.api.call()
-        if 'responses' in response_dict and \
+        if response_dict and 'responses' in response_dict and \
                 'FORT_SEARCH' in response_dict['responses']:
 
             spin_details = response_dict['responses']['FORT_SEARCH']


### PR DESCRIPTION
Short Description: 
When api response is none for response_dict it raises typeError so none check is required
Fixes:
- TypeError when response_dict is none
- 
- 


