### PR TITLE
Delay after printing the exchanged Pokemon but before exchanging, so …

### DIFF
--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -173,9 +173,9 @@ class TransferPokemon(BaseTask):
         logger.log('Exchanging {} [CP {}] [Potential {}] for candy!'.format(pokemon_name,
                                                                             cp,
                                                                             iv), 'green')
+        action_delay(self.bot.config.action_wait_min, self.bot.config.action_wait_max)
         self.bot.api.release_pokemon(pokemon_id=pokemon_id)
         response_dict = self.bot.api.call()
-        action_delay(self.bot.config.action_wait_min, self.bot.config.action_wait_max)
 
     def _get_release_config_for(self, pokemon):
         release_config = self.bot.config.release.get(pokemon)


### PR DESCRIPTION
Short Description: 
The bot currently prints an exchange message, then immediately exchanges, then waits for a few seconds. I changed it so it waits *before* releasing, instead of after, so someone has time to kill the bot if it's about to exchange a good pokemon.