### PR TITLE
Catch ServerBusyOrOfflineException and reconnect

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -35,7 +35,7 @@ import sys
 import time
 from datetime import timedelta
 from getpass import getpass
-from pgoapi.exceptions import NotLoggedInException
+from pgoapi.exceptions import NotLoggedInException, ServerBusyOrOfflineException
 
 from pokemongo_bot import PokemonGoBot, TreeConfigBuilder
 from pokemongo_bot import logger
@@ -73,7 +73,7 @@ def main():
             logger.log('Exiting PokemonGo Bot', 'red')
             finished = True
             report_summary(bot)
-        except NotLoggedInException:
+        except (NotLoggedInException, ServerBusyOrOfflineException):
             logger.log('[x] Error while connecting to the server, please wait %s minutes' % config.reconnecting_timeout, 'red')
             time.sleep(config.reconnecting_timeout * 60)
         except:


### PR DESCRIPTION
Short Description: 
The ApiWrapper raise ServerBusyOrOfflineException if you lose internet connection, or servers are busy. Why not use the `reconnecting_timeout` bit of code to retry logging


