### PR TITLE
Added nickname templating and associated worker

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -12,6 +12,12 @@
         "type": "CollectLevelUpReward"
       },
       {
+        "type": "NicknamePokemon",
+        "config": {
+          "nickname_template": "{iv_pct}_{iv_ads}"
+        }
+      },
+      {
         "type": "IncubateEggs",
         "config": {
           "longer_eggs_first": true

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -12,6 +12,12 @@
         "type": "CollectLevelUpReward"
       },
       {
+        "type": "NicknamePokemon",
+        "config": {
+          "nickname_template": "{iv_pct}_{iv_ads}"
+        }
+      },
+      {
         "type": "IncubateEggs",
         "config": {
           "longer_eggs_first": true

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -12,6 +12,12 @@
         "type": "CollectLevelUpReward"
       },
       {
+        "type": "NicknamePokemon",
+        "config": {
+          "nickname_template": "{iv_pct}_{iv_ads}"
+        }
+      },
+      {
         "type": "IncubateEggs",
         "config": {
           "longer_eggs_first": true

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -12,6 +12,12 @@
         "type": "CollectLevelUpReward"
       },
       {
+        "type": "NicknamePokemon",
+        "config": {
+          "nickname_template": "{iv_pct}_{iv_ads}"
+        }
+      },
+      {
         "type": "IncubateEggs",
         "config": {
           "longer_eggs_first": true

--- a/pokemongo_bot/cell_workers/__init__.py
+++ b/pokemongo_bot/cell_workers/__init__.py
@@ -5,6 +5,7 @@ from catch_visible_pokemon import CatchVisiblePokemon
 from evolve_all import EvolveAll
 from incubate_eggs import IncubateEggs
 from move_to_fort import MoveToFort
+from nickname_pokemon import NicknamePokemon
 from pokemon_catch_worker import PokemonCatchWorker
 from transfer_pokemon import TransferPokemon
 from recycle_items import RecycleItems

--- a/pokemongo_bot/cell_workers/incubate_eggs.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs.py
@@ -106,15 +106,13 @@ class IncubateEggs(BaseTask):
                         "used": False
                     })
                 elif 'is_egg' not in pokemon and pokemon['id'] in lookup_ids:
-                    matched_pokemon.append({
-                        "pokemon_id": pokemon.get('pokemon_id', -1),
-                        "cp": pokemon.get('cp', 0),
+                    matched_pokemon.append(pokemon.update({
                         "iv": [
                             pokemon.get('individual_attack', 0),
                             pokemon.get('individual_defense', 0),
                             pokemon.get('individual_stamina', 0)
                         ]
-                    })
+                    }))
                 continue
             if "player_stats" in inv_data:
                 self.km_walked = inv_data.get("player_stats", {}).get("km_walked", 0)
@@ -147,7 +145,7 @@ class IncubateEggs(BaseTask):
             for pokemon in pokemon_data:
                 # pokemon ids seem to be offset by one
                 if pokemon['pokemon_id']!=-1:
-                    pokemon['name'] = self.bot.pokemon_list[(pokemon['pokemon_id']-1)]['Name']
+                    pokemon['name'] = self.bot.pokemon_list[(pokemon.get('pokemon_id')-1)]['Name']
                 else:
                     pokemon['name'] = "error"
         except:
@@ -160,7 +158,7 @@ class IncubateEggs(BaseTask):
         for i in range(len(pokemon_data)):
             logger.log("-"*30,log_color)
             logger.log("[!] Pokemon: {}".format(pokemon_data[i]['name']), log_color)
-            logger.log("[!] CP: {}".format(pokemon_data[i]['cp']), log_color)
+            logger.log("[!] CP: {}".format(pokemon_data[i].get('cp',0)), log_color)
             logger.log("[!] IV: {} ({:.2f})".format("/".join(map(str, pokemon_data[i]['iv'])),(sum(pokemon_data[i]['iv'])/self.max_iv)), log_color)
             logger.log("[!] XP: {}".format(xp[i]), log_color)
             logger.log("[!] Stardust: {}".format(stardust[i]), log_color)

--- a/pokemongo_bot/cell_workers/nickname_pokemon.py
+++ b/pokemongo_bot/cell_workers/nickname_pokemon.py
@@ -1,0 +1,88 @@
+from pokemongo_bot import logger
+from pokemongo_bot.human_behaviour import sleep
+from pokemongo_bot.cell_workers.base_task import BaseTask
+
+class NicknamePokemon(BaseTask):
+    def initialize(self):
+        self.template = self.config.get('nickname_template','').lower().strip()
+        if self.template == "{name}":
+            self.template = ""
+    
+    def work(self):
+        try:
+            inventory = reduce(dict.__getitem__, ["responses", "GET_INVENTORY", "inventory_delta", "inventory_items"], self.bot.get_inventory())
+        except KeyError:
+            pass
+        else:
+            pokemon_data = self._get_inventory_pokemon(inventory)
+            for pokemon in pokemon_data:
+                self._nickname_pokemon(pokemon) 
+            
+    def _get_inventory_pokemon(self,inventory_dict):
+        pokemon_data = []
+        for inv_data in inventory_dict:
+            try:
+                pokemon = reduce(dict.__getitem__,['inventory_item_data','pokemon_data'],inv_data)
+            except KeyError:
+                pass
+            else:
+                if not pokemon.get('is_egg',False):
+                    pokemon_data.append(pokemon)
+        return pokemon_data
+        
+    def _nickname_pokemon(self,pokemon):
+        """This requies a pokemon object containing all the standard fields: id, ivs, cp, etc"""
+        new_name = ""
+        instance_id = pokemon.get('id',0)
+        if not instance_id:
+            logger.log("Pokemon instance id returned 0. Can't rename.",'red')
+            return
+        id = pokemon.get('pokemon_id',0)-1
+        name = self.bot.pokemon_list[id]['Name']
+        cp = pokemon.get('cp',0)
+        iv_attack = pokemon.get('individual_attack',0)
+        iv_defense = pokemon.get('individual_defense',0)
+        iv_stamina = pokemon.get('individual_stamina',0)
+        iv_list = [iv_attack,iv_defense,iv_stamina]
+        iv_ads = "/".join(map(str,iv_list))
+        iv_sum = sum(iv_list)
+        iv_pct = "{:0.0f}".format(100*iv_sum/45.0)
+        log_color = 'red'
+        try:
+            new_name = self.template.format(name=name,
+                                    id=id,
+                                    cp=cp,
+                                    iv_attack=iv_attack,
+                                    iv_defense=iv_defense,
+                                    iv_stamina=iv_stamina,
+                                    iv_ads=iv_ads,
+                                    iv_sum=iv_sum,
+                                    iv_pct=iv_pct)[:12]
+        except KeyError as bad_key:
+            logger.log("Unable to nickname {} due to bad template ({})".format(name,bad_key),log_color)
+        if pokemon.get('nickname', "") == new_name:
+            return
+        self.bot.api.nickname_pokemon(pokemon_id=instance_id,nickname=new_name)
+        response = self.bot.api.call()
+        sleep(1.2)
+        try: 
+            result =  reduce(dict.__getitem__, ["responses", "NICKNAME_POKEMON"], response)
+        except KeyError:
+            logger.log("Attempt to nickname received bad response from server.",log_color)
+            if self.bot.config.debug:
+                logger.log(response,log_color)
+            return
+        result = result['result']
+        if new_name == "":
+            new_name = name
+        output = {
+            0: 'Nickname unset',
+            1: 'Nickname set successfully! {} is now {}'.format(name,new_name),
+            2: 'Invalid nickname! ({})'.format(new_name),
+            3: 'Pokemon not found.',
+            4: 'Pokemon is egg'
+        }[result]
+        if result==1:
+            log_color='green'
+            pokemon['nickname'] = new_name
+        logger.log(output,log_color)

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import time
-
 from pokemongo_bot import logger
 from pokemongo_bot.human_behaviour import (normalized_reticle_size, sleep,
                                            spin_modifier)
-
 
 class PokemonCatchWorker(object):
     BAG_FULL = 'bag_full'
@@ -52,9 +50,9 @@ class PokemonCatchWorker(object):
                                 individual_defense = pokemon_data.get("individual_defense", 0)
 
                                 iv_display = '{}/{}/{}'.format(
-                                    individual_stamina,
                                     individual_attack,
-                                    individual_defense
+                                    individual_defense,
+                                    individual_stamina
                                 )
 
                                 pokemon_potential = self.pokemon_potential(pokemon_data)
@@ -63,7 +61,7 @@ class PokemonCatchWorker(object):
                                 logger.log('A Wild {} appeared! [CP {}] [Potential {}]'.format(
                                     pokemon_name, cp, pokemon_potential), 'yellow')
 
-                                logger.log('IV [Stamina/Attack/Defense] = [{}]'.format(iv_display))
+                                logger.log('IV [Attack/Defense/Stamina] = [{}]'.format(iv_display))
                                 pokemon_data['name'] = pokemon_name
                                 # Simulate app
                                 sleep(3)


### PR DESCRIPTION
Short Description: 
Users can now specify a template (using python Formatter syntax) to nickname pokemon in their inventory. The worker for this will process the user's entire inventory each tick, but will only update pokemon that require an update to match the new template (i.e. only caught/hatched pokemon after the first tick).

Use a blank template (`""`) to revert all pokemon to their original names.

Valid names in templates are:
- `name` = pokemon name
- `id` = pokemon type id (e.g. 1 for Bulbasaurs)
- `cp` = pokemon's CP
- `iv_attack` = pokemon's attack IV
- `iv_defense` = pokemon's defense IV
- `iv_stamina` = pokemon's stamina IV
- `iv_ads` = pokemon's IVs in X/X/X format (matches web UI format -- A/D/S)
- `iv_sum` = pokemon's IVs as a sum (e.g. 45 when 3 perfect 15 IVs)
- `iv_pct` = pokemon's IVs as a percentage (0-100)

Examples: 
- `{name}_{iv_pct}` => `Mankey_69`
- `{iv_pct}_{iv_ads}` => `91_15/11/15`
![sample](https://cloud.githubusercontent.com/assets/8896778/17285954/0fa44a88-577b-11e6-8204-b1302f4294bd.png)
