### PR TITLE
release logic fix

### DIFF
--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -41,7 +41,14 @@ class TransferPokemon(BaseTask):
                                 all_pokemons.remove(pokemon)
                                 best_pokemons.append(pokemon)
 
-                    transfer_pokemons = [pokemon for pokemon in all_pokemons
+                    transfer_pokemons = []
+                    release_config = self._get_release_config_for(pokemon_name)
+                    release_always = release_config.get('release_always',False)
+                    never_release = release_config.get('never_release',False)
+                    if not (release_always or never_release):
+                        transfer_pokemons = all_pokemons
+                    else:
+                        transfer_pokemons = [pokemon for pokemon in all_pokemons
                                          if self.should_release_pokemon(pokemon_name,
                                                                         pokemon['cp'],
                                                                         pokemon['iv'])]


### PR DESCRIPTION
Short Description: 
Release logic was changed in `keep_best` branch to also process `release_under` config rules. However, many users using `keep_best` logic forgo these rules, so it was keeping all pokemon instead of releasing as it should have. This fix addresses that issue by allowing users _with_ `release_under` rules to have that logic processed, while other users can continue to have existing behavior for `keep_best` rules.
Fixes:
- Pokemon not releasing when only `keep_best` logic in release section


