### PR TITLE
Do a Heartbeat even when a step was short

### DIFF
--- a/pokemongo_bot/step_walker.py
+++ b/pokemongo_bot/step_walker.py
@@ -39,6 +39,7 @@ class StepWalker(object):
     def step(self):
         if (self.dLat == 0 and self.dLng == 0) or self.dist < self.speed:
             self.api.set_position(self.destLat, self.destLng, 0)
+            self.bot.heartbeat()
             return True
 
         totalDLat = (self.destLat - self.initLat)


### PR DESCRIPTION
Short Description: 
When you supply a path for the PathNavigator and the waypoints are too dense the web-location json won't be updated.

Fixes:
- Do a heartbeat even when the StepWalker made a short step
