### PR TITLE
Fixes #2698 - Prevents "Possibly searching too often" error after re-login.

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -547,11 +547,17 @@ class PokemonGoBot(object):
                 self.api._auth_provider._ticket_expire / 1000 - time.time()
 
             if remaining_time < 60:
-                self.logger.info("Session stale, re-logging in", 'yellow')
+                self.event_manager.emit(
+                    'api_error',
+                    sender=self,
+                    level='info',
+                    formatted='Session stale, re-logging in.'
+                )
                 position = self.position
                 self.api = ApiWrapper()
                 self.position = position
                 self.login()
+                self.api.activate_signature("encrypt.so")
 
     @staticmethod
     def is_numeric(s):

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -557,7 +557,7 @@ class PokemonGoBot(object):
                 self.api = ApiWrapper()
                 self.position = position
                 self.login()
-                self.api.activate_signature("encrypt.so")
+                self.api.activate_signature(self.get_encryption_lib())
 
     @staticmethod
     def is_numeric(s):


### PR DESCRIPTION
Short Description: 

Fixes:
- #2698 
- 
- 


- Added api.activate_signature call to prevent issue after re-login.
- Also replaced deprecated log call with event_manager emit to prevent exception being thrown.