### PR TITLE
[Dev] Printing Catched pokemon list before exit

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -107,6 +107,43 @@ def report_summary(bot):
         logger.log('Highest CP Pokemon: {}'.format(metrics.highest_cp['desc']), 'cyan')
     if metrics.most_perfect is not None:
         logger.log('Most Perfect Pokemon: {}'.format(metrics.most_perfect['desc']), 'cyan')
+    if bot.config.print_catches:
+        print_catches(bot)
+
+def print_catches(bot):
+    logger.log('{:>45}'.format('List of captured pokemon'), 'white')
+    table_border = '-'*66
+    logger.log(table_border, 'white')
+    inner_border = '+{}+{}+{}+{}+{}+'.format(
+        '-'*20,
+        '-'*10,
+        '-'*10,
+        '-'*10,
+        '-'*10
+    )
+    logger.log(inner_border, 'white')
+    logger.log('|{}|{}|{}|{}|{}|'.format(
+        '{:<20}'.format('Pokemon name'),
+        '{:>10}'.format('CP'),
+        '{:>10}'.format('Potential'),
+        '{:>10}'.format('IV Display'),
+        '{:>10}'.format('Earned XP')
+    ), 'white')
+    logger.log(inner_border, 'white')
+    k=0
+    for catched_pokemon in bot.metrics.catches:
+        logger.log('|{}|{}|{}|{}|{} Exp|'.format(
+            '{:<20}'.format(catched_pokemon['pokemon_name']),
+            '{:>10}'.format(catched_pokemon['cp']),
+            '{:>10}'.format(catched_pokemon['pokemon_potential']),
+            '{:>10}'.format(catched_pokemon['iv_display']),
+            '{:6}'.format(catched_pokemon['xp'])
+        ), 'white')
+        k = (k + 1) % 5
+        if k == 0:
+            logger.log(inner_border, 'white')
+    if k != 0:
+        logger.log(table_border, 'white')
 
 def init_config():
     parser = argparse.ArgumentParser()
@@ -331,6 +368,15 @@ def init_config():
         help="Amount of seconds to keep the map object in cache (bypass Niantic throttling)",
         type=float,
         default=5.0
+    )
+    add_config(
+        parser,
+        load,
+        short_flag="-print_c",
+        long_flag="--print_catches",
+        help="Print captured pokemon before exit",
+        type=bool,
+        default=False
     )
 
     # Start to parse other attrs

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -233,15 +233,17 @@ class PokemonCatchWorker(object):
                                         self.softban = True
                                 if status is 1:
                                     self.bot.metrics.captured_pokemon(pokemon_name, cp, iv_display, pokemon_potential)
+                                    xp = sum(response_dict['responses']['CATCH_POKEMON']['capture_award']['xp'])
 
                                     logger.log('Captured {}! [CP {}] [Potential {}] [{}] [+{} exp]'.format(
                                         pokemon_name,
                                         cp,
                                         pokemon_potential,
                                         iv_display,
-                                        sum(response_dict['responses']['CATCH_POKEMON']['capture_award']['xp'])
+                                        xp
                                     ), 'blue')
                                     self.bot.softban = False
+                                    evolved = False
 
                                     if (self.config.evolve_captured
                                         and (self.config.evolve_captured[0] == 'all'
@@ -260,9 +262,11 @@ class PokemonCatchWorker(object):
                                         if status == 1:
                                             logger.log(
                                                 '{} has been evolved!'.format(pokemon_name), 'green')
+                                            evolved = True
                                         else:
                                             logger.log(
                                                 'Failed to evolve {}!'.format(pokemon_name))
+                                    self.bot.metrics.catches.append({'pokemon_name': pokemon_name, 'cp': cp, 'pokemon_potential': pokemon_potential, 'iv_display': iv_display, 'xp': xp, 'evolved': evolved})
                             break
         time.sleep(5)
 

--- a/pokemongo_bot/logger.py
+++ b/pokemongo_bot/logger.py
@@ -10,13 +10,15 @@ except Exception:
     lcd = False
 
 
-def log(string, color='white'):
+def log(string, color='none'):
     color_hex = {
         'red': '91m',
         'green': '92m',
         'yellow': '93m',
         'blue': '94m',
-        'cyan': '96m'
+        'purple': '95m',
+        'cyan': '96m',
+        'white': '97m'
     }
     if color not in color_hex:
         print('[{time}] {string}'.format(

--- a/pokemongo_bot/metrics.py
+++ b/pokemongo_bot/metrics.py
@@ -16,6 +16,7 @@ class Metrics(object):
         self.visits = {'start': None, 'latest': None}
         self.unique_mons = {'start': None, 'latest': None}
         self.evolutions = {'start': None, 'latest': None}
+        self.catches = list()
 
         self.releases = 0
         self.highest_cp = {'cp': 0, 'desc': ''}


### PR DESCRIPTION
Short Description: 
By adding `"print_catches": true` to config.json, a table listing all the catched pokemon during session will be printed after bot closes
![sample iamge](https://cloud.githubusercontent.com/assets/8875681/17306369/1b7ee7a4-5830-11e6-9720-4a5bbc84f0c0.png)

Fixes:
- 
- 
- 

