### PR TITLE
StepWalker should throw an error if the distance asked is too big

### DIFF
--- a/pokemongo_bot/cell_workers/utils.py
+++ b/pokemongo_bot/cell_workers/utils.py
@@ -144,3 +144,11 @@ def print_yellow(message):
 
 def print_red(message):
     print(u'\033[91m' + message.decode('utf-8') + '\033[0m')
+
+
+def float_equal(f1, f2, epsilon=1e-8):
+    if f1 > f2:
+        return f1 - f2 < epsilon
+    if f2 > f1:
+       return f2 - f1 < epsilon
+    return True

--- a/pokemongo_bot/step_walker.py
+++ b/pokemongo_bot/step_walker.py
@@ -1,6 +1,6 @@
 from math import sqrt
 
-from cell_workers.utils import distance
+from cell_workers.utils import distance, float_equal
 from human_behaviour import random_lat_long_delta, sleep
 
 
@@ -35,6 +35,12 @@ class StepWalker(object):
             self.dLat = (dest_lat - self.initLat) / int(self.steps)
             self.dLng = (dest_lng - self.initLng) / int(self.steps)
             self.magnitude = self._pythagorean(self.dLat, self.dLng)
+
+            if float_equal(self.dLat, 0) or float_equal(self.dLng, 0):
+                # self.steps is very big, reducing the division to nearly 0
+                # the user should use smaller parameters (dest_lat, dest_lng)
+                raise RuntimeError('Coordinate passed to StepWalker are too far away from the Bot')
+
 
     def step(self):
         if (self.dLat == 0 and self.dLng == 0) or self.dist < self.speed:


### PR DESCRIPTION
Short Description: 
When big distance are passed to the StepWalker it currently acts as if it should not step at all.
Fixes:
- StepWalker should throw an error if parameters are out of scale.
- it should catch error for future usage

Behavior observed in #1682 

