### PR TITLE
Added encrypt.so compilation process to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@ RUN echo $timezone > /etc/timezone \
 
 RUN apt-get update \
     && apt-get install -y python-protobuf
+RUN cd /tmp && wget "http://pgoapi.com/pgoencrypt.tar.gz" \
+    && tar zxvf pgoencrypt.tar.gz \
+    && cd pgoencrypt/src \
+    && make \
+    && cp libencrypt.so /usr/src/app/encrypt.so
 
 VOLUME ["/usr/src/app/web"]
 


### PR DESCRIPTION
Short Description: 
Following PR #2643 I added the retrieval, compilation and copy of the encrypt.so file to the dockerfile, in orer for the dockr version of the bot to be simply running correctly (and automatically)


