### PR TITLE
the MoveToFortWorker should always go to the nearest fort

### DIFF
--- a/pokemongo_bot/cell_workers/move_to_fort_worker.py
+++ b/pokemongo_bot/cell_workers/move_to_fort_worker.py
@@ -57,7 +57,7 @@ class MoveToFortWorker(object):
         return WorkerResult.SUCCESS
 
     def get_nearest_fort(self):
-        forts = self.bot.get_forts()
+        forts = self.bot.get_forts(order_by_distance=True)
 
         # Remove stops that are still on timeout
         forts = filter(lambda x: x["id"] not in self.fort_timeouts, forts)


### PR DESCRIPTION
Short Description: 
get_nearest_fort assumes that the list of forts is sorted by distance but its not unless order_by_distance is set to True.

Fixes:
- added order_by_distance=True param to get_forts 
