### PR TITLE
[Feature] added keep pokemon for batch evolution

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -94,6 +94,11 @@
       "// any": {"keep_best_iv": 3},
       "// Example of keeping the 2 strongest (based on CP) and 3 best (based on IV) Zubat:": {},
       "// Zubat": {"keep_best_cp": 2, "keep_best_iv": 3}
+      "// Example of keeping as many Zubat as you have candy to evolve,
+      "// Zubat": {"keep_for_evo": true}
+      "// Example of keeping the 2 strongest (based on CP) and 3 best (based on IV) Zubat and on top as many Zubat
+      as you have candy to evolve:": {},
+      "// Zubat": {"keep_best_cp": 2, "keep_best_iv": 3, "keep_for_evo": true}
     },
     "vips" : {
          "Any pokemon put here directly force to use Berry & Best Ball to capture, to secure the capture rate!": {},

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -94,6 +94,11 @@
       "// any": {"keep_best_iv": 3},
       "// Example of keeping the 2 strongest (based on CP) and 3 best (based on IV) Zubat:": {},
       "// Zubat": {"keep_best_cp": 2, "keep_best_iv": 3}
+      "// Example of keeping as many Zubat as you have candy to evolve,
+      "// Zubat": {"keep_for_evo": true}
+      "// Example of keeping the 2 strongest (based on CP) and 3 best (based on IV) Zubat and on top as many Zubat
+      as you have candy to evolve:": {},
+      "// Zubat": {"keep_best_cp": 2, "keep_best_iv": 3, "keep_for_evo": true}
     },
     "vips" : {
          "Any pokemon put here directly force to use Berry & Best Ball to capture, to secure the capture rate!": {},

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -82,6 +82,11 @@
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},
       "// Rattata": { "always_catch" : true }
