### PR TITLE
feat: request meta cell data once every 5 seconds (bypass Niantic throttling)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,3 +46,4 @@
  * kbinani
  * MFizz
  * NamPNQ
+ * matheussampaio

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -46,6 +46,7 @@
         "type": "FollowSpiral"
       }
     ],
+    "map_object_cache_time": 5,
     "max_steps": 5,
     "forts": {
       "avoid_circles": true,

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -50,6 +50,7 @@
         }
       }
     ],
+    "map_object_cache_time": 5,
     "max_steps": 5,
     "forts": {
       "avoid_circles": true,

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -46,6 +46,7 @@
         "type": "FollowSpiral"
       }
     ],
+    "map_object_cache_time": 5,
     "max_steps": 5,
     "forts": {
       "avoid_circles": true,

--- a/pokecli.py
+++ b/pokecli.py
@@ -338,6 +338,14 @@ def init_config():
         type=float,
         default=1.0
     )
+    add_config(
+        parser,
+        load,
+        long_flag="--map_object_cache_time",
+        help="Amount of seconds to keep the map object in cache (bypass Niantic throttling)",
+        type=float,
+        default=5.0
+    )
 
     # Start to parse other attrs
     config = parser.parse_args()
@@ -353,6 +361,11 @@ def init_config():
     config.action_wait_min = load.get('action_wait_min', 1)
     config.raw_tasks = load.get('tasks', [])
     config.vips = load.get('vips',{})
+    config.map_object_cache_time = load.get('map_object_cache_time')
+
+    if config.map_object_cache_time < 0.0:
+        parser.error("--map_object_cache_time is out of range! (should be >= 0.0)")
+        return None
 
     if len(config.raw_tasks) == 0:
         logging.error("No tasks are configured. Did you mean to configure some behaviors? Read https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Configuration-files#configuring-tasks for more information")

--- a/pokemongo_bot/cell_workers/catch_visible_pokemon.py
+++ b/pokemongo_bot/cell_workers/catch_visible_pokemon.py
@@ -21,7 +21,7 @@ class CatchVisiblePokemon(BaseTask):
                 with open(user_web_catchable, 'w') as outfile:
                     json.dump(pokemon, outfile)
 
-            return self.catch_pokemon(self.bot.cell['catchable_pokemons'][0])
+            return self.catch_pokemon(self.bot.cell['catchable_pokemons'].pop(0))
 
         if 'wild_pokemons' in self.bot.cell and len(self.bot.cell['wild_pokemons']) > 0:
             # Sort all by distance from current pos- eventually this should
@@ -29,7 +29,7 @@ class CatchVisiblePokemon(BaseTask):
             self.bot.cell['wild_pokemons'].sort(
                 key=
                 lambda x: distance(self.bot.position[0], self.bot.position[1], x['latitude'], x['longitude']))
-            return self.catch_pokemon(self.bot.cell['wild_pokemons'][0])
+            return self.catch_pokemon(self.bot.cell['wild_pokemons'].pop(0))
 
     def catch_pokemon(self, pokemon):
         worker = PokemonCatchWorker(pokemon, self.bot)


### PR DESCRIPTION
Short Description: 
This solve the Niantic "scan for pokemon" throttling without
making the bot very slow.

Fixes:
- Because we request meta cell data every tick, Niantic sometimes return an empty array for `catchable_pokemons` and `wild_pokemons`.
- Because `catchable_pokemons` and `wild_pokemons` sometime is empty, we can't catch pokemons. :(



