### PR TITLE
Warns if there aren't sufficient space left for loot.

### DIFF
--- a/pokemongo_bot/cell_workers/move_to_fort.py
+++ b/pokemongo_bot/cell_workers/move_to_fort.py
@@ -8,9 +8,10 @@ from utils import distance, format_dist, fort_details
 
 class MoveToFort(BaseTask):
     def should_run(self):
-        if not self.bot.has_space_for_loot():
+        has_space_for_loot = self.bot.has_space_for_loot()
+        if not has_space_for_loot:
             logger.log("Not moving to any forts as there aren't enough space. You might want to change your config to recycle more items if this message appears consistently.", 'yellow')
-        return (self.bot.has_space_for_loot()) or self.bot.softban
+        return has_space_for_loot or self.bot.softban
 
     def work(self):
         if not self.should_run():

--- a/pokemongo_bot/cell_workers/move_to_fort.py
+++ b/pokemongo_bot/cell_workers/move_to_fort.py
@@ -8,6 +8,8 @@ from utils import distance, format_dist, fort_details
 
 class MoveToFort(BaseTask):
     def should_run(self):
+        if not self.bot.has_space_for_loot():
+            logger.log("Not moving to any forts as there aren't enough space. You might want to change your config to recycle more items if this message appears consistently.", 'yellow')
         return (self.bot.has_space_for_loot()) or self.bot.softban
 
     def work(self):

--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -14,6 +14,8 @@ from utils import distance, format_time, fort_details
 
 class SpinFort(BaseTask):
     def should_run(self):
+        if not self.bot.has_space_for_loot():
+            logger.log("Not spinning any forts as there aren't enough space. You might want to change your config to recycle more items if this message appears consistently.", 'yellow')
         return self.bot.has_space_for_loot()
 
     def work(self):

--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -16,7 +16,8 @@ class SpinFort(BaseTask):
     def should_run(self):
         if not self.bot.has_space_for_loot():
             logger.log("Not spinning any forts as there aren't enough space. You might want to change your config to recycle more items if this message appears consistently.", 'yellow')
-        return self.bot.has_space_for_loot()
+            return False
+        return True
 
     def work(self):
         fort = self.get_fort_in_range()


### PR DESCRIPTION
Short Description: 
When space is insufficient, it sends out requests to Niantic even faster than before
becuase tasks are querying Niantic and doing noops. More server busy (error 52)
errors appear in the log without an explanation of what's actually
going on.

Fixes:
- MoveToFort, SpinFort, etc terminate silently
- Users do not notice that MoveToFort/SpinFort is skipping due to the lack of space.
- Causing error code 52 as a indirect result
- Misleading error message (Server busy)