### PR TITLE
Fix instance where evolve_all is unicode - fixes #2281

### DIFF
--- a/pokemongo_bot/cell_workers/evolve_all.py
+++ b/pokemongo_bot/cell_workers/evolve_all.py
@@ -12,7 +12,7 @@ class EvolveAll(BaseTask):
         self._validate_config()
 
     def _validate_config(self):
-        if isinstance(self.evolve_all, str) or isinstance(self.evolve_all, unicode):
+        if isinstance(self.evolve_all, basestring):
             self.evolve_all = [str(pokemon_name) for pokemon_name in self.evolve_all.split(',')]
 
     def work(self):

--- a/pokemongo_bot/cell_workers/evolve_all.py
+++ b/pokemongo_bot/cell_workers/evolve_all.py
@@ -9,9 +9,10 @@ class EvolveAll(BaseTask):
         self.evolve_speed = self.config.get('evolve_speed', 3.7)
         self.evolve_cp_min = self.config.get('evolve_cp_min', 300)
         self.use_lucky_egg = self.config.get('use_lucky_egg', False)
+        self._validate_config()
 
     def _validate_config(self):
-        if isinstance(self.evolve_all, str):
+        if isinstance(self.evolve_all, str) or isinstance(self.evolve_all, unicode):
             self.evolve_all = [str(pokemon_name) for pokemon_name in self.evolve_all.split(',')]
 
     def work(self):


### PR DESCRIPTION
Short Description: 

allows evolve_all to be Unicode, and runs the in-built _validate_config function which is currently not being called

Fixes:
- #2281 
- 
- 


