### PR TITLE
Re-enable item ID's in the item_filter.

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -426,12 +426,13 @@ def init_config():
         parser.error("--catch_randomize_spin_factor is out of range! (should be 0 <= catch_randomize_spin_factor <= 1)")
         return None
 
-    # item list config verification
-    item_list = json.load(open(os.path.join('data', 'items.json')))
-    for config_item_name, bag_count in config.item_filter.iteritems():
-        if config_item_name not in item_list.viewvalues():
-            parser.error('item "' + config_item_name + '" does not exist, spelling mistake? (check for valid item names in data/items.json)')
-            return None
+        # item list config verification
+        item_list = json.load(open(os.path.join('data', 'items.json')))
+        for config_item_name, bag_count in config.item_filter.iteritems():
+            if config_item_name not in item_list.viewvalues():
+                if config_item_name not in item_list:
+                    parser.error('item "' + config_item_name + '" does not exist, spelling mistake? (check for valid item names in data/items.json)')
+                    return None
 
     # create web dir if not exists
     try:

--- a/pokemongo_bot/cell_workers/recycle_items.py
+++ b/pokemongo_bot/cell_workers/recycle_items.py
@@ -7,6 +7,7 @@ class RecycleItems(object):
         self.bot = bot
 
     def work(self):
+
         self.bot.latest_inventory = None
         item_count_dict = self.bot.item_inventory_count('all')
 
@@ -15,9 +16,13 @@ class RecycleItems(object):
             id_filter = self.bot.config.item_filter.get(item_name, 0)
             if id_filter is not 0:
                 id_filter_keep = id_filter.get('keep', 20)
+            else:
+                id_filter = self.bot.config.item_filter.get(str(item_id), 0)
+                if id_filter is not 0:
+                    id_filter_keep = id_filter.get('keep', 20)
 
             bag_count = self.bot.item_inventory_count(item_id)
-            if item_name in self.bot.config.item_filter and bag_count > id_filter_keep:
+            if (item_name in self.bot.config.item_filter or str(item_id) in self.bot.config.item_filter) and bag_count > id_filter_keep:
                 items_recycle_count = bag_count - id_filter_keep
                 response_dict_recycle = self.send_recycle_item_request(item_id=item_id, count=items_recycle_count)
                 result = response_dict_recycle.get('responses', {}).get('RECYCLE_INVENTORY_ITEM', {}).get('result', 0)

--- a/pokemongo_bot/cell_workers/recycle_items.py
+++ b/pokemongo_bot/cell_workers/recycle_items.py
@@ -7,7 +7,6 @@ class RecycleItems(object):
         self.bot = bot
 
     def work(self):
-
         self.bot.latest_inventory = None
         item_count_dict = self.bot.item_inventory_count('all')
 


### PR DESCRIPTION
Short Description: 
Allows users to enter both item ID's and item names in the item_filter.

Fixes:
- Re-allow item ID's in item_filter

