### PR TITLE
Allow to collect level up rewards

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -9,6 +9,9 @@
         "type": "HandleSoftBan"
       },
       {
+        "type": "CollectLevelUpReward"
+      },
+      {
         "type": "IncubateEggs",
         "config": {
           "longer_eggs_first": true

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -9,6 +9,9 @@
         "type": "HandleSoftBan"
       },
       {
+        "type": "CollectLevelUpReward"
+      },
+      {
         "type": "IncubateEggs",
         "config": {
           "longer_eggs_first": true

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -9,6 +9,9 @@
         "type": "HandleSoftBan"
       },
       {
+        "type": "CollectLevelUpReward"
+      },
+      {
         "type": "IncubateEggs",
         "config": {
           "longer_eggs_first": true

--- a/pokemongo_bot/cell_workers/__init__.py
+++ b/pokemongo_bot/cell_workers/__init__.py
@@ -12,4 +12,5 @@ from spin_fort import SpinFort
 from handle_soft_ban import HandleSoftBan
 from follow_path import FollowPath
 from follow_spiral import FollowSpiral
+from collect_level_up_reward import CollectLevelUpReward
 from base_task import BaseTask

--- a/pokemongo_bot/cell_workers/collect_level_up_reward.py
+++ b/pokemongo_bot/cell_workers/collect_level_up_reward.py
@@ -1,0 +1,64 @@
+from pokemongo_bot import logger
+from pokemongo_bot.cell_workers.base_task import BaseTask
+
+
+class CollectLevelUpReward(BaseTask):
+    current_level = 0
+    previous_level = 0
+
+    def initialize(self):
+        self.current_level = self._get_current_level()
+        self.previous_level = 0
+
+    def work(self):
+        self.current_level = self._get_current_level()
+
+        # let's check level reward on bot initialization
+        # to be able get rewards for old bots
+        if self.previous_level == 0:
+            self._collect_level_reward()
+        # level up situation
+        elif self.current_level > self.previous_level:
+            logger.log('Level up from {} to {}!'.format(self.previous_level, self.current_level), 'green')
+            self._collect_level_reward()
+
+        self.previous_level = self.current_level
+
+    def _collect_level_reward(self):
+        self.bot.api.level_up_rewards(level=self.current_level)
+        response_dict = self.bot.api.call()
+        if 'status_code' in response_dict and response_dict['status_code'] == 1:
+            data = (response_dict
+                    .get('responses', {})
+                    .get('LEVEL_UP_REWARDS', {})
+                    .get('items_awarded', []))
+
+            if data:
+                logger.log('Collected level up rewards:', 'green')
+
+            for item in data:
+                if 'item_id' in item and str(item['item_id']) in self.bot.item_list:
+                    got_item = self.bot.item_list[str(item['item_id'])]
+                    count = 'item_count' in item and item['item_count'] or 0
+                    logger.log('{} x {}'.format(got_item, count), 'green')
+
+    def _get_current_level(self):
+        level = 0
+        response_dict = self.bot.get_inventory()
+        data = (response_dict
+                .get('responses', {})
+                .get('GET_INVENTORY', {})
+                .get('inventory_delta', {})
+                .get('inventory_items', {}))
+
+        for item in data:
+            level = (item
+                     .get('inventory_item_data', {})
+                     .get('player_stats', {})
+                     .get('level', 0))
+
+            # we found a level, no need to continue iterate
+            if level:
+                break
+
+        return level


### PR DESCRIPTION
Currently bot doesn't collect level up rewards.

So, for example bot was level up from 1 to 20 and you login from the phone after this, you will have 1000/350 items in your bag :)

This PR fixed it, and you will get level rewards just after your level up.

> [13:08:44]  Level up from 3 to 4!
> [13:08:45]  Collected level up rewards:
> [13:08:45]  Pokeball x 15