### PR TITLE
Add missing curly bracket

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -56,6 +56,7 @@
         "config": {
             "lure_attraction": true,
             "lure_max_distance": 2000
+        }
       },
       {
         "type": "FollowSpiral"


### PR DESCRIPTION
Short Description: 

Fixes:
- Missing curly bracket in config.json.example, causing issue #2280
- 
- 


Added missing curly bracket to tasks>MoveToFort>config