### PR TITLE
Added check for upper limit of catch_above_cp

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -332,11 +332,11 @@ class PokemonCatchWorker(object):
             catch_results['cp'] = True
 
         catch_iv = catch_config.get('catch_above_iv', 0)
-        if catch_iv > 1:
-            catch_iv = 0
         if iv > catch_iv:
             catch_results['iv'] = True
-
+        if catch_iv > 1:
+            logger.log("Max catch iv {} cannot be greater than 1".format(catch_iv),'red')
+            catch_results['iv'] = True
         logic_to_function = {
             'or': lambda x, y: x or y,
             'and': lambda x, y: x and y
@@ -400,9 +400,10 @@ class PokemonCatchWorker(object):
         if cp > catch_cp:
             catch_results['cp'] = True
         catch_iv = catch_config.get('catch_above_iv', 0)
-        if catch_iv > 1:
-            catch_iv = 0
         if iv > catch_iv:
+            catch_results['iv'] = True
+        if catch_iv > 1:
+            logger.log("Max catch iv {} cannot be greater than 1".format(catch_iv),'red')
             catch_results['iv'] = True
         logic_to_function = {
             'or': lambda x, y: x or y,

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -332,6 +332,8 @@ class PokemonCatchWorker(object):
             catch_results['cp'] = True
 
         catch_iv = catch_config.get('catch_above_iv', 0)
+        if catch_iv > 1:
+            catch_iv = 0
         if iv > catch_iv:
             catch_results['iv'] = True
 
@@ -398,6 +400,8 @@ class PokemonCatchWorker(object):
         if cp > catch_cp:
             catch_results['cp'] = True
         catch_iv = catch_config.get('catch_above_iv', 0)
+        if catch_iv > 1:
+            catch_iv = 0
         if iv > catch_iv:
             catch_results['iv'] = True
         logic_to_function = {
@@ -405,4 +409,3 @@ class PokemonCatchWorker(object):
             'and': lambda x, y: x and y
         }
         return logic_to_function[cp_iv_logic](*catch_results.values())
-

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -204,6 +204,10 @@ class TransferPokemon(BaseTask):
                 logger.log("Keep best can't be < 0. Ignore it.", "red")
                 keep_best = False
 
+            if keep_best_iv > 1:
+                logger.log("Keep best IV can't be > 1. Ignore it.", "red")
+                keep_best = False
+
             if keep_best_cp == 0 and keep_best_iv == 0:
                 keep_best = False
 

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -204,10 +204,6 @@ class TransferPokemon(BaseTask):
                 logger.log("Keep best can't be < 0. Ignore it.", "red")
                 keep_best = False
 
-            if keep_best_iv > 1:
-                logger.log("Keep best IV can't be > 1. Ignore it.", "red")
-                keep_best = False
-
             if keep_best_cp == 0 and keep_best_iv == 0:
                 keep_best = False
 


### PR DESCRIPTION
Short Description: 
If the config has a "catch_above_cp" greater than 1.0 the trainer will never catch anything.   If the value set is greater than 1, the default action should be to catch it
Fixes:
- catch_above_cp > 1 check

P.S. - Second pull request, my first one was garbage.

