### PR TITLE
Allow to set throw quality and spin odds

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -102,12 +102,12 @@
       "// Rattata": { "always_catch" : true }
     },
     "catch_throw_parameters": {
-	  "excellent_rate": 0.1,
-	  "great_rate": 0.5,
-	  "nice_rate": 0.3,
-	  "normal_rate": 0.1,
-	  "spin_success_rate" : 0.6,
-	},
+      "excellent_rate": 0.1,
+      "great_rate": 0.5,
+      "nice_rate": 0.3,
+      "normal_rate": 0.1,
+      "spin_success_rate" : 0.6,
+    },
     "release": {
       "any": {"release_below_cp": 0, "release_below_iv": 0, "logic": "or"},
       "// Example of always releasing Rattata:": {},

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -101,6 +101,13 @@
       "// Example of always catching Rattata:": {},
       "// Rattata": { "always_catch" : true }
     },
+    "catch_throw_parameters": {
+	  "excellent_rate": 0.1,
+	  "great_rate": 0.5,
+	  "nice_rate": 0.3,
+	  "normal_rate": 0.1,
+	  "spin_success_rate" : 0.6,
+	},
     "release": {
       "any": {"release_below_cp": 0, "release_below_iv": 0, "logic": "or"},
       "// Example of always releasing Rattata:": {},

--- a/pokecli.py
+++ b/pokecli.py
@@ -394,6 +394,51 @@ def init_config():
         type=bool,
         default=True
     )
+    add_config(
+        parser,
+        load,
+        short_flag="-cte",
+        long_flag="--catch_throw_parameters.excellent_rate",
+        help="Define the odd of performing an excellent throw",
+        type=float,
+        default=1
+    )
+    add_config(
+        parser,
+        load,
+        short_flag="-ctg",
+        long_flag="--catch_throw_parameters.great_rate",
+        help="Define the odd of performing a great throw",
+        type=float,
+        default=0
+    )
+    add_config(
+        parser,
+        load,
+        short_flag="-ctn",
+        long_flag="--catch_throw_parameters.nice_rate",
+        help="Define the odd of performing a nice throw",
+        type=float,
+        default=0
+    )
+    add_config(
+        parser,
+        load,
+        short_flag="-ctm",
+        long_flag="--catch_throw_parameters.normal_rate",
+        help="Define the odd of performing a normal throw",
+        type=float,
+        default=0
+    )
+    add_config(
+        parser,
+        load,
+        short_flag="-cts",
+        long_flag="--catch_throw_parameters.spin_success_rate",
+        help="Define the odds of performing a spin throw (Value between 0 (never) and 1 (always))",
+        type=float,
+        default=1
+    )
 
     # Start to parse other attrs
     config = parser.parse_args()

--- a/pokemongo_bot/human_behaviour.py
+++ b/pokemongo_bot/human_behaviour.py
@@ -25,22 +25,3 @@ def random_lat_long_delta():
     # should be 364,000 * .000025 = 9.1. So it returns between [-9.1, 9.1]
     return ((random() * 0.00001) - 0.000005) * 5
 
-
-# Humanized `normalized_reticle_size` parameter for `catch_pokemon` API.
-# 1.0 => normal, 1.950 => excellent
-def normalized_reticle_size(factor):
-    minimum = 1.0
-    maximum = 1.950
-    return uniform(
-        minimum + (maximum - minimum) * factor,
-        maximum)
-
-
-# Humanized `spin_modifier` parameter for `catch_pokemon` API.
-# 0.0 => normal ball, 1.0 => super spin curve ball
-def spin_modifier(factor):
-    minimum = 0.0
-    maximum = 1.0
-    return uniform(
-        minimum + (maximum - minimum) * factor,
-        maximum)


### PR DESCRIPTION
This is a new PR that replaces #2286

**_WARNING:_**
The  code below is safe to use.
However, I tried to test further the possibilities of the field _normalized_hit_position_, and, coincidence or not, couldn't log again with my account any more for 1 hour immediately after sending a weird value. If you want to proceed and modify _normalized_hit_position_ to test randomization, be careful.

**Short Description:** 
The code allows to modify the frequency of the various throw possibilities.
For example, with the following setting : 
"catch_throw_parameters": {
	  "excellent_rate": 4,
	  "great_rate": 10,
	  "nice_rate": 4,
	  "normal_rate": 2,
	  "spin_success_rate" : 0.6,
	}
The bot would have 4 chances out of  20 (4+10+4+2) to land an _Excellent_ throw.
In the sample config, those value add up to 1 to look like percentage, but the user is free to set the values to what speaks most to him/her.
The _spin_success_rate_ is a percentage of landing a successful spin. In the example above, the bot has 60% chance of landing a spin that will generate the bonus exp. 

**More information about the _normalized_hit_position_ :** 
The code below should work safely as it doesn't contain the further tests i have tried, however my paranoid nature would ask for people to test with account they don't care about for 1 day before merging it. I will do so myself tomorrow too. Since the (unban?) I have been testing the code below, and got no further problem.
The value of 0 for _normalized_hit_position_  is safe, as it was what we were sending before I correct the API call.
The value of 1.0 is also safe, as we used it forever.
I didn't test any values between 0 et 1.
Values above 1 seems to be what could have caused the potential temporary ban.
The last case don't happen with this code, as the value is set either to 0 or 1.

**Fixes:**
- #2250


