### PR TITLE
0 is a number, fixes #2165 (I hope)

### DIFF
--- a/pokemongo_bot/cell_workers/initial_transfer_worker.py
+++ b/pokemongo_bot/cell_workers/initial_transfer_worker.py
@@ -30,7 +30,7 @@ class InitialTransferWorker(object):
 
 
                 for x in range(1, len(group_cp)):
-                    if self.config.initial_transfer and group_cp[x] > self.config.initial_transfer:
+                    if group_cp[x] > self.config.initial_transfer:
                         continue
 
                     print('[x] Transferring {} with CP {}'.format(


### PR DESCRIPTION
Valid setting to not transfer anything below 0 (read as: don't transfer anything) was failing, when Pokemon Bag was full. This should fix it.
Fixes #2165 