### PR TITLE
Fixes "Possibly Searching Too Often" after stale session re-login

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -554,6 +554,7 @@ class PokemonGoBot(object):
                 self.api = ApiWrapper()
                 self.position = position
                 self.login()
+                self.api.activate_signature("encrypt.so")
 
     @staticmethod
     def is_numeric(s):

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -544,9 +544,9 @@ class PokemonGoBot(object):
                 self.api._auth_provider._ticket_expire / 1000 - time.time()
 
             if remaining_time < 60:
-                bot.event_manager.emit(
-                    'session_stale',
-                    sender=bot,
+                self.event_manager.emit(
+                    'api_error',
+                    sender=self,
                     level='info',
                     formatted='Session stale, re-logging in.'
                 )                

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -544,7 +544,12 @@ class PokemonGoBot(object):
                 self.api._auth_provider._ticket_expire / 1000 - time.time()
 
             if remaining_time < 60:
-                self.logger.info("Session stale, re-logging in", 'yellow')
+                bot.event_manager.emit(
+                    'session_stale',
+                    sender=bot,
+                    level='info',
+                    formatted='Session stale, re-logging in.'
+                )                
                 position = self.position
                 self.api = ApiWrapper()
                 self.position = position


### PR DESCRIPTION
Short Description: 

* Added call to `api.activate_signature` to prevent this issue after a re-login.
* Also fixed broken deprecated logger call and replaced it with an event_manager emit.

Fixes:
- #2698 
- 
- 

