### PR TITLE
Fix typo item_stock -> items_stock

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -195,7 +195,7 @@ class PokemonCatchWorker(object):
 
                                 # Add this logic to avoid Pokeball = 0, Great Ball = 0, Ultra Ball = X
                                 # And this logic saves Ultra Balls if it's a weak trash pokemon
-                                if catch_rate[pokeball-1]<0.30 and item_stock[3]>0:
+                                if catch_rate[pokeball-1]<0.30 and items_stock[3]>0:
                                     pokeball = 3
                                     
                             items_stock[pokeball] -= 1


### PR DESCRIPTION
Short Description: 
Fix a typo, "item_stock" should be "items_stock"

Fixes:
- Fix a typo, "item_stock" should be "items_stock"