### PR TITLE
Replace fort with Pokestop in log output

### DIFF
--- a/pokemongo_bot/cell_workers/move_to_fort.py
+++ b/pokemongo_bot/cell_workers/move_to_fort.py
@@ -38,7 +38,7 @@ class MoveToFort(BaseTask):
         )
 
         if dist > Constants.MAX_DISTANCE_FORT_IS_REACHABLE:
-            logger.log('Moving towards fort {}, {} left'.format(fort_name, format_dist(dist, unit)))
+            logger.log('Moving towards Pokestop {}, {} left'.format(fort_name, format_dist(dist, unit)))
 
             step_walker = StepWalker(
                 self.bot,


### PR DESCRIPTION
We shouldn't call them forts anywhere really.