### PR TITLE
Extract CatchLuredPokemonWorker from PokemonCatchWorker and improved worker order

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -36,8 +36,9 @@ class PokemonGoBot(object):
         cell_workers.EvolveAllWorker,
         cell_workers.RecycleItemsWorker,
         cell_workers.CatchVisiblePokemonWorker,
-        cell_workers.SeenFortWorker,
-        cell_workers.MoveToFortWorker
+        cell_workers.MoveToFortWorker,
+        cell_workers.CatchLuredPokemonWorker,
+        cell_workers.SeenFortWorker
     ]
 
     @property
@@ -83,7 +84,9 @@ class PokemonGoBot(object):
         # self.event_manager.emit('location', 'level'='info', data={'lat': 1, 'lng':1}),
 
     def tick(self):
+        logger.log('')
         self.cell = self.get_meta_cell()
+        self.tick_count +=1
 
         # Check if session token has expired
         self.check_session(self.position[0:2])
@@ -93,8 +96,6 @@ class PokemonGoBot(object):
                 return
 
         self.navigator.take_step()
-
-        self.tick_count +=1
 
     def get_meta_cell(self):
         location = self.position[0:2]

--- a/pokemongo_bot/cell_workers/__init__.py
+++ b/pokemongo_bot/cell_workers/__init__.py
@@ -8,3 +8,4 @@ from evolve_all_worker import EvolveAllWorker
 from catch_visible_pokemon_worker import CatchVisiblePokemonWorker
 from recycle_items_worker import RecycleItemsWorker
 from incubate_eggs_worker import IncubateEggsWorker
+from catch_lured_pokemon_worker import CatchLuredPokemonWorker

--- a/pokemongo_bot/cell_workers/catch_lured_pokemon_worker.py
+++ b/pokemongo_bot/cell_workers/catch_lured_pokemon_worker.py
@@ -1,0 +1,57 @@
+
+import json
+from utils import distance, format_dist, i2f
+from pokemongo_bot.human_behaviour import sleep
+from pokemongo_bot import logger
+from pokemongo_bot.step_walker import StepWalker
+from pokemongo_bot.cell_workers import PokemonCatchWorker
+
+
+class CatchLuredPokemonWorker(object):
+    def __init__(self, bot):
+        self.bot = bot
+        self.cell = bot.cell;
+        self.api = bot.api
+        self.config = bot.config
+        self.position = bot.position
+
+    def work(self):
+        if not self.config.catch_pokemon:
+            return
+
+        lured_pokemon = self.get_lured_pokemon()
+        if lured_pokemon:
+            self.catch_pokemon(lured_pokemon)
+
+    def get_lured_pokemon(self):
+        forts = self.bot.get_forts(order_by_distance=True)
+
+        if len(forts) == 0:
+            return False
+
+        fort = forts[0]
+
+        self.api.fort_details(fort_id=fort['id'],
+                              latitude=fort['latitude'],
+                              longitude=fort['longitude'])
+
+        response_dict = self.api.call()
+        fort_details = response_dict.get('responses', {}).get('FORT_DETAILS', {})
+        fort_name = fort_details.get('name', 'Unknown').encode('utf8', 'replace')
+
+        encounter_id = fort.get('lure_info', {}).get('encounter_id', None)
+
+        pokemon = {
+            'encounter_id': encounter_id,
+            'fort_id': fort['id'],
+            'latitude': fort['latitude'],
+            'longitude': fort['longitude']
+        }
+
+        return pokemon
+
+    def catch_pokemon(self, pokemon):
+        worker = PokemonCatchWorker(pokemon, self.bot)
+        return_value = worker.work()
+
+        return return_value

--- a/pokemongo_bot/cell_workers/catch_visible_pokemon_worker.py
+++ b/pokemongo_bot/cell_workers/catch_visible_pokemon_worker.py
@@ -6,6 +6,7 @@ from pokemongo_bot import logger
 from pokemongo_bot.step_walker import StepWalker
 from pokemongo_bot.cell_workers import PokemonCatchWorker
 
+
 class CatchVisiblePokemonWorker(object):
     def __init__(self, bot):
         self.bot = bot
@@ -43,33 +44,6 @@ class CatchVisiblePokemonWorker(object):
                 key=
                 lambda x: distance(self.position[0], self.position[1], x['latitude'], x['longitude']))
             return self.catch_pokemon(self.cell['wild_pokemons'][0])
-
-        lured_pokemon = self.get_lured_pokemon()
-        if lured_pokemon:
-            self.catch_pokemon(lured_pokemon)
-
-    def get_lured_pokemon(self):
-        forts = self.bot.get_forts(order_by_distance=True)
-        fort = forts[0]
-
-        self.api.fort_details(fort_id=fort['id'],
-                              latitude=fort['latitude'],
-                              longitude=fort['longitude'])
-
-        response_dict = self.api.call()
-        fort_details = response_dict.get('responses', {}).get('FORT_DETAILS', {})
-        fort_name = fort_details.get('name', 'Unknown').encode('utf8', 'replace')
-
-        encounter_id = fort.get('lure_info', {}).get('encounter_id', None)
-
-        pokemon = {
-            'encounter_id': encounter_id,
-            'fort_id': fort['id'],
-            'latitude': fort['latitude'],
-            'longitude': fort['longitude']
-        }
-
-        return pokemon
 
     def catch_pokemon(self, pokemon):
         worker = PokemonCatchWorker(pokemon, self.bot)

--- a/pokemongo_bot/cell_workers/move_to_fort_worker.py
+++ b/pokemongo_bot/cell_workers/move_to_fort_worker.py
@@ -53,7 +53,7 @@ class MoveToFortWorker(object):
             if not step_walker.step():
                 return WorkerResult.RUNNING
 
-        logger.log('Arrived at Pokestop')
+        logger.log('Arrived at pokestop.')
         return WorkerResult.SUCCESS
 
     def get_nearest_fort(self):

--- a/pokemongo_bot/spiral_navigator.py
+++ b/pokemongo_bot/spiral_navigator.py
@@ -48,11 +48,6 @@ class SpiralNavigator(object):
         point = self.points[self.ptr]
         self.cnt += 1
 
-        if self.cnt == 1:
-            logger.log('Scanning area for objects....')
-
-        # Scan location math
-
         if self.config.walk > 0:
             step_walker = StepWalker(
                 self.bot,

--- a/pokemongo_bot/step_walker.py
+++ b/pokemongo_bot/step_walker.py
@@ -40,8 +40,6 @@ class StepWalker(object):
 
     def step(self):
         if (self.dLat == 0 and self.dLng == 0) or self.dist < self.speed:
-            if sys.stdout.isatty():
-                sys.stdout.write('\n')
             self.api.set_position(self.destLat, self.destLng, 0)
             return True
 


### PR DESCRIPTION
Improved worker order: MoveToFortWorker before spinning and capturing from lure.

If we move to fort in end of the tick the navigator will step away from it and in the next tick we won't be able to spin it.