### PR TITLE
[Need to discuss] has_space_for_loot() changes

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -113,7 +113,7 @@ class PokemonGoBot(object):
         if lat == None:
             lat = self.api._position_lat
         if lng == None:
-            lng = self.api._position_lng
+            lng = selfnumber_of_things_gained_by_stop.api._position_lng
         if alt == None:
             alt = 0
 
@@ -581,7 +581,7 @@ class PokemonGoBot(object):
                                                 ' | Pokestops Visited: {poke_stop_visits}'.format(**playerdata), 'cyan')
 
     def has_space_for_loot(self):
-        number_of_things_gained_by_stop = 5
+        number_of_things_gained_by_stop = 8
         enough_space = self.get_inventory_count('item') < self._player['max_item_storage'] - number_of_things_gained_by_stop
 
         return enough_space

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -113,7 +113,7 @@ class PokemonGoBot(object):
         if lat == None:
             lat = self.api._position_lat
         if lng == None:
-            lng = selfnumber_of_things_gained_by_stop.api._position_lng
+            lng = self.api._position_lng
         if alt == None:
             alt = 0
 


### PR DESCRIPTION
5 is not always correct number for gained items from fort.

I have example of gaining 8 items from fort. Maybe this number can be greater?

> [00:15:20] Now at Pokestop: Brass Dancers
> [00:15:20] Spinning ...
> [00:15:22] Loot:
> [00:15:22] 100 xp
> [00:15:22] - 3x Pokeball (Total: 33)
> [00:15:22] - 2x Greatball (Total: 72)
> [00:15:22] - 2x Potion (Total: 2)
> [00:15:22] - 1x Revive (Total: 31)