### PR TITLE
[FIX-Config] 'use_lucky_egg' should not be true in the exemple config file

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -24,7 +24,7 @@
         "type": "EvolveAll",
         "config": {
           "evolve_speed": 20,
-          "use_lucky_egg": true
+          "use_lucky_egg": false
         }
       },
       {

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -24,7 +24,7 @@
         "type": "EvolveAll",
         "config": {
           "evolve_speed": 20,
-          "use_lucky_egg": true
+          "use_lucky_egg": false
         }
       },
       {

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -24,7 +24,7 @@
         "type": "EvolveAll",
         "config": {
           "evolve_speed": 20,
-          "use_lucky_egg": true
+          "use_lucky_egg": false
         }
       },
       {


### PR DESCRIPTION
Short Description: 
Just to avoid people complaining, and really this config is so long that some times it's easy to lose track of a undesirable value.
Fixes:
- 'use_lucky_egg' should not be true in the exemple config file
- changed 'use_lucky_egg' to false in all config exemple files.
- 

