### PR TITLE
Fix transfer worker not triggered for last pokemon

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_transfer_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_transfer_worker.py
@@ -20,7 +20,7 @@ class PokemonTransferWorker(object):
         for pokemon_id in pokemon_groups:
             group = pokemon_groups[pokemon_id]
 
-            if len(group) > 1:
+            if len(group) > 0:
                 pokemon_name = self.pokemon_list[pokemon_id - 1]['Name']
                 keep_best, keep_best_cp, keep_best_iv = self._validate_keep_best_config(pokemon_name)
 


### PR DESCRIPTION
Short Description: 
If there is only one pokemon and there is no duplicate, release validation will skip that pokemon

Fixes:
- Transfer worker not triggered for last pokemon


