### PR TITLE
Dev - Fixed the loss of fort data

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,3 +46,4 @@
  * kbinani
  * MFizz
  * NamPNQ
+ * matheussampaio

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -58,6 +58,7 @@
         "type": "FollowSpiral"
       }
     ],
+    "map_object_cache_time": 5,
     "max_steps": 5,
     "forts": {
       "avoid_circles": true,

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -59,6 +59,7 @@
         }
       }
     ],
+    "map_object_cache_time": 5,
     "max_steps": 5,
     "forts": {
       "avoid_circles": true,

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -58,6 +58,7 @@
         "type": "FollowSpiral"
       }
     ],
+    "map_object_cache_time": 5,
     "max_steps": 5,
     "forts": {
       "avoid_circles": true,

--- a/pokecli.py
+++ b/pokecli.py
@@ -324,6 +324,14 @@ def init_config():
         type=float,
         default=1.0
     )
+    add_config(
+        parser,
+        load,
+        long_flag="--map_object_cache_time",
+        help="Amount of seconds to keep the map object in cache (bypass Niantic throttling)",
+        type=float,
+        default=5.0
+    )
 
     # Start to parse other attrs
     config = parser.parse_args()
@@ -338,6 +346,10 @@ def init_config():
     config.action_wait_min = load.get('action_wait_min', 1)
     config.raw_tasks = load.get('tasks', [])
     config.vips = load.get('vips',{})
+
+    if config.map_object_cache_time < 0.0:
+        parser.error("--map_object_cache_time is out of range! (should be >= 0.0)")
+        return None
 
     if len(config.raw_tasks) == 0:
         logging.error("No tasks are configured. Did you mean to configure some behaviors? Read https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Configuration-files#configuring-tasks for more information")

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -94,19 +94,30 @@ class PokemonGoBot(object):
         forts = []
         wild_pokemons = []
         catchable_pokemons = []
+        fortspresent = False
         for cell in cells:
             if "forts" in cell and len(cell["forts"]):
+                fortspresent = True
                 forts += cell["forts"]
             if "wild_pokemons" in cell and len(cell["wild_pokemons"]):
                 wild_pokemons += cell["wild_pokemons"]
             if "catchable_pokemons" in cell and len(cell["catchable_pokemons"]):
                 catchable_pokemons += cell["catchable_pokemons"]
 
-        return {
-            "forts": forts,
-            "wild_pokemons": wild_pokemons,
-            "catchable_pokemons": catchable_pokemons
-        }
+        # If there are forts present in the cells sent from the server or we don't yet have any cell data, return all data retrieved
+        if fortspresent or not self.cell:
+            return {
+                "forts": forts,
+                "wild_pokemons": wild_pokemons,
+                "catchable_pokemons": catchable_pokemons
+            }
+        # If there are no forts present in the data from the server, keep our existing fort data and only update the pokemon cells.
+        else:
+            return {
+                "forts": self.cell["forts"],
+                "wild_pokemons": wild_pokemons,
+                "catchable_pokemons": catchable_pokemons
+            }
 
     def update_web_location(self, cells=[], lat=None, lng=None, alt=None):
         # we can call the function with no arguments and still get the position
@@ -119,20 +130,8 @@ class PokemonGoBot(object):
             alt = 0
 
         if cells == []:
-            cellid = get_cell_ids(lat, lng)
-            timestamp = [0, ] * len(cellid)
-            self.api.get_map_objects(
-                latitude=f2i(lat),
-                longitude=f2i(lng),
-                since_timestamp_ms=timestamp,
-                cell_id=cellid
-            )
-            response_dict = self.api.call()
-            map_objects = response_dict.get(
-                'responses', {}
-            ).get('GET_MAP_OBJECTS', {})
-            status = map_objects.get('status', None)
-            cells = map_objects['map_cells']
+            location = self.position[0:2]
+            cells = self.find_close_cells(*location)
 
             # insert detail info about gym to fort
             for cell in cells:

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -46,6 +46,8 @@ class PokemonGoBot(object):
         self.tick_count = 0
         self.softban = False
         self.start_position = None
+        self.last_map_object = None
+        self.last_time_map_object = 0
 
         # Make our own copy of the workers for this instance
         self.workers = []
@@ -132,7 +134,6 @@ class PokemonGoBot(object):
         if cells == []:
             location = self.position[0:2]
             cells = self.find_close_cells(*location)
-
             # insert detail info about gym to fort
             for cell in cells:
                 if 'forts' in cell:
@@ -181,14 +182,7 @@ class PokemonGoBot(object):
     def find_close_cells(self, lat, lng):
         cellid = get_cell_ids(lat, lng)
         timestamp = [0, ] * len(cellid)
