### PR TITLE
Fix a crash in incubate_eggs_worker

### DIFF
--- a/pokemongo_bot/cell_workers/incubate_eggs_worker.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs_worker.py
@@ -130,7 +130,7 @@ class IncubateEggsWorker(object):
         try:
             pokemon_data = self._check_inventory(pokemon_ids)
         except:
-            pass  # just proceed with what we have
+            return
         for pokemon in pokemon_data:
             # pokemon ids seem to be offset by one
             pokemon['name'] = self.bot.pokemon_list[(pokemon['pokemon_id']-1)]['Name']


### PR DESCRIPTION
Short Description: 
Traceback (most recent call last):
  File "pokecli.py", line 455, in <module>
    main()
  File "pokecli.py", line 68, in main
    bot.tick()
  File "/usr/src/app/pokemongo_bot/__init__.py", line 84, in tick
    if worker.work() == WorkerResult.RUNNING:
  File "/usr/src/app/pokemongo_bot/cell_workers/incubate_eggs_worker.py", line 29, in work
    self._hatch_eggs()
  File "/usr/src/app/pokemongo_bot/cell_workers/incubate_eggs_worker.py", line 134, in _hatch_eggs
    for pokemon in pokemon_data:
UnboundLocalError: local variable 'pokemon_data' referenced before assignment

Fixes:
- return instead of pass'ing the UnboundLocalError
