### PR TITLE
Fixed a small bug when user didn't have a VIP config!

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -390,6 +390,8 @@ class PokemonCatchWorker(object):
             return True
         else:
             catch_config = self.config.vips.get("any")
+            if not catch_config:
+                return False
             cp_iv_logic = catch_config.get('logic', 'or')
         catch_results = {
             'cp': False,


### PR DESCRIPTION
Short Description: 
This fix a small bug when user didn't update their config file for VIP pokemon setting (leave it for empty)

Fixes:
Return false if there is no such a setting instead of crashing.
- 
- 