-
-        self.api.get_map_objects(
-            latitude=f2i(lat),
-            longitude=f2i(lng),
-            since_timestamp_ms=timestamp,
-            cell_id=cellid
-        )
-        response_dict = self.api.call()
+        response_dict = self.get_map_objects(lat, lng, timestamp, cellid)
         map_objects = response_dict.get(
             'responses', {}
         ).get('GET_MAP_OBJECTS', {})
@@ -624,3 +618,19 @@ class PokemonGoBot(object):
             ))
 
         return forts
+
+    def get_map_objects(self, lat, lng, timestamp, cellid):
+        if time.time() - self.last_time_map_object < self.config.map_object_cache_time:
+            return self.last_map_object
+
+        self.api.get_map_objects(
+            latitude=f2i(lat),
+            longitude=f2i(lng),
+            since_timestamp_ms=timestamp,
+            cell_id=cellid
+        )
+
+        self.last_map_object = self.api.call()
+        self.last_time_map_object = time.time()
+
+        return self.last_map_object

--- a/pokemongo_bot/cell_workers/catch_lured_pokemon.py
+++ b/pokemongo_bot/cell_workers/catch_lured_pokemon.py
@@ -24,7 +24,7 @@ class CatchLuredPokemon(BaseTask):
         encounter_id = fort.get('lure_info', {}).get('encounter_id', None)
 
         if encounter_id:
-            logger.log('Lured pokemon at fort {}'.format(fort['id']))
+            logger.log('Lured pokemon at fort {}'.format(fort_name))
             return {
                 'encounter_id': encounter_id,
                 'fort_id': fort['id'],

--- a/pokemongo_bot/cell_workers/catch_visible_pokemon.py
+++ b/pokemongo_bot/cell_workers/catch_visible_pokemon.py
@@ -21,7 +21,7 @@ class CatchVisiblePokemon(BaseTask):
                 with open(user_web_catchable, 'w') as outfile:
                     json.dump(pokemon, outfile)
 
-            return self.catch_pokemon(self.bot.cell['catchable_pokemons'][0])
+            return self.catch_pokemon(self.bot.cell['catchable_pokemons'].pop(0))
 
         if 'wild_pokemons' in self.bot.cell and len(self.bot.cell['wild_pokemons']) > 0:
             # Sort all by distance from current pos- eventually this should
@@ -29,7 +29,7 @@ class CatchVisiblePokemon(BaseTask):
             self.bot.cell['wild_pokemons'].sort(
                 key=
                 lambda x: distance(self.bot.position[0], self.bot.position[1], x['latitude'], x['longitude']))
-            return self.catch_pokemon(self.bot.cell['wild_pokemons'][0])
+            return self.catch_pokemon(self.bot.cell['wild_pokemons'].pop(0))
 
     def catch_pokemon(self, pokemon):
         worker = PokemonCatchWorker(pokemon, self.bot)

--- a/pokemongo_bot/cell_workers/follow_cluster.py
+++ b/pokemongo_bot/cell_workers/follow_cluster.py
@@ -42,7 +42,7 @@ class FollowCluster(object):
 
                 log_str = log_lure_avail_str + 'Move to destiny. ' + str(cnt) + ' ' + log_lured_str + \
                           'pokestops will be in range of ' + str(self.radius) + 'm. Arrive in ' \
-                          + str(round(distance(self.bot.position[0], self.bot.position[1], lat, lng))) + 'm.'
+                          + str(distance(self.bot.position[0], self.bot.position[1], lat, lng)) + 'm.'
                 logger.log(log_str)
                 self.announced = False
 

--- a/pokemongo_bot/cell_workers/follow_cluster.py
+++ b/pokemongo_bot/cell_workers/follow_cluster.py
@@ -42,7 +42,7 @@ class FollowCluster(object):
 
                 log_str = log_lure_avail_str + 'Move to destiny. ' + str(cnt) + ' ' + log_lured_str + \
                           'pokestops will be in range of ' + str(self.radius) + 'm. Arrive in ' \
-                          + str(distance(self.bot.position[0], self.bot.position[1], lat, lng)) + 'm.'
+                          + str(round(distance(self.bot.position[0], self.bot.position[1], lat, lng))) + 'm.'
                 logger.log(log_str)
                 self.announced = False
 


### PR DESCRIPTION
Short Description:  This fixes loss of fort data when the server returns no fort data. 

It seems like the server is saving cycles/bandwidth by only returning fort data when there has been a change to forts in your cells. When it returns no forts, we currently replace our existing data with the empty data.  This fixes that so we keep our fort data if the server returned no fort data.  Wild/lured pokemon are still updated in any case.

Fixes:
- If the server returns no fort data in the cell data, keep our existing fort data. (Web location data is still going to lose fort data, but the bot itself won't)
- I removed duplicate code
- Edited cluster log function to round to nearest meter

Known related Issues:
-https://github.com/PokemonGoF/PokemonGo-Bot/issues/2184

