### PR TITLE
Let the user know that the maps api key exceeded its limits.

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -36,6 +36,7 @@ import time
 from datetime import timedelta
 from getpass import getpass
 from pgoapi.exceptions import NotLoggedInException
+from geopy.exc import GeocoderQuotaExceeded
 
 from pokemongo_bot import PokemonGoBot, TreeConfigBuilder
 from pokemongo_bot import logger
@@ -76,6 +77,9 @@ def main():
         except NotLoggedInException:
             logger.log('[x] Error while connecting to the server, please wait %s minutes' % config.reconnecting_timeout, 'red')
             time.sleep(config.reconnecting_timeout * 60)
+        except GeocoderQuotaExceeded:
+            logger.log('[x] The given maps api key has gone over the requests limit.', 'red')
+            finished = True
         except:
             # always report session summary and then raise exception
             report_summary(bot)


### PR DESCRIPTION
Short Description: When the maps api key exceeds the maximum number of requests geopy.exc.GeocoderQuotaExceeded is raised, but main() on pokecli.py won't catch it and will just raise a not very meaninful NotLoggedInException(). This change lets the user know it's time to get a new key. 

This: 
<img width="763" alt="screen shot 2016-07-30 at 9 00 21 pm" src="https://cloud.githubusercontent.com/assets/3504711/17274496/b8634ad6-5698-11e6-92a6-6dee6aa3c480.png">

Becomes this:
<img width="599" alt="screen shot 2016-07-30 at 9 00 39 pm" src="https://cloud.githubusercontent.com/assets/3504711/17274497/bf949d64-5698-11e6-84b9-d6400d552f3e.png">

