### PR TITLE
Decrease logging spam by showing walker logs temporarily in console

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -53,6 +53,7 @@ class PokemonGoBot(object):
         self.latest_inventory = None
         self.cell = None
         self.recent_forts = [None] * config.forts_max_circle_size
+	self.last_fort = None
         self.tick_count = 0
 
         # Make our own copy of the workers for this instance

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -84,7 +84,7 @@ class PokemonGoBot(object):
         # self.event_manager.emit('location', 'level'='info', data={'lat': 1, 'lng':1}),
 
     def tick(self):
-        logger.log('')
+        #logger.log('')
         self.cell = self.get_meta_cell()
         self.tick_count +=1
 

--- a/pokemongo_bot/cell_workers/move_to_fort_worker.py
+++ b/pokemongo_bot/cell_workers/move_to_fort_worker.py
@@ -56,7 +56,7 @@ class MoveToFortWorker(object):
             if not step_walker.step():
                 return WorkerResult.RUNNING
 
-	logger.log('Arrived at pokestop.')
+        logger.log('Arrived at pokestop.')
         return WorkerResult.SUCCESS
 
     def get_nearest_fort(self):

--- a/pokemongo_bot/cell_workers/move_to_fort_worker.py
+++ b/pokemongo_bot/cell_workers/move_to_fort_worker.py
@@ -1,3 +1,4 @@
+import sys
 from utils import distance, format_dist, i2f
 from pokemongo_bot.constants import Constants
 from pokemongo_bot.human_behaviour import sleep
@@ -41,8 +42,10 @@ class MoveToFortWorker(object):
         )
 
         if dist > Constants.MAX_DISTANCE_FORT_IS_REACHABLE:
-            logger.log('Moving towards fort {}, {} left'.format(fortID, format_dist(dist, unit)))
-
+	    sys.stdout.write("\033[K")
+            sys.stdout.write('\rMoving towards fort {}, {} left\r'.format(fortID, format_dist(dist, unit)))
+            sys.stdout.flush()
+	    sys.stdout.write("\033[K")
             step_walker = StepWalker(
                 self.bot,
                 self.config.walk,
@@ -53,7 +56,7 @@ class MoveToFortWorker(object):
             if not step_walker.step():
                 return WorkerResult.RUNNING
 
-        logger.log('Arrived at pokestop.')
+	logger.log('Arrived at pokestop.')
         return WorkerResult.SUCCESS
 
     def get_nearest_fort(self):

--- a/pokemongo_bot/cell_workers/move_to_fort_worker.py
+++ b/pokemongo_bot/cell_workers/move_to_fort_worker.py
@@ -32,6 +32,10 @@ class MoveToFortWorker(object):
         lat = nearest_fort['latitude']
         lng = nearest_fort['longitude']
         fortID = nearest_fort['id']
+	if not self.bot.last_fort == fortID:
+	    self.bot.last_fort = fortID
+	    logger.log("Moving to new fort: {}".format(fortID))
+	
         unit = self.config.distance_unit  # Unit to use when printing formatted distance
 
         dist = distance(


### PR DESCRIPTION
Short Description: Show walking logs only temporarily at the bottom line to prevent a log spammed with this. 

Fixes:
- Walking logs do not spam the logfile anymore 

