### PR TITLE
Fix auto-wrapped multiline "GET_INVENTORY" issue

### DIFF
--- a/pokemongo_bot/cell_workers/initial_transfer_worker.py
+++ b/pokemongo_bot/cell_workers/initial_transfer_worker.py
@@ -46,8 +46,7 @@ class InitialTransferWorker(object):
         pokemon_groups = {}
         self.api.get_player().get_inventory()
         inventory_req = self.api.call()
-        inventory_dict = inventory_req['responses']['GET_INVENTORY'][
-            'inventory_delta']['inventory_items']
+        inventory_dict = inventory_req['responses']['GET_INVENTORY']['inventory_delta']['inventory_items']
 
         user_web_inventory = 'web/inventory-%s.json' % (self.config.username)
         with open(user_web_inventory, 'w') as outfile:


### PR DESCRIPTION
Short Description: 
Key lookups split across lines seem to break things?
Fixes:
Place all work on single line

