### PR TITLE
Fix to display stats on iTerm2 terminal

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -50,3 +50,4 @@
  * z4ppy.bbc
  * matheussampaio
  * Abraxas000
+ * lucasfevi

--- a/pokemongo_bot/cell_workers/update_title_stats.py
+++ b/pokemongo_bot/cell_workers/update_title_stats.py
@@ -6,7 +6,6 @@ from pokemongo_bot.cell_workers.base_task import BaseTask
 from pokemongo_bot.worker_result import WorkerResult
 from pokemongo_bot.tree_config_builder import ConfigException
 
-
 class UpdateTitleStats(BaseTask):
     """
     Periodically updates the terminal title to display stats about the bot.
@@ -108,8 +107,10 @@ class UpdateTitleStats(BaseTask):
         :raise: RuntimeError: When the given platform isn't supported.
         """
         if platform == "linux" or platform == "linux2"\
-                or platform == "darwin" or platform == "cygwin":
+                or platform == "cygwin":
             stdout.write("\x1b]2;{}\x07".format(title))
+        elif platform == "darwin":
+            stdout.write("\033]0;{}\007".format(title))
         elif platform == "win32":
             ctypes.windll.kernel32.SetConsoleTitleA(title)
         else:


### PR DESCRIPTION
**Short Description:**
Displays stats on iTerm2 terminal.

**Long Description:**
The PR #2252 was working on the default OS X terminal but not on iTerm2, now with this fix it is working on both.
