### PR TITLE
Make SpinFort spin even when bag is full

### DIFF
--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -13,16 +13,10 @@ from utils import distance, format_time, fort_details
 
 
 class SpinFort(BaseTask):
-    def should_run(self):
-        if not self.bot.has_space_for_loot():
-            logger.log("Not spinning any forts as there aren't enough space. You might want to change your config to recycle more items if this message appears consistently.", 'yellow')
-            return False
-        return True
-
     def work(self):
         fort = self.get_fort_in_range()
 
-        if not self.should_run() or fort is None:
+        if fort is None:
             return WorkerResult.SUCCESS
 
         lat = fort['latitude']


### PR DESCRIPTION
Short Description: 
Spin fort reward XP
Fixes:
- #2180 


Remove space check before spinning.
Spin fort still usefull because it rewars XP (#2180)