### PR TITLE
Don't try to release pokemons in forts

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_transfer_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_transfer_worker.py
@@ -93,6 +93,11 @@ class PokemonTransferWorker(object):
                 continue
 
             pokemon_data = pokemon['inventory_item_data']['pokemon_data']
+
+            # pokemon in fort, so we cant transfer it
+            if 'deployed_fort_id' in pokemon_data and pokemon_data['deployed_fort_id']:
+                continue
+
             group_id = pokemon_data['pokemon_id']
             group_pokemon_cp = pokemon_data['cp']
             group_pokemon_iv = self.get_pokemon_potential(pokemon_data)


### PR DESCRIPTION
Without this check transfer worker will try to release pokemon in fort each tick (without success), so it is not right behaviour.