### PR TITLE
Call heartbeat on step_walker even if speed is higher than distance

### DIFF
--- a/pokemongo_bot/step_walker.py
+++ b/pokemongo_bot/step_walker.py
@@ -39,6 +39,7 @@ class StepWalker(object):
     def step(self):
         if (self.dLat == 0 and self.dLng == 0) or self.dist < self.speed:
             self.api.set_position(self.destLat, self.destLng, 0)
+            self.bot.heartbeat()
             return True
 
         totalDLat = (self.destLat - self.initLat)


### PR DESCRIPTION
**Short Description:** Bot wasn't calling `bot.hearbeat()` when speed was higher than distance.

**Long Description:** I found this bug while using walk speed of 80, which causes the speed to be higher than the distance to the next fort most of the times (in places with loads of forts). Basically the position was being updated but no call to `bot.hearbeat()`, therefore not updating the location on the web, which made me look for what was happening.

Fixes:
- call `bot.hearbeat()` even if speed is higher than distance


