### PR TITLE
Make logger work with both str and unicode

### DIFF
--- a/pokemongo_bot/logger.py
+++ b/pokemongo_bot/logger.py
@@ -10,6 +10,11 @@ except Exception:
 
 
 def log(string, color='white'):
+    try:
+        string = string.decode('utf8')
+    except UnicodeEncodeError:
+        pass
+    
     color_hex = {
         'red': '91m',
         'green': '92m',
@@ -20,7 +25,7 @@ def log(string, color='white'):
     if color not in color_hex:
         print('[' + time.strftime("%H:%M:%S") + '] ' + string)
     else:
-        print('[' + time.strftime("%H:%M:%S") + '] ' + u'\033[' + color_hex[color] + string.decode('utf-8') + '\033[0m')
+        print('[' + time.strftime("%H:%M:%S") + '] ' + '\033[' + color_hex[color] + string + '\033[0m')
     if lcd:
         if string:
             lcd.message(string)


### PR DESCRIPTION
Short Description: 
log is sometimes called with str, other times with unicode sequences. This change makes it work for both cases.

Fixes:
- Unicode decode errors at Pokestops with special chars (see #1814)