### PR TITLE
Lure encoding fix

### DIFF
--- a/pokemongo_bot/cell_workers/catch_lured_pokemon.py
+++ b/pokemongo_bot/cell_workers/catch_lured_pokemon.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from pokemongo_bot.cell_workers.utils import fort_details
 from pokemongo_bot.cell_workers.pokemon_catch_worker import PokemonCatchWorker
-from pokemongo_bot.cell_workers.base_task import BaseTask
+from pokemongo_bot.base_task import BaseTask
 
 
 class CatchLuredPokemon(BaseTask):
@@ -34,13 +34,12 @@ class CatchLuredPokemon(BaseTask):
                 'latitude': fort['latitude'],
                 'longitude': fort['longitude']
             }
-            
+
             self.emit_event(
                 'lured_pokemon_found',
                 formatted='Lured pokemon at fort {fort_name} ({fort_id})',
                 data=result
             )
-
             return result
 
         return False

--- a/pokemongo_bot/cell_workers/catch_lured_pokemon.py
+++ b/pokemongo_bot/cell_workers/catch_lured_pokemon.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from pokemongo_bot.cell_workers.utils import fort_details
 from pokemongo_bot.cell_workers.pokemon_catch_worker import PokemonCatchWorker
-from pokemongo_bot.base_task import BaseTask
+from pokemongo_bot.cell_workers.base_task import BaseTask
 
 
 class CatchLuredPokemon(BaseTask):
@@ -22,7 +22,7 @@ class CatchLuredPokemon(BaseTask):
         details = fort_details(self.bot, fort_id=fort['id'],
                               latitude=fort['latitude'],
                               longitude=fort['longitude'])
-        fort_name = details.get('name', 'Unknown').encode('utf8', 'replace')
+        fort_name = details.get('name', 'Unknown')
 
         encounter_id = fort.get('lure_info', {}).get('encounter_id', None)
 
@@ -30,16 +30,17 @@ class CatchLuredPokemon(BaseTask):
             result = {
                 'encounter_id': encounter_id,
                 'fort_id': fort['id'],
-                'fort_name': fort_name,
+                'fort_name': u"{}".format(fort_name),
                 'latitude': fort['latitude'],
                 'longitude': fort['longitude']
             }
-
+            
             self.emit_event(
                 'lured_pokemon_found',
                 formatted='Lured pokemon at fort {fort_name} ({fort_id})',
                 data=result
             )
+
             return result
 
         return False


### PR DESCRIPTION
Short Description: 
Undo encoding and format to unicode.
Make it consistent with move_to_fort.py

Fixes:
- UnicodeDecodeError: 'ascii' codec can't decode ....


This closes #2718, #2686, #2678, #2677, #2641 and possibly #2722 