### PR TITLE
Fix using -1 pokeball to catch. Add a logic if user don't set VIP pokemons, then don't save their Ultra ball.

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -382,6 +382,9 @@ def init_config():
     config.action_wait_min = load.get('action_wait_min', 1)
     config.raw_tasks = load.get('tasks', [])
     config.vips = load.get('vips',{})
+    config.vip_strategy = True
+    if not config.vips:
+        config.vip_strategy = False
 
     if len(config.raw_tasks) == 0:
         logging.error("No tasks are configured. Did you mean to configure some behaviors? Read https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Configuration-files#configuring-tasks for more information")

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -192,8 +192,15 @@ class PokemonCatchWorker(object):
                                 # Add this logic to avoid Pokeball = 0, Great Ball = 0, Ultra Ball = X
                                 # And this logic saves Ultra Balls if it's a weak trash pokemon
                                 # Add the logic that if there is  no VIP config, do not save the Utralball
-                                if (catch_rate[pokeball-1]<0.30 or self.config.vip_strategy == False) and items_stock[3]>0:
-                                    pokeball = 3
+                                if self.config.vip_strategy == False:
+                                    current_type=pokeball
+                                    while items_stock[current_type] is 0:
+                                        current_type += 1
+                                        if items_stock[current_type] > 0:
+                                            pokeball = current_type # use better ball
+                                else :
+                                    if catch_rate[pokeball-1]<0.30 and items_stock[3]>0:
+                                        pokeball = 3
  
                             # re-check if there is no suitable pokeball
                             if items_stock[pokeball] is 0:

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -191,9 +191,15 @@ class PokemonCatchWorker(object):
 
                                 # Add this logic to avoid Pokeball = 0, Great Ball = 0, Ultra Ball = X
                                 # And this logic saves Ultra Balls if it's a weak trash pokemon
-                                if catch_rate[pokeball-1]<0.30 and items_stock[3]>0:
+                                # Add the logic that if there is  no VIP config, do not save the Utralball
+                                if (catch_rate[pokeball-1]<0.30 or self.config.vip_strategy == False) and items_stock[3]>0:
                                     pokeball = 3
-
+ 
+                            # re-check if there is no suitable pokeball
+                            if items_stock[pokeball] is 0:
+                                logger.log('Seems out of pokeballs or BOT tries to save Ultra Balls', 'red')
+                                return PokemonCatchWorker.NO_POKEBALLS
+                            
                             items_stock[pokeball] -= 1
                             success_percentage = '{0:.2f}'.format(catch_rate[pokeball - 1] * 100)
                             logger.log('Using {} (chance: {}%)... ({} left!)'.format(


### PR DESCRIPTION
Short Description: 

Fix using -1 pokeball to catch. Add a logic if user don't set VIP pokemons, then don't save their Ultra ball.

Fixes:
1.Check the stock before throwing a ball [fix the -1 pokeball throwing]

2.Check if user set VIPs pokemons in config, if not, don't try to save Ultra Ball, just get them all
