### PR TITLE
Unban Immediately When You Fly

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -321,6 +321,24 @@ def init_config():
     add_config(
         parser,
         load,
+        short_flag="-bf",
+        long_flag="--softban_fix",
+        help="Fix softban automatically",
+        type=bool,
+        default=False
+    )
+    add_config(
+        parser,
+        load,
+        short_flag="-hl",
+        long_flag="--home_location",
+        help="Fly home to get rid of being banned when catch with changed location",
+        type=str,
+        default=[]
+    )
+    add_config(
+        parser,
+        load,
         short_flag="-hr",
         long_flag="--health_record",
         help="Send anonymous bot event to GA for bot health record. Set \"health_record\":false if you need disable it.",

--- a/pokemongo_bot/cell_workers/handle_soft_ban.py
+++ b/pokemongo_bot/cell_workers/handle_soft_ban.py
@@ -43,6 +43,8 @@ class HandleSoftBan(object):
                     logger.log('Spin #{}'.format(str(i+1)))
                 self.spin_fort(forts[0])
             self.bot.softban = False
+            if self.bot.config.home_location:
+                self.bot.config.home_location = ', '.join([str(x) for x in self.bot.position])
             logger.log('Softban should be fixed.')
 
     def spin_fort(self, fort):

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -31,6 +31,9 @@ class PokemonCatchWorker(object):
         if response_dict and 'responses' in response_dict:
             if self.response_key in response_dict['responses']:
                 if self.response_status_key in response_dict['responses'][self.response_key]:
+                    if self.config.home_location:
+                        self.reset_location()
+
                     if response_dict['responses'][self.response_key][self.response_status_key] is 1:
                         cp = 0
                         if 'wild_pokemon' in response_dict['responses'][self.response_key] or 'pokemon_data' in \
@@ -232,7 +235,7 @@ class PokemonCatchWorker(object):
                                     logger.log(
                                         'Oh no! {} vanished! :('.format(pokemon_name), 'red')
                                     if success_percentage == 100:
-                                        self.softban = True
+                                        self.bot.softban = True
                                 if status is 1:
                                     self.bot.metrics.captured_pokemon(pokemon_name, cp, iv_display, pokemon_potential)
 
@@ -267,6 +270,13 @@ class PokemonCatchWorker(object):
                                                 'Failed to evolve {}!'.format(pokemon_name))
                             break
         time.sleep(5)
+
+    def reset_location(self):
+        location_str = str(self.config.home_location)
+        location = (self.bot.get_pos_by_name(location_str.replace(" ", "")))
+        self.position = location
+        self.api.set_position(*self.position)
+        logger.log('Location has been reset to home_location {}'.format(self.position), 'red')
 
     def count_pokemon_inventory(self):
         # don't use cached bot.get_inventory() here
@@ -369,7 +379,7 @@ class PokemonCatchWorker(object):
             self.response_status_key = 'status'
             self.api.encounter(encounter_id=encounter_id, spawn_point_id=spawn_point_id,
                                player_latitude=player_latitude, player_longitude=player_longitude)
-        else:
+        elif (not self.config.home_location) or (self.config.home_location == self.config.location):
             fort_id = self.pokemon['fort_id']
             self.spawn_point_guid = fort_id
             self.response_key = 'DISK_ENCOUNTER'


### PR DESCRIPTION
Short Description: 
  Since the SoftBan can be resolved, trainer is able to fly to some specific location to catch legendary Pokemon. In order to do so,  you need to encounter the Pokemon first, and fly back to the home location you have set.

Only thing we need to do: change the location, set your home location where you cannot get banned in `config.json`, run the program.  Set `'home_location' = "home, location"`,  in `configs/config.json`.

Better Close 
```json
      {
        "type": "FollowSpiral"
      }
```
Fixed:
`self.softban` -> `self.bot.softban`, to make sure softban works on Bot Object.


