### PR TITLE
Fix throw type always normal when trying to catch pokemon

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -213,7 +213,7 @@ class PokemonCatchWorker(object):
                                                    spawn_point_id=self.spawn_point_guid,
                                                    hit_pokemon=1,
                                                    spin_modifier=spin_modifier_parameter,
-                                                   NormalizedHitPosition=1)
+                                                   normalized_hit_position=1)
                             response_dict = self.api.call()
 
                             if response_dict and \


### PR DESCRIPTION
Short Description: 
Fix the catch pokemon call to match the API one.

Fixes:
- Throw are now rightly typed, i.e. Excellent, Great, Nice, etc...


