### PR TITLE
correct parsing evolve_all

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -400,7 +400,7 @@ def init_config():
             raise
 
     if config.evolve_captured and isinstance(config.evolve_captured, str):
-        config.evolve_captured = [str(pokemon_name) for pokemon_name in config.evolve_captured.split(',')]
+        config.evolve_captured = [str(pokemon_name).strip() for pokemon_name in config.evolve_captured.split(',')]
 
     fix_nested_config(config)
     return config

--- a/pokemongo_bot/cell_workers/evolve_pokemon.py
+++ b/pokemongo_bot/cell_workers/evolve_pokemon.py
@@ -17,7 +17,7 @@ class EvolvePokemon(BaseTask):
 
     def _validate_config(self):
         if isinstance(self.evolve_all, basestring):
-            self.evolve_all = [str(pokemon_name) for pokemon_name in self.evolve_all.split(',')]
+            self.evolve_all = [str(pokemon_name).strip() for pokemon_name in self.evolve_all.split(',')]
 
     def work(self):
         if not self._should_run():


### PR DESCRIPTION
Short Description: 
Previously, 
```
 "evolve_all": "Pidgey, Caterpie, Weedle",
```
would only evolve Pidgey. This PR fix that.