### PR TITLE
Prevent crash checking session

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -236,11 +236,24 @@ class PokemonGoBot(object):
     def check_session(self, position):
         # Check session expiry
         if self.api._auth_provider and self.api._auth_provider._ticket_expire:
+            
+            # prevent crash if return not numeric value
+            if not is_number(self.api._auth_provider._ticket_expire):
+                logger.log("Ticket expired value is not numeric", 'yellow')
+                return
+
             remaining_time = self.api._auth_provider._ticket_expire/1000 - time.time()
 
             if remaining_time < 60:
                 logger.log("Session stale, re-logging in", 'yellow')
                 self.login()
+
+    def is_numeric(self, s):
+        try: 
+            float(s)
+            return True
+        except ValueError:
+            return False
 
     def login(self):
         logger.log('Attempting login to Pokemon Go.', 'white')

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -238,7 +238,7 @@ class PokemonGoBot(object):
         if self.api._auth_provider and self.api._auth_provider._ticket_expire:
             
             # prevent crash if return not numeric value
-            if not is_number(self.api._auth_provider._ticket_expire):
+            if not self.is_numeric(self.api._auth_provider._ticket_expire):
                 logger.log("Ticket expired value is not numeric", 'yellow')
                 return
 


### PR DESCRIPTION
Short Description: 
 Sometimes when checking expiration time got not numeric value(e.g `yjogF9K0qaCAKX3MNtu1oA==` that make bot crashed. Related to issue #1206

Fixes:
- Make sure to check expiration time is numeric to prevent crash


