### PR TITLE
[FIX] removed wrong log (keep_best_iv)

### DIFF
--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -204,10 +204,6 @@ class TransferPokemon(BaseTask):
                 logger.log("Keep best can't be < 0. Ignore it.", "red")
                 keep_best = False
 
-            if keep_best_iv > 1:
-                logger.log("Keep best IV can't be > 1. Ignore it.", "red")
-                keep_best = False
-
             if keep_best_cp == 0 and keep_best_iv == 0:
                 keep_best = False
 


### PR DESCRIPTION
Short Description: 
in most cases with correct usage keep_best_iv has values of 1 and over. So this log should be removed (introduced #2150).

Fixes:
#2157

