### PR TITLE
Catch ChunkedEncodingError, wait and retry.

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -35,6 +35,7 @@ import sys
 import time
 from datetime import timedelta
 from getpass import getpass
+from requests.exceptions import ChunkedEncodingError
 from pgoapi.exceptions import NotLoggedInException, ServerSideRequestThrottlingException, ServerBusyOrOfflineException
 from geopy.exc import GeocoderQuotaExceeded
 
@@ -74,7 +75,7 @@ def main():
             logger.log('Exiting PokemonGo Bot', 'red')
             finished = True
             report_summary(bot)
-        except (NotLoggedInException, ServerBusyOrOfflineException):
+        except (NotLoggedInException, ServerBusyOrOfflineException, ChunkedEncodingError):
             logger.log('[x] Error while connecting to the server, please wait %s minutes' % config.reconnecting_timeout, 'red')
             time.sleep(config.reconnecting_timeout * 60)
         except ServerSideRequestThrottlingException:


### PR DESCRIPTION
Short Description: 
I got this crash, and decided to catch this Exception  :
```bash
Traceback (most recent call last):
  File "pokecli.py", line 442, in <module>
    main()
  File "pokecli.py", line 71, in main
    bot.tick()
  File "/home/pokemon/PokemonGo-Bot/pokemongo_bot/__init__.py", line 88, in tick
    if worker.work() == WorkerResult.RUNNING:
  File "/home/pokemon/PokemonGo-Bot/pokemongo_bot/cell_workers/recycle_items.py", line 21, in work
    item_count_dict = self.bot.item_inventory_count('all')
  File "/home/pokemon/PokemonGo-Bot/pokemongo_bot/__init__.py", line 418, in item_inventory_count
    inventory_req = self.get_inventory()
  File "/home/pokemon/PokemonGo-Bot/pokemongo_bot/__init__.py", line 378, in get_inventory
    response = self.api.call()
  File "/home/pokemon/PokemonGo-Bot/pokemongo_bot/api_wrapper.py", line 68, in call
    result = self._api.call()
  File "/home/pokemon/PokemonGo-Bot/src/pgoapi/pgoapi/pgoapi.py", line 81, in call
    response = request.request(api_endpoint, self._req_method_list, player_position)
  File "/home/pokemon/PokemonGo-Bot/src/pgoapi/pgoapi/rpc_api.py", line 93, in request
    response = self._make_rpc(endpoint, request_proto)
  File "/home/pokemon/PokemonGo-Bot/src/pgoapi/pgoapi/rpc_api.py", line 81, in _make_rpc
    http_response = self._session.post(endpoint, data=request_proto_serialized)
  File "/home/pokemon/PokemonGo-Bot/lib/python2.7/site-packages/requests/sessions.py", line 518, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/home/pokemon/PokemonGo-Bot/lib/python2.7/site-packages/requests/sessions.py", line 475, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/pokemon/PokemonGo-Bot/lib/python2.7/site-packages/requests/sessions.py", line 617, in send
    r.content
  File "/home/pokemon/PokemonGo-Bot/lib/python2.7/site-packages/requests/models.py", line 741, in content
    self._content = bytes().join(self.iter_content(CONTENT_CHUNK_SIZE)) or bytes()
  File "/home/pokemon/PokemonGo-Bot/lib/python2.7/site-packages/requests/models.py", line 667, in generate
    raise ChunkedEncodingError(e)
requests.exceptions.ChunkedEncodingError: ("Connection broken: error(104, 'Connection reset by peer')", error(104, 'Connection reset by peer'))
```
Fixes:
- Cacth ChunkedEncodingError