+      "// Example of keeping as many Zubat as you have candy to evolve,
+      "// Zubat": {"keep_for_evo": true}
+      "// Example of keeping the 2 strongest (based on CP) and 3 best (based on IV) Zubat and on top as many Zubat
+      as you have candy to evolve:": {},
+      "// Zubat": {"keep_best_cp": 2, "keep_best_iv": 3, "keep_for_evo": true}
     },
     "release": {
       "any": {"release_below_cp": 0, "release_below_iv": 0, "logic": "or"},

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -9,6 +9,7 @@ class TransferPokemon(BaseTask):
     def work(self):
         pokemon_groups = self._release_pokemon_get_groups()
         candies = self._get_candies()
+        evolvable = 0
         for pokemon_id in pokemon_groups:
             group = pokemon_groups[pokemon_id]
 
@@ -82,6 +83,7 @@ class TransferPokemon(BaseTask):
                             evo_pokemon = group
                             group = []
 
+                        evolvable += len(evo_pokemon)
                         if len(evo_pokemon) > 0:
                             logger.log("Keep {} {}, for evolution - {} candies".format(len(evo_pokemon),
                                                                              pokemon_name, candy), "green")
@@ -94,6 +96,9 @@ class TransferPokemon(BaseTask):
 
                 for pokemon in group:
                     self.release_pokemon(pokemon_name, pokemon['cp'], pokemon['iv'], pokemon['pokemon_data']['id'])
+
+        logger.log("{} pokemon transferred total. {} evolutions ready (based on pokemons additional to the ones kept"
+                   " with cp/iv criteria)".format(len(group), evolvable), "green")
 
     def _release_pokemon_get_groups(self):
         pokemon_groups = {}

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -70,24 +70,25 @@ class TransferPokemon(BaseTask):
                         logger.log("Api call for candies failed, try again")
                         return
                     candy = candies[pokemon_id]
-                    req_candy = self.bot.pokemon_list[pokemon_id - 1]['Next Evolution Requirements']['Amount']
-                    num_keep = (len(group) + candy) / (req_candy + 1)
+                    if 'Next Evolution Requirements' in self.bot.pokemon_list[pokemon_id - 1]:
+                        req_candy = self.bot.pokemon_list[pokemon_id - 1]['Next Evolution Requirements']['Amount']
+                        num_keep = (len(group) + candy) / (req_candy + 1)
 
-                    if len(group) > num_keep:
-                        group.sort(key=lambda x: x['iv'], reverse=True)
-                        evo_pokemon = group[:num_keep]
-                        group = group[num_keep:]
-                    else:
-                        evo_pokemon = group
-                        group = []
+                        if len(group) > num_keep:
+                            group.sort(key=lambda x: x['iv'], reverse=True)
+                            evo_pokemon = group[:num_keep]
+                            group = group[num_keep:]
+                        else:
+                            evo_pokemon = group
+                            group = []
 
-                    if len(evo_pokemon) > 0:
-                        logger.log("Keep {} {}, for evolution - {} candies".format(len(evo_pokemon),
-                                                                         pokemon_name, candy), "green")
-                        for evo_pokemon in evo_pokemon:
-                            logger.log("{} [CP {}] [Potential {}]".format(pokemon_name,
-                                                                          evo_pokemon['cp'],
-                                                                          evo_pokemon['iv']), 'green')
+                        if len(evo_pokemon) > 0:
+                            logger.log("Keep {} {}, for evolution - {} candies".format(len(evo_pokemon),
+                                                                             pokemon_name, candy), "green")
+                            for evo_pokemon in evo_pokemon:
+                                logger.log("{} [CP {}] [Potential {}]".format(pokemon_name,
+                                                                              evo_pokemon['cp'],
+                                                                              evo_pokemon['iv']), 'green')
 
                 logger.log("Transferring {} pokemon".format(len(group)), "green")
 

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -4,15 +4,17 @@ from pokemongo_bot import logger
 from pokemongo_bot.human_behaviour import action_delay
 from pokemongo_bot.cell_workers.base_task import BaseTask
 
+
 class TransferPokemon(BaseTask):
     def work(self):
         pokemon_groups = self._release_pokemon_get_groups()
+        candies = self._get_candies()
         for pokemon_id in pokemon_groups:
             group = pokemon_groups[pokemon_id]
 
             if len(group) > 0:
                 pokemon_name = self.bot.pokemon_list[pokemon_id - 1]['Name']
-                keep_best, keep_best_cp, keep_best_iv = self._validate_keep_best_config(pokemon_name)
+                keep_best, keep_best_cp, keep_best_iv, keep_for_evo = self._validate_keep_best_config(pokemon_name)
 
                 if keep_best:
                     best_pokemon_ids = set()
@@ -33,41 +35,64 @@ class TransferPokemon(BaseTask):
                             order_criteria = 'iv'
 
                     # remove best pokemons from all pokemons array
-                    all_pokemons = group
-                    best_pokemons = []
+                    best_pokemon = []
                     for best_pokemon_id in best_pokemon_ids:
-                        for pokemon in all_pokemons:
+                        for pokemon in group:
                             if best_pokemon_id == pokemon['pokemon_data']['id']:
-                                all_pokemons.remove(pokemon)
-                                best_pokemons.append(pokemon)
+                                group.remove(pokemon)
+                                best_pokemon.append(pokemon)
 
-                    transfer_pokemons = [pokemon for pokemon in all_pokemons
-                                         if self.should_release_pokemon(pokemon_name,
-                                                                        pokemon['cp'],
-                                                                        pokemon['iv'],
-                                                                        True)]
-
-                    if transfer_pokemons:
-                        logger.log("Keep {} best {}, based on {}".format(len(best_pokemons),
+                    if len(best_pokemon) > 0:
+                        logger.log("Keep {} best {}, based on {}".format(len(best_pokemon),
                                                                          pokemon_name,
                                                                          order_criteria), "green")
-                        for best_pokemon in best_pokemons:
+                        for best_pokemon in best_pokemon:
                             logger.log("{} [CP {}] [Potential {}]".format(pokemon_name,
                                                                           best_pokemon['cp'],
                                                                           best_pokemon['iv']), 'green')
 
-                        logger.log("Transferring {} pokemon".format(len(transfer_pokemons)), "green")
+                high_pokemon = []
+                for pokemon in group:
+                    if self.should_release_pokemon(pokemon_name, pokemon['cp'], pokemon['iv']):
+                        group.remove(pokemon)
+                        high_pokemon.append(pokemon)
+                if len(high_pokemon) > 0:
+                    logger.log("Keep {} {}, based on cp/iv criteria".format(len(high_pokemon),
+                                                                            pokemon_name), "green")
+                    for high_pokemon in high_pokemon:
+                        logger.log("{} [CP {}] [Potential {}]".format(pokemon_name,
+                                                                      high_pokemon['cp'],
+                                                                      high_pokemon['iv']), 'green')
 
-                        for pokemon in transfer_pokemons:
-                            self.release_pokemon(pokemon_name, pokemon['cp'], pokemon['iv'], pokemon['pokemon_data']['id'])
-                else:
-                    group = sorted(group, key=lambda x: x['cp'], reverse=True)
-                    for item in group:
-                        pokemon_cp = item['cp']
-                        pokemon_potential = item['iv']
+                if keep_for_evo and len(group) > 0:
 
-                        if self.should_release_pokemon(pokemon_name, pokemon_cp, pokemon_potential):
-                            self.release_pokemon(pokemon_name, item['cp'], item['iv'], item['pokemon_data']['id'])
+                    if candies == {}:
+                        logger.log("Api call for candies failed, try again")
+                        return
+                    candy = candies[pokemon_id]
+                    req_candy = self.bot.pokemon_list[pokemon_id - 1]['Next Evolution Requirements']['Amount']
+                    num_keep = (len(group) + candy) / (req_candy + 1)
+
+                    if len(group) > num_keep:
+                        group.sort(key=lambda x: x['iv'], reverse=True)
+                        evo_pokemon = group[:num_keep]
+                        group = group[num_keep:]
+                    else:
+                        evo_pokemon = group
+                        group = []
+
+                    if len(evo_pokemon) > 0:
+                        logger.log("Keep {} {}, for evolution - {} candies".format(len(evo_pokemon),
+                                                                         pokemon_name, candy), "green")
+                        for evo_pokemon in evo_pokemon:
+                            logger.log("{} [CP {}] [Potential {}]".format(pokemon_name,
+                                                                          evo_pokemon['cp'],
+                                                                          evo_pokemon['iv']), 'green')
+
+                logger.log("Transferring {} pokemon".format(len(group)), "green")
+
+                for pokemon in group:
+                    self.release_pokemon(pokemon_name, pokemon['cp'], pokemon['iv'], pokemon['pokemon_data']['id'])
 
     def _release_pokemon_get_groups(self):
         pokemon_groups = {}
@@ -126,15 +151,16 @@ class TransferPokemon(BaseTask):
                 continue
         return round((total_iv / 45.0), 2)
 
-    def should_release_pokemon(self, pokemon_name, cp, iv, keep_best_mode = False):
+    def should_release_pokemon(self, pokemon_name, cp, iv):
         release_config = self._get_release_config_for(pokemon_name)
 
-        if (keep_best_mode
-            and not release_config.has_key('never_release')
-            and not release_config.has_key('always_release')
-            and not release_config.has_key('release_below_cp')
-            and not release_config.has_key('release_below_iv')):
-            return True
+        release_strings = ['never_release', 'always_release', 'release_below_cp', 'release_below_iv']
+        keep_strings = ['keep_best_cp', 'keep_best_iv']
+        if not any(x in release_config for x in release_strings):
+            if any(x in release_config for x in keep_strings):
+                return True
+            else:
+                return False
 
         cp_iv_logic = release_config.get('logic')
         if not cp_iv_logic:
@@ -201,6 +227,7 @@ class TransferPokemon(BaseTask):
 
         keep_best_cp = release_config.get('keep_best_cp', 0)
         keep_best_iv = release_config.get('keep_best_iv', 0)
+        keep_for_evo = release_config.get('keep_for_evo', False)
 
         if keep_best_cp or keep_best_iv:
             keep_best = True
@@ -221,4 +248,14 @@ class TransferPokemon(BaseTask):
             if keep_best_cp == 0 and keep_best_iv == 0:
                 keep_best = False
 
-        return keep_best, keep_best_cp, keep_best_iv
+        return keep_best, keep_best_cp, keep_best_iv, keep_for_evo
+
+    def _get_candies(self):
+        response_dict = self.bot.get_inventory()
+        inv = response_dict.get("responses", {}).get("GET_INVENTORY", {}).get("inventory_delta").get("inventory_items")
+        candies = {}
+        for item in inv:
+            candy = item.get("inventory_item_data", {}).get("candy", {})
+            if candy != {}:
+                candies[candy['family_id']] = candy['candy']
+        return candies

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -67,6 +67,11 @@ class TransferPokemon(BaseTask):
                                                                       high_pokemon['iv']), 'green')
 
                 if keep_for_evo and len(group) > 0:
+                    if 'Previous evolution(s)' in self.bot.pokemon_list[pokemon_id - 1]:
+                        logger.log(
+                            '{} has previous evolution stages. This focuses on 1st stage because they use less '
+                            'candy'.format(pokemon_name), 'red')
+                        continue
 
                     if candies == {}:
                         logger.log("Api call for candies failed, try again")
@@ -87,7 +92,7 @@ class TransferPokemon(BaseTask):
                         evolvable += len(evo_pokemon)
                         if len(evo_pokemon) > 0:
                             logger.log("Keep {} {}, for evolution - {} candies".format(len(evo_pokemon),
-                                                                             pokemon_name, candy), "green")
+                                                                                       pokemon_name, candy), "green")
                             for evo_pokemon in evo_pokemon:
                                 logger.log("{} [CP {}] [Potential {}]".format(pokemon_name,
                                                                               evo_pokemon['cp'],

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -90,7 +90,7 @@ class TransferPokemon(BaseTask):
                                                                               evo_pokemon['cp'],
                                                                               evo_pokemon['iv']), 'green')
 
