### PR TITLE
fixed "keep_best" which didn't work alone anymore

### DIFF
--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -44,7 +44,8 @@ class TransferPokemon(BaseTask):
                     transfer_pokemons = [pokemon for pokemon in all_pokemons
                                          if self.should_release_pokemon(pokemon_name,
                                                                         pokemon['cp'],
-                                                                        pokemon['iv'])]
+                                                                        pokemon['iv'],
+                                                                        True)]
 
                     if transfer_pokemons:
                         logger.log("Keep {} best {}, based on {}".format(len(best_pokemons),
@@ -125,8 +126,16 @@ class TransferPokemon(BaseTask):
                 continue
         return round((total_iv / 45.0), 2)
 
-    def should_release_pokemon(self, pokemon_name, cp, iv):
+    def should_release_pokemon(self, pokemon_name, cp, iv, keep_best_mode = False):
         release_config = self._get_release_config_for(pokemon_name)
+
+        if (keep_best_mode
+            and not release_config.has_key('never_release')
+            and not release_config.has_key('always_release')
+            and not release_config.has_key('release_below_cp')
+            and not release_config.has_key('release_below_iv')):
+            return True
+
         cp_iv_logic = release_config.get('logic')
         if not cp_iv_logic:
             cp_iv_logic = self._get_release_config_for('any').get('logic', 'and')


### PR DESCRIPTION
#2073 broke "keep_best_iv" and "keep_best_cp" when those were used as the only rules (without any "release_below_*" or "*_release" rules).

This pull request fixes the situation so that "keep_best_iv" and "keep_best_cp" can still be used as standalone rules just like before.

tl;dr:
Those examples (which are still currently published on the example configs and wiki) could not work anymore because of #2073 : 

```
      "// Example of keeping 3 stronger (based on CP) Pidgey:": {},
      "// Pidgey": {"keep_best_cp": 3},
      "// Example of keeping 2 stronger (based on IV) Zubat:": {},
      "// Zubat": {"keep_best_iv": 2},
      "// Also, it is working with any": {},
      "// any": {"keep_best_iv": 3},
      "// Example of keeping the 2 strongest (based on CP) and 3 best (based on IV) Zubat:": {},
      "// Zubat": {"keep_best_cp": 2, "keep_best_iv": 3}
```

This pull request makes them work again.