### PR TITLE
Added login and username to available stats in window title

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -51,3 +51,4 @@
  * matheussampaio
  * Abraxas000
  * lucasfevi
+ * Moonlight-Angel

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -36,6 +36,15 @@ class PokemonGoBot(object):
     def position(self, position_tuple):
         self.api._position_lat, self.api._position_lng, self.api._position_alt = position_tuple
 
+    @property
+    def player_data(self):
+        """
+        Returns the player data as received from the API.
+        :return: The player data.
+        :rtype: dict
+        """
+        return self._player
+
     def __init__(self, config):
         self.config = config
         self.fort_timeouts = dict()

--- a/pokemongo_bot/cell_workers/update_title_stats.py
+++ b/pokemongo_bot/cell_workers/update_title_stats.py
@@ -18,11 +18,13 @@ class UpdateTitleStats(BaseTask):
         "type": "UpdateTitleStats",
         "config": {
             "min_interval": 10,
-            "stats": ["uptime", "km_walked", "level_stats", "xp_earned", "xp_per_hour"]
+            "stats": ["login", "uptime", "km_walked", "level_stats", "xp_earned", "xp_per_hour"]
         }
     }
 
     Available stats :
+    - login : The account login (from the credentials).
+    - username : The trainer name (asked at first in-game connection).
     - uptime : The bot uptime.
     - km_walked : The kilometers walked since the bot started.
     - level : The current character's level.
@@ -106,8 +108,7 @@ class UpdateTitleStats(BaseTask):
         :rtype: None
         :raise: RuntimeError: When the given platform isn't supported.
         """
-        if platform == "linux" or platform == "linux2"\
-                or platform == "cygwin":
+        if platform == "linux" or platform == "linux2" or platform == "cygwin":
             stdout.write("\x1b]2;{}\x07".format(title))
         elif platform == "darwin":
             stdout.write("\033]0;{}\007".format(title))
@@ -144,6 +145,9 @@ class UpdateTitleStats(BaseTask):
         metrics = self.bot.metrics
         metrics.capture_stats()
         runtime = metrics.runtime()
+        login = self.bot.config.username
+        player_data = self.bot.player_data
+        username = player_data.get('username', '?')
         distance_travelled = metrics.distance_travelled()
         current_level = int(player_stats.get('level', 0))
         prev_level_xp = int(player_stats.get('prev_level_xp', 0))
@@ -171,6 +175,8 @@ class UpdateTitleStats(BaseTask):
 
         # Create stats strings.
         available_stats = {
+            'login': login,
+            'username': username,
             'uptime': 'Uptime : {}'.format(runtime),
             'km_walked': '{:,.2f}km walked'.format(distance_travelled),
             'level': 'Level {}'.format(current_level),


### PR DESCRIPTION
**Short Description**: Adds two more stats to display in the window title, as requested in https://github.com/PokemonGoF/PokemonGo-Bot/pull/2252#issuecomment-237185844.

**Changes**:
- Added a `player_data` property in `PokemonGoBot` to access player data from outside
- Added unit tests for login and username stats
- Added tests for call args when updating the window title (see https://github.com/PokemonGoF/PokemonGo-Bot/pull/2440#issuecomment-237259509)
- Added a platform-specific test for window title updating on win32 platform (ran it under Windows and the test succeeded)
- Added myself to contributors

The two stats that were added in this PR :
```
- login : The account login (from the credentials).
- username : The trainer name (asked at first in-game connection).
```