### PR TITLE
Dev - Fixed the loss of fort data (updated)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -47,3 +47,4 @@
  * MFizz
  * NamPNQ
  * matheussampaio
+ * Abraxas000

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -105,7 +105,7 @@ class PokemonGoBot(object):
                 catchable_pokemons += cell["catchable_pokemons"]
         
         # If there are forts present in the cells sent from the server or we don't yet have any cell data, return all data retrieved
-        if len(forts) or not self.cell:
+        if len(forts) > 1 or not self.cell:
             return {
                 "forts": forts,
                 "wild_pokemons": wild_pokemons,

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -103,12 +103,21 @@ class PokemonGoBot(object):
                 wild_pokemons += cell["wild_pokemons"]
             if "catchable_pokemons" in cell and len(cell["catchable_pokemons"]):
                 catchable_pokemons += cell["catchable_pokemons"]
-
-        return {
-            "forts": forts,
-            "wild_pokemons": wild_pokemons,
-            "catchable_pokemons": catchable_pokemons
-        }
+        
+        # If there are forts present in the cells sent from the server or we don't yet have any cell data, return all data retrieved
+        if len(forts) or not self.cell:
+            return {
+                "forts": forts,
+                "wild_pokemons": wild_pokemons,
+                "catchable_pokemons": catchable_pokemons
+            }
+        # If there are no forts present in the data from the server, keep our existing fort data and only update the pokemon cells.
+        else:
+            return {
+                "forts": self.cell["forts"],
+                "wild_pokemons": wild_pokemons,
+                "catchable_pokemons": catchable_pokemons
+            }
 
     def update_web_location(self, cells=[], lat=None, lng=None, alt=None):
         # we can call the function with no arguments and still get the position
@@ -121,14 +130,8 @@ class PokemonGoBot(object):
             alt = 0
 
         if cells == []:
-            cellid = get_cell_ids(lat, lng)
-            timestamp = [0, ] * len(cellid)
-            response_dict = self.get_map_objects(lat, lng, timestamp, cellid)
-            map_objects = response_dict.get(
-                'responses', {}
-            ).get('GET_MAP_OBJECTS', {})
-            status = map_objects.get('status', None)
-            cells = map_objects['map_cells']
+            location = self.position[0:2]
+            cells = self.find_close_cells(*location)
 
             # insert detail info about gym to fort
             for cell in cells:


### PR DESCRIPTION


Short Description: This fixes loss of fort data when the server returns no fort data.

It seems like the server is saving cycles/bandwidth by only returning fort data when there has been a change to forts in your cells. When it returns no forts, we currently replace our existing data with the empty data. This fixes that so we keep our fort data if the server returned no fort data. Wild/lured pokemon are still updated in any case.

Fixes:
- If the server returns no fort data in the cell data, keep our existing fort data. (Web location data is still going to lose fort data, but the bot itself won't)
- I removed duplicate code

Known related Issues:
-https://github.com/PokemonGoF/PokemonGo-Bot/issues/2184