### PR TITLE
Log location as a str to fix crash on start when initial location contains special chars

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -453,7 +453,7 @@ class PokemonGoBot(object):
             location = (self._get_pos_by_name(location_str.replace(" ", "")))
             self.api.set_position(*location)
             logger.log('')
-            logger.log(u'Location Found: {}'.format(self.config.location))
+            logger.log('Location Found: {}'.format(location_str))
             logger.log('GeoPosition: {}'.format(self.position))
             logger.log('')
             has_position = True


### PR DESCRIPTION
Short Description: 

We already have location as an encoded str in location_str and most calls to log pass a string as argument, so this is a bit more consistent. Only tested on top of #1824, please do not merge without it.

Fixes:
- Nothing, this should be equivalent but a bit more consistent. 