### PR TITLE
Failing tests for loading a plugin directly from a path instead of the parent dir

### DIFF
--- a/pokemongo_bot/plugin_loader.py
+++ b/pokemongo_bot/plugin_loader.py
@@ -5,26 +5,13 @@ import importlib
 class PluginLoader(object):
   folder_cache = []
 
-  def _get_correct_path(self, path):
-    extension = os.path.splitext(path)[1]
-
-    if extension == '.zip':
-      correct_path = path
-    else:
-      correct_path = os.path.dirname(path)
-
-    return correct_path
-
   def load_path(self, path):
-    correct_path = self._get_correct_path(path)
-
-    if correct_path not in self.folder_cache:
-      self.folder_cache.append(correct_path)
-      sys.path.append(correct_path)
+    if path not in self.folder_cache:
+      self.folder_cache.append(path)
+      sys.path.append(path)
 
   def remove_path(self, path):
-    correct_path = self._get_correct_path(path)
-    sys.path.remove(correct_path)
+    sys.path.remove(path)
 
   def get_class(self, namespace_class):
     [namespace, class_name] = namespace_class.split('.')

--- a/pokemongo_bot/test/plugin_loader_test.py
+++ b/pokemongo_bot/test/plugin_loader_test.py
@@ -21,7 +21,7 @@ class PluginLoaderTest(unittest.TestCase):
         self.plugin_loader.remove_path(package_path)
 
     def test_load_zip(self):
-        package_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'resources', 'plugin_fixture_test.zip')
+        package_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'resources', 'plugin_fixture_test.zip', 'plugin_fixture_test')
         self.plugin_loader.load_path(package_path)
         loaded_class = self.plugin_loader.get_class('plugin_fixture_test.FakeTask')
         self.assertEqual(loaded_class({}, {}).work(), 'FakeTask')


### PR DESCRIPTION
Short Description: 

Fixes:
- 
- 
- 


…e parent folder