### PR TITLE
Fix UnboundLocalError

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -186,22 +186,6 @@ def init_config():
     return config
 
 
-def start_bot(bot, retries=2):
-    if retries == 0:
-            logger.log('[x] All retries failed', 'yellow')
-            logger.log('[x] Terminating PokemonGo Bot', 'yellow')
-            from sys import exit
-            exit(-1)
-
-    try:
-        bot.start()
-    except Exception as err:
-        logger.log('[x] Error starting bot, reason: {}'.format(err), 'yellow')
-        logger.log('[x] Trying to start the bot again.', 'yellow')
-        logger.log('[x] Retries remaining: {}.'.format(retries - 1), 'yellow')
-        start_bot(bot, retries - 1)
-
-
 def main():
     # log settings
     # log format
@@ -217,14 +201,15 @@ def main():
     logger.log('[x] PokemonGO Bot v1.0', 'green')
     logger.log('[x] Configuration initialized', 'yellow')
 
-    logger.log('[x] Starting PokemonGo Bot....', 'green')
-
-    bot = PokemonGoBot(config)
-    start_bot(bot)
-
     try:
+        bot = PokemonGoBot(config)
+        bot.start()
+
+        logger.log('[x] Starting PokemonGo Bot....', 'green')
+
         while True:
             bot.take_step()
+
     except KeyboardInterrupt:
         logger.log('[x] Exiting PokemonGo Bot', 'red')
         # TODO Add number of pokemon catched, pokestops visited, highest CP

--- a/pokecli.py
+++ b/pokecli.py
@@ -186,20 +186,20 @@ def init_config():
     return config
 
 
-def start_bot(bot, retries=1):
-    try:
-        bot.start()
-    except Exception, e:
-        logger.log('[x] Error starting bot, reason: {e}'.format(e), 'red')
-        if retries == 0:
-            logger.log('[x] All retries failed', 'red')
-            logger.log('[x] Terminating PokemonGo Bot', 'red')
+def start_bot(bot, retries=2):
+    if retries == 0:
+            logger.log('[x] All retries failed', 'yellow')
+            logger.log('[x] Terminating PokemonGo Bot', 'yellow')
             from sys import exit
             exit(-1)
-        else:
-            logger.log('[x] Trying to start the bot again.', 'yellow')
-            logger.log('[x] Retries remaining: {}.'.format(retries - 1), 'yellow')
-            start_bot(retries - 1)
+
+    try:
+        bot.start()
+    except Exception as err:
+        logger.log('[x] Error starting bot, reason: {}'.format(err), 'yellow')
+        logger.log('[x] Trying to start the bot again.', 'yellow')
+        logger.log('[x] Retries remaining: {}.'.format(retries - 1), 'yellow')
+        start_bot(bot, retries - 1)
 
 
 def main():

--- a/pokecli.py
+++ b/pokecli.py
@@ -190,7 +190,7 @@ def start_bot(bot, retries=1):
     try:
         bot.start()
     except Exception, e:
-        logger.log('[x] Error starting bot, reason: {e}'.format(), 'red')
+        logger.log('[x] Error starting bot, reason: {e}'.format(e), 'red')
         if retries == 0:
             logger.log('[x] All retries failed', 'red')
             logger.log('[x] Terminating PokemonGo Bot', 'red')

--- a/pokecli.py
+++ b/pokecli.py
@@ -186,6 +186,22 @@ def init_config():
     return config
 
 
+def start_bot(bot, retries=1):
+    try:
+        bot.start()
+    except Exception, e:
+        logger.log('[x] Error starting bot, reason: {e}'.format(), 'red')
+        if retries == 0:
+            logger.log('[x] All retries failed', 'red')
+            logger.log('[x] Terminating PokemonGo Bot', 'red')
+            from sys import exit
+            exit(-1)
+        else:
+            logger.log('[x] Trying to start the bot again.', 'yellow')
+            logger.log('[x] Retries remaining: {}.'.format(retries - 1), 'yellow')
+            start_bot(retries - 1)
+
+
 def main():
     # log settings
     # log format
@@ -201,15 +217,14 @@ def main():
     logger.log('[x] PokemonGO Bot v1.0', 'green')
     logger.log('[x] Configuration initialized', 'yellow')
 
+    logger.log('[x] Starting PokemonGo Bot....', 'green')
+
+    bot = PokemonGoBot(config)
+    start_bot(bot)
+
     try:
-        bot = PokemonGoBot(config)
-        bot.start()
-
-        logger.log('[x] Starting PokemonGo Bot....', 'green')
-
         while True:
             bot.take_step()
-
     except KeyboardInterrupt:
         logger.log('[x] Exiting PokemonGo Bot', 'red')
         # TODO Add number of pokemon catched, pokestops visited, highest CP

--- a/pokemongo_bot/cell_workers/seen_fort_worker.py
+++ b/pokemongo_bot/cell_workers/seen_fort_worker.py
@@ -79,6 +79,8 @@ class SeenFortWorker(object):
                             #RECYCLE_INVENTORY_ITEM
                             response_dict_recycle = self.bot.drop_item(item_id=item_id, count=item_count)
 
+                            result = 0
+
                             if response_dict_recycle and \
                                 'responses' in response_dict_recycle and \
                                 'RECYCLE_INVENTORY_ITEM' in response_dict_recycle['responses'] and \


### PR DESCRIPTION
Short Description: 

* Fix the error when the bot is trying to recycle items - the variable result may not exist if the network call is not success.

Example Trackback for `UnboundLocalError `:

```
Traceback (most recent call last):
  File "pokecli.py", line 220, in <module>
    main()
  File "pokecli.py", line 211, in main
    bot.take_step()
  File "/Users/xliang/Dropbox/Playground/PokemonGo-Bot/pokemongo_bot/__init__.py", line 36, in take_step
    self.stepper.take_step()
  File "/Users/xliang/Dropbox/Playground/PokemonGo-Bot/pokemongo_bot/stepper.py", line 62, in take_step
    self._work_at_position(position[0], position[1], position[2], True)
  File "/Users/xliang/Dropbox/Playground/PokemonGo-Bot/pokemongo_bot/stepper.py", line 139, in _work_at_position
    self.bot.work_on_cell(cell, position, pokemon_only)
  File "/Users/xliang/Dropbox/Playground/PokemonGo-Bot/pokemongo_bot/__init__.py", line 96, in work_on_cell
    hack_chain = worker.work()
  File "/Users/xliang/Dropbox/Playground/PokemonGo-Bot/pokemongo_bot/cell_workers/seen_fort_worker.py", line 87, in work
    'result' in response_dict_recycle['responses']['RECYCLE_INVENTORY_ITEM']:
UnboundLocalError: local variable 'result' referenced before assignment
```

Fixes:
- Initialize the local variable before trying to assign any value to it. 
