### PR TITLE
Avoid transferring favorite pokemons

### DIFF
--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -91,6 +91,10 @@ class TransferPokemon(BaseTask):
             if 'deployed_fort_id' in pokemon_data and pokemon_data['deployed_fort_id']:
                 continue
 
+            # favorite pokemon can't transfer in official game client
+            if pokemon_data.get('favorite', 0) is 1:
+                continue
+
             group_id = pokemon_data['pokemon_id']
             group_pokemon_cp = pokemon_data['cp']
             group_pokemon_iv = self.get_pokemon_potential(pokemon_data)


### PR DESCRIPTION
Short Description: 
---
- Exclude favorite pokemons from transfer list.
- "With the new update it is impossible to transfer favourite pokemon" / https://www.reddit.com/r/TheSilphRoad/comments/4vd8ry/with_the_new_update_it_is_impossible_to_transfer/

Fixes:
---
- Bot transfer favorite pokemons. With official game client, we cannot do that (we have to unfavorite before transfer).


