### PR TITLE
Added a configuration option "path_startmode"

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -51,3 +51,4 @@
  * matheussampaio
  * Abraxas000
  * lucasfevi
+ * JaapMoolenaar

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -58,6 +58,7 @@
         "type": "FollowPath",
         "config": {
           "path_mode": "loop",
+          "path_startmode": "first",
           "path_file": "configs/path.example.json"
         }
       }

--- a/pokemongo_bot/cell_workers/follow_path.py
+++ b/pokemongo_bot/cell_workers/follow_path.py
@@ -13,13 +13,19 @@ from pgoapi.utilities import f2i
 
 class FollowPath(BaseTask):
     def initialize(self):
-        self.ptr = 0
         self._process_config()
         self.points = self.load_path()
+
+        if self.path_startmode == 'closest':
+            self.ptr = self.find_closest_point_idx(self.points)
+        
+        else:
+            self.ptr = 0
 
     def _process_config(self):
         self.path_file = self.config.get("path_file", None)
         self.path_mode = self.config.get("path_mode", "linear")
+        self.path_startmode = self.config.get("path_startmode", "first")
 
     def load_path(self):
         if self.path_file is None:
@@ -60,6 +66,36 @@ class FollowPath(BaseTask):
 
         return points
 
+    def find_closest_point_idx(self, points):
+        logger.log("Finding closest point in path")
+
+        return_idx = 0
+        min_distance = float("inf");
+        for index in range(len(points)):
+            point = points[index]
+            botlat = self.bot.api._position_lat
+            botlng = self.bot.api._position_lng
+            lat = float(point['lat'])
+            lng = float(point['lng'])
+
+            if self.bot.config.debug:
+                logger.log("Checking if point {}, {} is closest to {}, {}".format(lat, lng, botlat, botlng))
+            
+            dist = distance(
+                botlat,
+                botlng,
+                lat,
+                lng
+            )
+
+            if dist < min_distance:
+                min_distance = dist
+                return_idx = index
+
+        logger.log("Chose closest point in path #{}: {}, {}".format(return_idx+1, points[return_idx]['lat'], points[return_idx]['lng']))
+
+        return return_idx
+
     def work(self):
         point = self.points[self.ptr]
         lat = float(point['lat'])
@@ -94,5 +130,7 @@ class FollowPath(BaseTask):
                     self.points = list(reversed(self.points))
             else:
                 self.ptr += 1
+
+            logger.log("Moving to next point in path #{}".format(self.ptr+1))
 
         return [lat, lng]


### PR DESCRIPTION
_Python is most definitely not my main programming language, however, I thought this was a nice addition to the path walker nonetheless._

Short Description: 
Updates the FollowPath walker to allow a "path_startmode" configuration option. Setting it to "first" mimics the current behavior: move to the first point in the list and walk through them from there. Setting it to the "new" value of "closest" will try to find the closest point to the bots position and first move there before continuing along the other point in the path.

I also added a log message to see which point the bot is walking to (so one can tell it's still walking)