### PR TITLE
Fix 'pokemon_data' referenced before assignment in incubate_eggs_worker (#1823)

### DIFF
--- a/pokemongo_bot/cell_workers/incubate_eggs_worker.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs_worker.py
@@ -127,6 +127,7 @@ class IncubateEggsWorker(object):
         xp = result.get('experience_awarded', 0)
         sleep(self.hatching_animation_delay)
         self.bot.latest_inventory = None
+        pokemon_data = None
         try:
             pokemon_data = self._check_inventory(pokemon_ids)
         except:


### PR DESCRIPTION
Short Description: 
'pokemon_data' referenced before assignment in incubate_eggs_worker

Fixes:
- 'pokemon_data' referenced before assignment in incubate_eggs_worker #1823
- 
- 


