### PR TITLE
remove sleep from step walker, makes ticks take minimum time

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -317,6 +317,14 @@ def init_config():
     add_config(
         parser,
         load,
+        long_flag="--minimum_tick_time",
+        help="Sleeps until a tick reaches this minimum, in seconds",
+        type=float,
+        default=1.5
+    )
+    add_config(
+        parser,
+        load,
         long_flag="--map_object_cache_time",
         help="Amount of seconds to keep the map object in cache (bypass Niantic throttling)",
         type=float,

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -78,6 +78,8 @@ class PokemonGoBot(object):
         # self.event_manager.emit('location', 'level'='info', data={'lat': 1, 'lng':1}),
 
     def tick(self):
+        start_time = time.time()
+
         self.cell = self.get_meta_cell()
         self.tick_count += 1
 
@@ -86,7 +88,11 @@ class PokemonGoBot(object):
 
         for worker in self.workers:
             if worker.work() == WorkerResult.RUNNING:
-                return
+                break
+
+        elapsed_time = time.time() - start_time
+        sleep_time = max(0, self.config.minimum_tick_time - elapsed_time)
+        time.sleep(sleep_time)
 
     def get_meta_cell(self):
         location = self.position[0:2]

--- a/pokemongo_bot/step_walker.py
+++ b/pokemongo_bot/step_walker.py
@@ -56,7 +56,6 @@ class StepWalker(object):
         self.api.set_position(cLat, cLng, 0)
         self.bot.heartbeat()
 
-        sleep(1)  # sleep one second plus a random delta
         # self._work_at_position(
         #     self.initLat, self.initLng,
         #     alt, False)


### PR DESCRIPTION
@TheSavior I have begun breaking changes out of #2370 
This removes `sleep(1)` from movement, and replaces it with a configurable minimum time for each tick to take.