### PR TITLE
Workaround Empty Forts

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -111,7 +111,7 @@ class PokemonGoBot(object):
 
         if (len(forts) == 0):
             forts = oldForts
-            logger.log('using old forts list')
+#            logger.log('using old forts list')
 
         return {
             "forts": forts,

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -94,6 +94,9 @@ class PokemonGoBot(object):
         cells = self.find_close_cells(*location)
 
         # Combine all cells into a single dict of the items we care about.
+        oldForts = []
+        if (self.cell and "forts" in self.cell):
+            oldForts = self.cell['forts']
         forts = []
         wild_pokemons = []
         catchable_pokemons = []
@@ -104,6 +107,10 @@ class PokemonGoBot(object):
                 wild_pokemons += cell["wild_pokemons"]
             if "catchable_pokemons" in cell and len(cell["catchable_pokemons"]):
                 catchable_pokemons += cell["catchable_pokemons"]
+
+        if (len(forts) == 0):
+            forts = oldForts
+            logger.log('using old forts list')
 
         return {
             "forts": forts,


### PR DESCRIPTION
Short Description: Sometimes, the API return empty forts. This causes move_to_fort fail. To workaround this, return prev forts, if API return empty forts.

Fixes:
- 
- 
- 

