### PR TITLE
Making the SpiralNavigator a worker

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -38,7 +38,8 @@ class PokemonGoBot(object):
         cell_workers.CatchVisiblePokemonWorker,
         cell_workers.MoveToFortWorker,
         cell_workers.CatchLuredPokemonWorker,
-        cell_workers.SeenFortWorker
+        cell_workers.SeenFortWorker,
+        cell_workers.SpiralNavigator
     ]
 
     @property
@@ -62,7 +63,6 @@ class PokemonGoBot(object):
     def start(self):
         self._setup_logging()
         self._setup_api()
-        self.navigator = SpiralNavigator(self)
         random.seed()
 
     def _setup_event_system(self):
@@ -93,8 +93,6 @@ class PokemonGoBot(object):
         for worker in self.workers:
             if worker(self).work() == WorkerResult.RUNNING:
                 return
-
-        self.navigator.take_step()
 
     def get_meta_cell(self):
         location = self.position[0:2]

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -22,7 +22,6 @@ from metrics import Metrics
 from pokemongo_bot.event_handlers import LoggingHandler
 from pokemongo_bot.event_handlers import SocketIoHandler
 from pokemongo_bot.socketio_server.runner import SocketIoRunner
-from spiral_navigator import SpiralNavigator
 from worker_result import WorkerResult
 from event_manager import EventManager
 from api_wrapper import ApiWrapper

--- a/pokemongo_bot/cell_workers/__init__.py
+++ b/pokemongo_bot/cell_workers/__init__.py
@@ -9,3 +9,4 @@ from catch_visible_pokemon_worker import CatchVisiblePokemonWorker
 from recycle_items_worker import RecycleItemsWorker
 from incubate_eggs_worker import IncubateEggsWorker
 from catch_lured_pokemon_worker import CatchLuredPokemonWorker
+from spiral_navigator import SpiralNavigator

--- a/pokemongo_bot/cell_workers/move_to_fort_worker.py
+++ b/pokemongo_bot/cell_workers/move_to_fort_worker.py
@@ -13,7 +13,6 @@ class MoveToFortWorker(object):
         self.config = bot.config
         self.fort_timeouts = bot.fort_timeouts
         self.recent_forts = bot.recent_forts
-        self.navigator = bot.navigator
         self.position = bot.position
 
     def should_run(self):

--- a/pokemongo_bot/cell_workers/spiral_navigator.py
+++ b/pokemongo_bot/cell_workers/spiral_navigator.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 from pokemongo_bot import logger
-from cell_workers.utils import distance, i2f, format_dist
-from human_behaviour import sleep
-from step_walker import StepWalker
-
+from pokemongo_bot.cell_workers.utils import distance, format_dist
+from pokemongo_bot.step_walker import StepWalker
 
 class SpiralNavigator(object):
     def __init__(self, bot):
@@ -64,9 +62,11 @@ class SpiralNavigator(object):
             )
 
             if self.cnt == 1:
-                logger.log('Walking from ' + str((self.api._position_lat,
-                    self.api._position_lng)) + " to " + str([point['lat'], point['lng']]) + " " + format_dist(dist,
-                                                                                                   self.config.distance_unit))
+                logger.log('Walking from {} to {} {}'.format(
+                    str((self.api._position_lat, self.api._position_lng)),
+                    str([point['lat'], point['lng']]),
+                    format_dist(dist, self.config.distance_unit)
+                ))
 
             if step_walker.step():
                 step_walker = None
@@ -74,11 +74,11 @@ class SpiralNavigator(object):
             self.api.set_position(point['lat'], point['lng'])
 
         if distance(
-                    self.api._position_lat,
-                    self.api._position_lng,
-                    point['lat'],
-                    point['lng']
-                ) <= 1 or (self.config.walk > 0 and step_walker == None):
+                self.api._position_lat,
+                self.api._position_lng,
+                point['lat'],
+                point['lng']
+            ) <= 1 or (self.config.walk > 0 and step_walker is None):
             if self.ptr + self.direction == len(self.points) or self.ptr + self.direction == -1:
                 self.direction *= -1
             self.ptr += self.direction

--- a/pokemongo_bot/cell_workers/spiral_navigator.py
+++ b/pokemongo_bot/cell_workers/spiral_navigator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import logger
+from pokemongo_bot import logger
 from cell_workers.utils import distance, i2f, format_dist
 from human_behaviour import sleep
 from step_walker import StepWalker

--- a/pokemongo_bot/cell_workers/spiral_navigator.py
+++ b/pokemongo_bot/cell_workers/spiral_navigator.py
@@ -44,7 +44,7 @@ class SpiralNavigator(object):
             m += 1
         return coords
 
-    def take_step(self):
+    def work(self):
         point = self.points[self.ptr]
         self.cnt += 1
 


### PR DESCRIPTION
This will make it easier for people to configure what navigation scheme they want. 

The list of workers will end up being defined in people's configuration files once we get the behavior tree stuff. People will be able to put whatever they want in whatever order they want. 

And they we can support people creating new repos that export a plugin that we can load and they can use those additional custom workers!