### PR TITLE
Add option to spin fort even if inventory is full

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -74,6 +74,7 @@
     "evolve_captured": "NONE",
     "catch_randomize_reticle_factor": 1.0,
     "catch_randomize_spin_factor": 1.0,
+    "move_to_fort_even_if_full_inventory": false,
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -37,7 +37,10 @@
         "type": "CatchLuredPokemon"
       },
       {
-        "type": "SpinFort"
+        "type": "SpinFort",
+        "config": {
+          "spin_even_if_inventory_full": false
+        }
       },
       {
         "type": "MoveToFort"
@@ -79,6 +82,7 @@
     "evolve_captured": "NONE",
     "catch_randomize_reticle_factor": 1.0,
     "catch_randomize_spin_factor": 1.0,
+    "move_to_fort_even_if_full_inventory": false,
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -37,7 +37,10 @@
         "type": "CatchLuredPokemon"
       },
       {
-        "type": "SpinFort"
+        "type": "SpinFort",
+        "config": {
+          "spin_even_if_inventory_full": false
+        }
       },
       {
         "type": "MoveToFort"
@@ -76,6 +79,7 @@
     "evolve_captured": "NONE",
     "catch_randomize_reticle_factor": 1.0,
     "catch_randomize_spin_factor": 1.0,
+    "move_to_fort_even_if_full_inventory": false,
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or" },
 

--- a/pokecli.py
+++ b/pokecli.py
@@ -367,6 +367,14 @@ def init_config():
         type=float,
         default=1.0
     )
+    add_config(
+        parser,
+        load,
+        long_flag="--move_to_fort_even_if_full_inventory",
+        help="Move to fort and spin it for XP, even if inventory is full",
+        type=bool,
+        default=False
+    )
 
     # Start to parse other attrs
     config = parser.parse_args()

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -34,10 +34,10 @@ class PokemonGoBot(object):
     def __init__(self, config):
         self.config = config
         self.fort_timeouts = dict()
-        self.pokemon_list = json.load(
-            open(os.path.join('data', 'pokemon.json'))
-        )
-        self.item_list = json.load(open(os.path.join('data', 'items.json')))
+        with open(os.path.join('data', 'pokemon.json')) as fp:
+            self.pokemon_list = json.load(fp)
+        with open(os.path.join('data', 'items.json')) as fp:
+            self.item_list = json.load(fp)
         self.metrics = Metrics(self)
         self.latest_inventory = None
         self.cell = None

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -639,14 +639,14 @@ class PokemonGoBot(object):
                                                 '{poke_stop_visits}'.format(
                                                     **playerdata), 'cyan')
 
-    def has_space_for_loot(self):
+    def should_move_to_fort_for_loot(self):
         number_of_things_gained_by_stop = 5
         enough_space = (
             self.get_inventory_count('item') <
             self._player['max_item_storage'] - number_of_things_gained_by_stop
         )
 
-        return enough_space
+        return enough_space or self.config.move_to_fort_even_if_full_inventory
 
     def get_forts(self, order_by_distance=False):
         forts = [fort

--- a/pokemongo_bot/cell_workers/move_to_fort.py
+++ b/pokemongo_bot/cell_workers/move_to_fort.py
@@ -8,7 +8,10 @@ from utils import distance, format_dist, fort_details
 
 class MoveToFort(BaseTask):
     def should_run(self):
-        return (self.bot.has_space_for_loot()) or self.bot.softban
+        if self.bot.softban:
+            return True
+        else:
+            return self.bot.should_move_to_fort_for_loot()
 
     def work(self):
         if not self.should_run():

--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -14,7 +14,7 @@ from utils import distance, format_time, fort_details
 
 class SpinFort(BaseTask):
     def should_run(self):
-        return self.bot.has_space_for_loot()
+        return self.bot.should_move_to_fort_for_loot()
 
     def work(self):
         fort = self.get_fort_in_range()
@@ -41,14 +41,16 @@ class SpinFort(BaseTask):
 
             spin_details = response_dict['responses']['FORT_SEARCH']
             spin_result = spin_details.get('result', -1)
-            if spin_result == 1:
+            if spin_result == 1 or spin_result == 4:
+                if spin_result == 4:
+                    logger.log('Inventory is full', 'red')
+
                 self.bot.softban = False
                 logger.log("Loot: ", 'green')
                 experience_awarded = spin_details.get('experience_awarded',
                                                       False)
                 if experience_awarded:
-                    logger.log(str(experience_awarded) + " xp",
-                               'green')
+                    logger.log('- {} xp'.format(experience_awarded), 'yellow')
 
                 items_awarded = spin_details.get('items_awarded', False)
                 if items_awarded:
@@ -67,7 +69,7 @@ class SpinFort(BaseTask):
                             '- ' + str(item_count) + "x " + item_name +
                             " (Total: " + str(self.bot.item_inventory_count(item_id)) + ")", 'yellow'
                         )
-                else:
+                elif spin_result == 1:
                     logger.log("[#] Nothing found.", 'yellow')
 
                 pokestop_cooldown = spin_details.get(
@@ -91,8 +93,6 @@ class SpinFort(BaseTask):
                     logger.log('PokeStop on cooldown. Time left: ' + str(
                         format_time((pokestop_cooldown / 1000) -
                                     seconds_since_epoch)))
-            elif spin_result == 4:
-                logger.log("Inventory is full", 'red')
             else:
                 logger.log("Unknown spin result: " + str(spin_result), 'red')
 

--- a/pokemongo_bot/logger.py
+++ b/pokemongo_bot/logger.py
@@ -25,7 +25,7 @@ def log(string, color='white'):
         ))
     else:
         print(
-            '[{time}] \033[{color} {string} \033[0m'.format(
+            '[{time}] \033[{color}{string}\033[0m'.format(
                 time=time.strftime("%H:%M:%S"),
                 color=color_hex[color],
                 string=string.decode('utf-8')


### PR DESCRIPTION
Short Description:
---
Added new option `move_to_fort_even_if_full_inventory` which allows bot to move to forts and spin it for XP, even if inventory is full.

Fixes:
---
- Bot cannot earn XP by spinning forts in case inventory is full.
- Minor resource leak in `pokemongo_bot#__init__`, by using `with` for `json.load`.
- Minor logger bug: unexpected space char included in colored log message.