-                logger.log("Transferring {} pokemon".format(len(group)), "green")
+                logger.log("Transferring {} {}".format(len(group), pokemon_name), "green")
 
                 for pokemon in group:
                     self.release_pokemon(pokemon_name, pokemon['cp'], pokemon['iv'], pokemon['pokemon_data']['id'])

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -3,12 +3,13 @@ import json
 from pokemongo_bot import logger
 from pokemongo_bot.human_behaviour import action_delay
 from pokemongo_bot.cell_workers.base_task import BaseTask
+from pokemongo_bot.cell_workers.utils import get_candies
 
 
 class TransferPokemon(BaseTask):
     def work(self):
         pokemon_groups = self._release_pokemon_get_groups()
-        candies = self._get_candies()
+        candies = get_candies(self.bot)
         evolvable = 0
         for pokemon_id in pokemon_groups:
             group = pokemon_groups[pokemon_id]
@@ -255,13 +256,3 @@ class TransferPokemon(BaseTask):
                 keep_best = False
 
         return keep_best, keep_best_cp, keep_best_iv, keep_for_evo
-
-    def _get_candies(self):
-        response_dict = self.bot.get_inventory()
-        inv = response_dict.get("responses", {}).get("GET_INVENTORY", {}).get("inventory_delta").get("inventory_items")
-        candies = {}
-        for item in inv:
-            candy = item.get("inventory_item_data", {}).get("candy", {})
-            if candy != {}:
-                candies[candy['family_id']] = candy['candy']
-        return candies

--- a/pokemongo_bot/cell_workers/utils.py
+++ b/pokemongo_bot/cell_workers/utils.py
@@ -234,3 +234,14 @@ def find_biggest_cluster(radius, points, order=None):
         return {'latitude': best_coord[0], 'longitude': best_coord[1], 'num_points': len(max_clique)}
     else:
         return None
+
+
+def get_candies(bot):
+        response_dict = bot.get_inventory()
+        inv = response_dict.get("responses", {}).get("GET_INVENTORY", {}).get("inventory_delta").get("inventory_items")
+        candies = {}
+        for item in inv:
+            candy = item.get("inventory_item_data", {}).get("candy", {})
+            if candy != {}:
+                candies[candy['family_id']] = candy['candy']
+        return candies


### PR DESCRIPTION
Short Description: 
After all keep/release configs are processed, the remaining pokemon are released on how many evolutions a currently possible. E.g, if you have additional 12 squirtles (to the ones you would keep normally) and 72 squirtle candies, you release 9 and keep 3, because you can evolve 3 (25 candies required). 

Fixes:
#1973
#1972
#1528

Please help me with testing this, since there are many moving parts and release is crucial.


