### PR TITLE
fix for #2104

### DIFF
--- a/pokemongo_bot/cell_workers/handle_soft_ban.py
+++ b/pokemongo_bot/cell_workers/handle_soft_ban.py
@@ -28,7 +28,7 @@ class HandleSoftBan(BaseTask):
         )
 
         if fort_distance > Constants.MAX_DISTANCE_FORT_IS_REACHABLE:
-            MoveToFort(self.bot).work()
+            MoveToFort(self.bot, self.config).work()
             self.bot.recent_forts = self.bot.recent_forts[0:-1]
             if forts[0]['id'] in self.bot.fort_timeouts:
                 del self.bot.fort_timeouts[forts[0]['id']]


### PR DESCRIPTION
Short Description: 
Fix TypeError
```
Traceback (most recent call last):
File "pokecli.py", line 494, in 
main()
File "pokecli.py", line 70, in main
bot.tick()
File "/Users/toremielck/Desktop/PokemonGo-Bot-kajoschooPTC/pokemongo_bot/init.py", line 85, in tick
if worker.work() == WorkerResult.RUNNING:
File "/Users/toremielck/Desktop/PokemonGo-Bot-kajoschooPTC/pokemongo_bot/cell_workers/handle_soft_ban.py", line 31, in work
MoveToFort(self.bot).work()
TypeError: init() takes exactly 3 arguments (2 given)
```
Fixes:
- Worker needs the config param

