### PR TITLE
Adding plugin support

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -40,6 +40,7 @@ from geopy.exc import GeocoderQuotaExceeded
 
 from pokemongo_bot import PokemonGoBot, TreeConfigBuilder
 from pokemongo_bot.health_record import BotEvent
+from pokemongo_bot.plugin_loader import PluginLoader
 
 if sys.version_info >= (2, 7, 9):
     ssl._create_default_https_context = ssl._create_unverified_context
@@ -384,6 +385,7 @@ def init_config():
     config.release = load.get('release', {})
     config.action_wait_max = load.get('action_wait_max', 4)
     config.action_wait_min = load.get('action_wait_min', 1)
+    config.plugins = load.get('plugins', [])
     config.raw_tasks = load.get('tasks', [])
 
     config.vips = load.get('vips', {})
@@ -438,6 +440,10 @@ def init_config():
     if config.catch_randomize_spin_factor < 0 or 1 < config.catch_randomize_spin_factor:
         parser.error("--catch_randomize_spin_factor is out of range! (should be 0 <= catch_randomize_spin_factor <= 1)")
         return None
+
+    plugin_loader = PluginLoader()
+    for plugin in config.plugins:
+        plugin_loader.load_path(plugin)
 
     # create web dir if not exists
     try:

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -15,6 +15,7 @@ from pgoapi import PGoApi
 from pgoapi.utilities import f2i, get_cell_ids
 
 import cell_workers
+from plugin_loader import PluginLoader
 from api_wrapper import ApiWrapper
 from cell_workers.utils import distance
 from event_manager import EventManager

--- a/pokemongo_bot/plugin_loader.py
+++ b/pokemongo_bot/plugin_loader.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import importlib
+
+class PluginLoader(object):
+  folder_cache = []
+
+  def load_path(self, path):
+    parent_dir = os.path.dirname(path)
+    if parent_dir not in self.folder_cache:
+      self.folder_cache.append(parent_dir)
+      sys.path.append(parent_dir)
+
+  def get_class(self, namespace_class):
+    [namespace, class_name] = namespace_class.split('.')
+    my_module = importlib.import_module(namespace)
+    return getattr(my_module, class_name)
+

--- a/pokemongo_bot/test/plugin_loader_test.py
+++ b/pokemongo_bot/test/plugin_loader_test.py
@@ -1,0 +1,20 @@
+import imp
+import sys
+import pkgutil
+import importlib
+import unittest
+import os
+from datetime import timedelta, datetime
+from mock import patch, MagicMock
+from pokemongo_bot.plugin_loader import PluginLoader
+from pokemongo_bot.test.resources.plugin_fixture import FakeTask
+
+class PluginLoaderTest(unittest.TestCase):
+    def setUp(self):
+        self.plugin_loader = PluginLoader()
+
+    def test_load_namespace_class(self):
+        package_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'resources', 'plugin_fixture')
+        self.plugin_loader.load_path(package_path)
+        loaded_class = self.plugin_loader.get_class('plugin_fixture.FakeTask')
+        self.assertEqual(loaded_class({}, {}).work(), 'FakeTask')

--- a/pokemongo_bot/test/resources/plugin_fixture/__init__.py
+++ b/pokemongo_bot/test/resources/plugin_fixture/__init__.py
@@ -1,0 +1,1 @@
+from fake_task import FakeTask

--- a/pokemongo_bot/test/resources/plugin_fixture/fake_task.py
+++ b/pokemongo_bot/test/resources/plugin_fixture/fake_task.py
@@ -1,0 +1,5 @@
+from pokemongo_bot.cell_workers import BaseTask
+
+class FakeTask(BaseTask):
+  def work(self):
+    return 'FakeTask'

--- a/tests/tree_config_builder_test.py
+++ b/tests/tree_config_builder_test.py
@@ -1,7 +1,9 @@
 import unittest
 import json
-from pokemongo_bot import PokemonGoBot, ConfigException, TreeConfigBuilder
+import os
+from pokemongo_bot import PokemonGoBot, ConfigException, TreeConfigBuilder, PluginLoader
 from pokemongo_bot.cell_workers import HandleSoftBan, CatchLuredPokemon
+from pokemongo_bot.test.resources.plugin_fixture import FakeTask
 
 def convert_from_json(str):
     return json.loads(str)
@@ -83,3 +85,17 @@ class TreeConfigBuilderTest(unittest.TestCase):
         builder = TreeConfigBuilder(self.bot, obj)
         tree = builder.build()
         self.assertTrue(tree[0].config.get('longer_eggs_first', False))
+
+    def test_load_plugin_task(self):
+        package_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'resources', 'plugin_fixture')
+        plugin_loader = PluginLoader()
+        plugin_loader.load_path(package_path)
+
+        obj = convert_from_json("""[{
+            "type": "plugin_fixture.FakeTask"
+        }]""")
+
+        builder = TreeConfigBuilder(self.bot, obj)
+        tree = builder.build()
+        result = tree[0].work()
+        self.assertEqual(result, 'FakeTask')


### PR DESCRIPTION
This will support a plugins configuration item that contains paths to directories containing "plugins". A plugin is a python module that contains an `__init__.py`. Then you can specify `package_name.MyTask` in this format in the tasks object:

```
{
    // ...
    "tasks": [
      {
        "type": "package_name.MyTask"
      }
    ],
    // ...
}
```
