### PR TITLE
Update MoveToMapPokemon to use events instead of logger (similar to #2867)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ var/
 .pydevproject
 .settings/
 
+# Cloud9 Users
+.c9/
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ include/
 pip-selfcheck.json
 
 local/
+share/

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,5 @@ include/
 
 # Pip check file
 pip-selfcheck.json
+
+local/

--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ web/
 data/last-location*.json
 data/cells-*.json
 data/map-caught-*.json
+user_web_catchable
 
 # Multiple config
 configs/*
@@ -123,3 +124,4 @@ pip-selfcheck.json
 
 local/
 share/
+

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -45,9 +45,3 @@
  * DayBr3ak
  * kbinani
  * mhdasding
- * MFizz
- * NamPNQ
- * z4ppy.bbc
- * matheussampaio
- * Abraxas000
- * lucasfevi

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -55,7 +55,23 @@
         "type": "SpinFort"
       },
       {
-        "type": "MoveToMapPokemon"
+        "type": "MoveToMapPokemon",
+        "config": {
+          "db_file": "../PokemonGo-Map/pogom.db",
+          "address": "http://localhost:5000",
+          "max_distance": 500,
+          "min_time": 60,
+          "prioritize_vips": true,
+          "mode": "distance",
+          "priority": {
+              "Bulbasaur": 1,
+              "Squirtle": 3,
+              "Mewtwo": 100
+          },
+          "ignore": {
+              "Drowzee"
+          }
+        }
       },
       {
         "type": "MoveToFort"
@@ -72,19 +88,6 @@
     "forts": {
       "avoid_circles": true,
       "max_circle_size": 50
-    },
-    "map": {
-        "db_file": "../PokemonGo-Map/pogom.db",
-        "address": "http://localhost:5000",
-        "max_distance": 300,
-        "min_time": 60,
-        "prioritize_vips": true,
-        "mode": "distance",
-        "priority": {
-            "Bulbasaur": 1,
-            "Squirtle": 3,
-            "Mewtwo": 100
-        }
     },
     "websocket_server": false,
     "walk": 4.16,

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -75,6 +75,7 @@
     },
     "map": {
         "db_file": "../PokemonGo-Map/pogom.db",
+        "address": "http://localhost:5000",
         "max_distance": 300,
         "min_time": 60,
         "prioritize_vips": true,

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -55,11 +55,10 @@
         "type": "SpinFort"
       },
       {
-        "type": "MoveToFort",
-        "config": {
-            "lure_attraction": true,
-            "lure_max_distance": 2000
-        }
+        "type": "MoveToMapPokemon"
+      },
+      {
+        "type": "MoveToFort"
       },
       {
         "type": "FollowSpiral",
@@ -73,6 +72,18 @@
     "forts": {
       "avoid_circles": true,
       "max_circle_size": 50
+    },
+    "map": {
+        "db_file": "../PokemonGo-Map/pogom.db",
+        "max_distance": 300,
+        "min_time": 60,
+        "prioritize_vips": true,
+        "mode": "distance",
+        "priority": {
+            "Bulbasaur": 1,
+            "Squirtle": 3,
+            "Mewtwo": 100
+        }
     },
     "websocket_server": false,
     "walk": 4.16,

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -55,27 +55,6 @@
         "type": "SpinFort"
       },
       {
-        "type": "MoveToMapPokemon",
-        "config": {
-          "db_file": "../PokemonGo-Map/pogom.db",
-          "address": "http://localhost:5000",
-          "max_distance": 500,
-          "min_time": 60,
-          "prioritize_vips": true,
-          "snipe": false,
-          "mode": "distance",
-          "priority": {
-              "Bulbasaur": 1,
-              "Squirtle": 3,
-              "Mewtwo": 100
-          },
-          "ignore": [
-            "Drowzee",
-            "Jynx"
-        	]
-        }
-      },
-      {
         "type": "MoveToFort"
       },
       {

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -62,6 +62,7 @@
           "max_distance": 500,
           "min_time": 60,
           "prioritize_vips": true,
+          "snipe": false,
           "mode": "distance",
           "priority": {
               "Bulbasaur": 1,

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -68,9 +68,10 @@
               "Squirtle": 3,
               "Mewtwo": 100
           },
-          "ignore": {
-              "Drowzee"
-          }
+          "ignore": [
+            "Drowzee",
+            "Jynx"
+        	]
         }
       },
       {

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -77,7 +77,7 @@
             "==========Region Locked==========": 0,
             "Farfetch'd": 1000,
             "Kangaskhan": 1000,
-            "Mr Mime": 1000,
+            "Mr. Mime": 1000,
             "Tauros": 1000,
 
             "==========Very Rare==========": 0,

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -242,11 +242,11 @@
             "Pidgeot": 300,
 
             "==========T2 Evolvers==========": 0,
-            "Nidoran ♀": 10,
+            "Nidoran F": 10,
             "Nidorina": 10,
             "Nidoqueen": 10,
 
-            "Nidoran ♂": 10,
+            "Nidoran M": 10,
             "Nidorino": 10,
             "Nidoking": 10,
 

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -47,17 +47,12 @@
           "min_time": 60,
           "prioritize_vips": true,
           "snipe": false,
-          "mode": "distance",
-          "priority": {
+          "mode": "priority",
+          "catch": {
               "Bulbasaur": 1,
               "Squirtle": 3,
               "Mewtwo": 100
-          },
-          "ignore": [
-            "Drowzee",
-            "Jynx"
-        	]
-        }
+          }
       },
       {
         "type": "MoveToFort"

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -62,10 +62,235 @@
           "update_map": true,
           "mode": "priority",
           "catch": {
-              "Bulbasaur": 1,
-              "Squirtle": 3,
-              "Mewtwo": 100
+            "==========Legendaries==========": 0,
+            "Aerodactyl": 1000,
+            "Snorlax": 1000,
+            "Articuno": 1000,
+            "Zapdos": 1000,
+            "Moltres": 1000,
+            "Dratini": 1000,
+            "Dragonair": 1000,
+            "Dragonite": 1000,
+            "Mewtwo": 1000,
+            "Mew": 1000,
+
+            "==========Region Locked==========": 0,
+            "Farfetch'd": 1000,
+            "Kangaskhan": 1000,
+            "Mr Mime": 1000,
+            "Tauros": 1000,
+
+            "==========Very Rare==========": 0,
+            "Lapras": 900,
+            "Electabuzz": 900,
+            "Magmar": 900,
+            "Ditto": 900,
+
+            "==========Starters==========": 0,
+            "Bulbasaur": 400,
+            "Ivysaur": 600,
+            "Venusaur": 1000,
+
+            "Charmander": 400,
+            "Charmeleon": 600,
+            "Charizard": 1000,
+
+            "Squirtle": 400,
+            "Wartortle": 600,
+            "Blastoise": 1000,
+
+            "Pikachu": 600,
+            "Raichu": 1000,
+
+            "==========Semi Rare==========": 0,
+            "Porygon": 200,
+            "Scyther": 200,
+            "Jynx": 200,
+
+            "==========Uncommon==========": 0,
+
+            "Omanyte": 150,
+            "Omastar": 500,
+
+            "Seel": 300,
+            "Dewgong": 500,
+
+            "Grimer": 200,
+            "Muk": 500,
+
+            "Shellder": 200,
+            "Cloyster": 500,
+
+            "Gastly": 200,
+            "Haunter": 500,
+            "Gengar": 1000,
+
+            "Onix": 600,
+
+            "Drowzee": 600,
+
+            "Hypno": 600,
+
+            "Vulpix": 200,
+            "Ninetales": 600,
+
+            "Paras": 100,
+            "Parasect": 500,
+
+            "Growlithe": 200,
+            "Arcanine": 700,
+
+            "Tentacool": 200,
+            "Tentacruel": 500,
+
+            "Mankey": 150,
+            "Primeape": 500,
+
+            "Clefairy": 150,
+            "Clefable": 500,
+
+            "Jigglypuff": 150,
+            "Wigglytuff": 500,
+
+            "Venonat": 100,
+            "Venomoth": 500,
+
+            "Diglett": 200,
+            "Dugtrio": 500,
+
+            "Meowth": 250,
+            "Persian": 500,
+
+            "Psyduck": 150,
+            "Golduck": 500,
+
+            "Geodude": 100,
+            "Graveler": 500,
+            "Golem": 800,
+
+            "Eevee": 200,
+            "Vaporeon": 800,
+            "Jolteon": 800,
+            "Flareon": 800,
+
+            "Kabuto": 150,
+            "Kabutops": 500,
+
+            "Magikarp": 150,
+            "Gyarados": 800,
+
+            "Pinsir": 150,
+
+            "Ponyta": 200,
+            "Rapidash": 500,
+
+            "Slowpoke": 200,
+            "Slowbro": 500,
+
+            "Magnemite": 250,
+            "Magneton": 500,
+
+            "Krabby": 100,
+            "Kingler": 500,
+
+            "Voltorb": 200,
+            "Electrode": 500,
+
+            "Exeggcute": 250,
+            "Exeggcutor": 500,
+
+            "Cubone": 300,
+            "Marowak": 800,
+
+            "Hitmonlee": 400,
+
+            "Hitmonchan": 400,
+
+            "Lickitung": 500,
+
+            "Koffing": 200,
+            "Weezing": 500,
+
+            "Rhyhorn": 200,
+            "Rhydon": 500,
+
+            "Chansey": 800,
+
+            "Tangela": 300,
+
+            "Horsea": 200,
+            "Seadra": 600,
+
+            "Goldeen": 150,
+            "Seaking": 500,
+
+            "Staryu": 200,
+            "Starmie": 800,
+
+
+            "==========T1 Evolvers==========": 0,
+            "Caterpie": 10,
+            "Metapod": 10,
+            "Butterfree": 500,
+
+            "Weedle": 10,
+            "Kakuna": 10,
+            "Beedrill": 500,
+
+            "Pidgey": 10,
+            "Pidgeotto": 10,
+            "Pidgeot": 300,
+
+            "==========T2 Evolvers==========": 0,
+            "Nidoran ♀": 10,
+            "Nidorina": 10,
+            "Nidoqueen": 10,
+
+            "Nidoran ♂": 10,
+            "Nidorino": 10,
+            "Nidoking": 10,
+
+            "Oddish": 100,
+            "Gloom": 200,
+            "Vileplume": 600,
+
+            "Poliwag": 200,
+            "Poliwhirl": 400,
+            "Poliwrath": 800,
+
+            "Abra": 300,
+            "Kadabra": 600,
+            "Alakazam": 800,
+
+            "Machop": 150,
+            "Machoke": 400,
+            "Machamp": 800,
+
+            "Bellsprout": 100,
+            "Weepinbell": 400,
+            "Victreebel": 800,
+
+            "==========Trash==========": 0,
+
+            "Rattata": 10,
+            "Raticate": 10,
+
+            "Spearow": 10,
+            "Fearow": 10,
+
+            "Ekans": 10,
+            "Arbok": 10,
+
+            "Sandshrew": 10,
+            "Sandslash": 10,
+
+            "Zubat": 10,
+            "Golbat": 10,
+
+            "Doduo": 10,
+            "Dodrio": 10
           }
+        }
       },
       {
         "type": "MoveToFort"

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -42,7 +42,6 @@
       {
         "type": "MoveToMapPokemon",
         "config": {
-          "db_file": "../PokemonGo-Map/pogom.db",
           "address": "http://localhost:5000",
           "max_distance": 500,
           "min_time": 60,

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -47,6 +47,7 @@
           "min_time": 60,
           "prioritize_vips": true,
           "snipe": false,
+          "update_map": true,
           "mode": "priority",
           "catch": {
               "Bulbasaur": 1,

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -23,12 +23,24 @@
       {
         "type": "EvolveAll",
         "config": {
+          "evolve_all": "NONE",
+          "evolve_cp_min": 300,
           "evolve_speed": 20,
-          "use_lucky_egg": true
+          "use_lucky_egg": false
         }
       },
       {
-        "type": "RecycleItems"
+        "type": "RecycleItems",
+        "config": {
+          "item_filter": {
+            "Pokeball":       { "keep" : 100 },
+            "Potion":         { "keep" : 10 },
+            "Super Potion":   { "keep" : 20 },
+            "Hyper Potion":   { "keep" : 30 },
+            "Revive":         { "keep" : 30 },
+            "Razz Berry":     { "keep" : 100 }
+          }
+        }
       },
       {
         "type": "CatchVisiblePokemon"
@@ -62,6 +74,7 @@
         "type": "FollowSpiral"
       }
     ],
+    "map_object_cache_time": 5,
     "max_steps": 5,
     "forts": {
       "avoid_circles": true,
@@ -77,16 +90,6 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-    "item_filter": {
-      "Pokeball":       { "keep" : 100 },
-      "Potion":         { "keep" : 10 },
-      "Super Potion":   { "keep" : 20 },
-      "Hyper Potion":   { "keep" : 30 },
-      "Revive":         { "keep" : 30 },
-      "Razz Berry":     { "keep" : 100 }
-    },
-    "evolve_all": "NONE",
-    "evolve_cp_min": 300,
     "evolve_captured": "NONE",
     "catch_randomize_reticle_factor": 1.0,
     "catch_randomize_spin_factor": 1.0,

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -21,26 +21,14 @@
         "type": "TransferPokemon"
       },
       {
-        "type": "EvolvePokemon",
+        "type": "EvolveAll",
         "config": {
-          "evolve_all": "NONE",
-          "evolve_cp_min": 300,
           "evolve_speed": 20,
-          "use_lucky_egg": false
+          "use_lucky_egg": true
         }
       },
       {
-        "type": "RecycleItems",
-        "config": {
-          "item_filter": {
-            "Pokeball":       { "keep" : 100 },
-            "Potion":         { "keep" : 10 },
-            "Super Potion":   { "keep" : 20 },
-            "Hyper Potion":   { "keep" : 30 },
-            "Revive":         { "keep" : 30 },
-            "Razz Berry":     { "keep" : 100 }
-          }
-        }
+        "type": "RecycleItems"
       },
       {
         "type": "CatchVisiblePokemon"
@@ -54,242 +42,22 @@
       {
         "type": "MoveToMapPokemon",
         "config": {
+          "db_file": "../PokemonGo-Map/pogom.db",
           "address": "http://localhost:5000",
           "max_distance": 500,
           "min_time": 60,
           "prioritize_vips": true,
           "snipe": false,
-          "update_map": true,
-          "mode": "priority",
-          "catch": {
-            "==========Legendaries==========": 0,
-            "Aerodactyl": 1000,
-            "Snorlax": 1000,
-            "Articuno": 1000,
-            "Zapdos": 1000,
-            "Moltres": 1000,
-            "Dratini": 1000,
-            "Dragonair": 1000,
-            "Dragonite": 1000,
-            "Mewtwo": 1000,
-            "Mew": 1000,
-
-            "==========Region Locked==========": 0,
-            "Farfetch'd": 1000,
-            "Kangaskhan": 1000,
-            "Mr. Mime": 1000,
-            "Tauros": 1000,
-
-            "==========Very Rare==========": 0,
-            "Lapras": 900,
-            "Electabuzz": 900,
-            "Magmar": 900,
-            "Ditto": 900,
-
-            "==========Starters==========": 0,
-            "Bulbasaur": 400,
-            "Ivysaur": 600,
-            "Venusaur": 1000,
-
-            "Charmander": 400,
-            "Charmeleon": 600,
-            "Charizard": 1000,
-
-            "Squirtle": 400,
-            "Wartortle": 600,
-            "Blastoise": 1000,
-
-            "Pikachu": 600,
-            "Raichu": 1000,
-
-            "==========Semi Rare==========": 0,
-            "Porygon": 200,
-            "Scyther": 200,
-            "Jynx": 200,
-
-            "==========Uncommon==========": 0,
-
-            "Omanyte": 150,
-            "Omastar": 500,
-
-            "Seel": 300,
-            "Dewgong": 500,
-
-            "Grimer": 200,
-            "Muk": 500,
-
-            "Shellder": 200,
-            "Cloyster": 500,
-
-            "Gastly": 200,
-            "Haunter": 500,
-            "Gengar": 1000,
-
-            "Onix": 600,
-
-            "Drowzee": 600,
-
-            "Hypno": 600,
-
-            "Vulpix": 200,
-            "Ninetales": 600,
-
-            "Paras": 100,
-            "Parasect": 500,
-
-            "Growlithe": 200,
-            "Arcanine": 700,
-
-            "Tentacool": 200,
-            "Tentacruel": 500,
-
-            "Mankey": 150,
-            "Primeape": 500,
-
-            "Clefairy": 150,
-            "Clefable": 500,
-
-            "Jigglypuff": 150,
-            "Wigglytuff": 500,
-
-            "Venonat": 100,
-            "Venomoth": 500,
-
-            "Diglett": 200,
-            "Dugtrio": 500,
-
-            "Meowth": 250,
-            "Persian": 500,
-
-            "Psyduck": 150,
-            "Golduck": 500,
-
-            "Geodude": 100,
-            "Graveler": 500,
-            "Golem": 800,
-
-            "Eevee": 200,
-            "Vaporeon": 800,
-            "Jolteon": 800,
-            "Flareon": 800,
-
-            "Kabuto": 150,
-            "Kabutops": 500,
-
-            "Magikarp": 150,
-            "Gyarados": 800,
-
-            "Pinsir": 150,
-
-            "Ponyta": 200,
-            "Rapidash": 500,
-
-            "Slowpoke": 200,
-            "Slowbro": 500,
-
-            "Magnemite": 250,
-            "Magneton": 500,
-
-            "Krabby": 100,
-            "Kingler": 500,
-
-            "Voltorb": 200,
-            "Electrode": 500,
-
-            "Exeggcute": 250,
-            "Exeggcutor": 500,
-
-            "Cubone": 300,
-            "Marowak": 800,
-
-            "Hitmonlee": 400,
-
-            "Hitmonchan": 400,
-
-            "Lickitung": 500,
-
-            "Koffing": 200,
-            "Weezing": 500,
-
-            "Rhyhorn": 200,
-            "Rhydon": 500,
-
-            "Chansey": 800,
-
-            "Tangela": 300,
-
-            "Horsea": 200,
-            "Seadra": 600,
-
-            "Goldeen": 150,
-            "Seaking": 500,
-
-            "Staryu": 200,
-            "Starmie": 800,
-
-
-            "==========T1 Evolvers==========": 0,
-            "Caterpie": 10,
-            "Metapod": 10,
-            "Butterfree": 500,
-
-            "Weedle": 10,
-            "Kakuna": 10,
-            "Beedrill": 500,
-
-            "Pidgey": 10,
-            "Pidgeotto": 10,
-            "Pidgeot": 300,
-
-            "==========T2 Evolvers==========": 0,
-            "Nidoran F": 10,
-            "Nidorina": 10,
-            "Nidoqueen": 10,
-
-            "Nidoran M": 10,
-            "Nidorino": 10,
-            "Nidoking": 10,
-
-            "Oddish": 100,
-            "Gloom": 200,
-            "Vileplume": 600,
-
-            "Poliwag": 200,
-            "Poliwhirl": 400,
-            "Poliwrath": 800,
-
-            "Abra": 300,
-            "Kadabra": 600,
-            "Alakazam": 800,
-
-            "Machop": 150,
-            "Machoke": 400,
-            "Machamp": 800,
-
-            "Bellsprout": 100,
-            "Weepinbell": 400,
-            "Victreebel": 800,
-
-            "==========Trash==========": 0,
-
-            "Rattata": 10,
-            "Raticate": 10,
-
-            "Spearow": 10,
-            "Fearow": 10,
-
-            "Ekans": 10,
-            "Arbok": 10,
-
-            "Sandshrew": 10,
-            "Sandslash": 10,
-
-            "Zubat": 10,
-            "Golbat": 10,
-
-            "Doduo": 10,
-            "Dodrio": 10
-          }
+          "mode": "distance",
+          "priority": {
+              "Bulbasaur": 1,
+              "Squirtle": 3,
+              "Mewtwo": 100
+          },
+          "ignore": [
+            "Drowzee",
+            "Jynx"
+        	]
         }
       },
       {
@@ -299,7 +67,7 @@
         "type": "FollowSpiral"
       }
     ],
-    "map_object_cache_time": 5,
+    "max_steps": 5,
     "forts": {
       "avoid_circles": true,
       "max_circle_size": 50
@@ -314,6 +82,16 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
+    "item_filter": {
+      "Pokeball":       { "keep" : 100 },
+      "Potion":         { "keep" : 10 },
+      "Super Potion":   { "keep" : 20 },
+      "Hyper Potion":   { "keep" : 30 },
+      "Revive":         { "keep" : 30 },
+      "Razz Berry":     { "keep" : 100 }
+    },
+    "evolve_all": "NONE",
+    "evolve_cp_min": 300,
     "evolve_captured": "NONE",
     "catch_randomize_reticle_factor": 1.0,
     "catch_randomize_spin_factor": 1.0,

--- a/pokecli.py
+++ b/pokecli.py
@@ -370,10 +370,42 @@ def init_config():
     add_config(
         parser,
         load,
-        long_flag="--map_object_cache_time",
-        help="Amount of seconds to keep the map object in cache (bypass Niantic throttling)",
-        type=float,
-        default=5.0
+        long_flag="--map.db_file",
+        help="PokemonGo-Map db file",
+        type=str,
+        default=None
+    )
+    add_config(
+        parser,
+        load,
+        long_flag="--map.max_distance",
+        help="Max distance to move for a pokemon in meters",
+        type=int,
+        default=100
+    )
+    add_config(
+        parser,
+        load,
+        long_flag="--map.min_time",
+        help="Min time for the monster until despawn in seconds",
+        type=int,
+        default=30
+    )
+    add_config(
+        parser,
+        load,
+        long_flag="--map.prioritize_vips",
+        help="Catch VIP Pokemon from the map first",
+        type=bool,
+        default=True
+    )
+    add_config(
+        parser,
+        load,
+        long_flag="--map.mode",
+        help="Score pokemon either by distance or priority",
+        type=str,
+        default="distance"
     )
 
     # Start to parse other attrs
@@ -392,9 +424,8 @@ def init_config():
 
     config.vips = load.get('vips', {})
 
-    if config.map_object_cache_time < 0.0:
-        parser.error("--map_object_cache_time is out of range! (should be >= 0.0)")
-        return None
+    config.vips = load.get('vips', {})
+    config.map_priority = load.get('map', {}).get('priority', {})
 
     if len(config.raw_tasks) == 0:
         logging.error("No tasks are configured. Did you mean to configure some behaviors? Read https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Configuration-files#configuring-tasks for more information")

--- a/pokecli.py
+++ b/pokecli.py
@@ -367,46 +367,6 @@ def init_config():
         type=float,
         default=1.0
     )
-    add_config(
-        parser,
-        load,
-        long_flag="--map.db_file",
-        help="PokemonGo-Map db file",
-        type=str,
-        default=None
-    )
-    add_config(
-        parser,
-        load,
-        long_flag="--map.max_distance",
-        help="Max distance to move for a pokemon in meters",
-        type=int,
-        default=100
-    )
-    add_config(
-        parser,
-        load,
-        long_flag="--map.min_time",
-        help="Min time for the monster until despawn in seconds",
-        type=int,
-        default=30
-    )
-    add_config(
-        parser,
-        load,
-        long_flag="--map.prioritize_vips",
-        help="Catch VIP Pokemon from the map first",
-        type=bool,
-        default=True
-    )
-    add_config(
-        parser,
-        load,
-        long_flag="--map.mode",
-        help="Score pokemon either by distance or priority",
-        type=str,
-        default="distance"
-    )
 
     # Start to parse other attrs
     config = parser.parse_args()
@@ -423,9 +383,6 @@ def init_config():
     config.raw_tasks = load.get('tasks', [])
 
     config.vips = load.get('vips', {})
-
-    config.vips = load.get('vips', {})
-    config.map_priority = load.get('map', {}).get('priority', {})
 
     if len(config.raw_tasks) == 0:
         logging.error("No tasks are configured. Did you mean to configure some behaviors? Read https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Configuration-files#configuring-tasks for more information")

--- a/pokecli.py
+++ b/pokecli.py
@@ -52,81 +52,45 @@ logger = logging.getLogger('cli')
 logger.setLevel(logging.INFO)
 
 def main():
-    try:
-        bot = False
-        logger.info('PokemonGO Bot v1.0')
-        sys.stdout = codecs.getwriter('utf8')(sys.stdout)
-        sys.stderr = codecs.getwriter('utf8')(sys.stderr)
+    logger.log('PokemonGO Bot v1.0', 'green')
+    sys.stdout = codecs.getwriter('utf8')(sys.stdout)
+    sys.stderr = codecs.getwriter('utf8')(sys.stderr)
 
-        config = init_config()
-        if not config:
-            return
+    config = init_config()
+    if not config:
+        return
+    logger.log('Configuration initialized', 'yellow')
 
-        logger.info('Configuration initialized')
-        health_record = BotEvent(config)
-        health_record.login_success()
+    finished = False
 
-        finished = False
+    while not finished:
+        try:
+            bot = PokemonGoBot(config)
+            bot.start()
+            tree = TreeConfigBuilder(bot, config.raw_tasks).build()
+            bot.workers = tree
+            bot.metrics.capture_stats()
 
-        while not finished:
-            try:
-                bot = PokemonGoBot(config)
-                bot.start()
-                tree = TreeConfigBuilder(bot, config.raw_tasks).build()
-                bot.workers = tree
-                bot.metrics.capture_stats()
-                bot.health_record = health_record
+            logger.log('Starting PokemonGo Bot....', 'green')
 
-                bot.event_manager.emit(
-                    'bot_start',
-                    sender=bot,
-                    level='info',
-                    formatted='Starting bot...'
-                )
+            while True:
+                bot.tick()
 
-                while True:
-                    bot.tick()
-
-            except KeyboardInterrupt:
-                bot.event_manager.emit(
-                    'bot_exit',
-                    sender=bot,
-                    level='info',
-                    formatted='Exiting bot.'
-                )
-                finished = True
-                report_summary(bot)
-
-            except NotLoggedInException:
-                wait_time = config.reconnecting_timeout * 60
-                bot.event_manager.emit(
-                    'api_error',
-                    sender=bot,
-                    level='info',
-                    formmated='Log logged in, reconnecting in {:s}'.format(wait_time)
-                )
-                time.sleep(wait_time)
-            except ServerBusyOrOfflineException:
-                bot.event_manager.emit(
-                    'api_error',
-                    sender=bot,
-                    level='info',
-                    formatted='Server busy or offline'
-                )
-            except ServerSideRequestThrottlingException:
-                bot.event_manager.emit(
-                    'api_error',
-                    sender=bot,
-                    level='info',
-                    formatted='Server is throttling, reconnecting in 30 seconds'
-                )
-                time.sleep(30)
-
-    except GeocoderQuotaExceeded:
-        raise Exception("Google Maps API key over requests limit.")
-    except Exception as e:
-        # always report session summary and then raise exception
-        if bot:
+        except KeyboardInterrupt:
+            logger.log('Exiting PokemonGo Bot', 'red')
+            finished = True
+            report_summary(bot)
+        except (NotLoggedInException, ServerBusyOrOfflineException):
+            logger.log('[x] Error while connecting to the server, please wait %s minutes' % config.reconnecting_timeout, 'red')
+            time.sleep(config.reconnecting_timeout * 60)
+        except ServerSideRequestThrottlingException:
+            logger.log('Server is throttling, reconnecting in 30sec')
+            time.sleep(30)
+        except GeocoderQuotaExceeded:
+            logger.log('[x] The given maps api key has gone over the requests limit.', 'red')
+            finished = True
+        except:
+            # always report session summary and then raise exception
             report_summary(bot)
 
         raise e

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -733,9 +733,7 @@ class PokemonGoBot(object):
             'inventory_delta', {}).get('inventory_items', {})
         if inventory_items:
             for item in inventory_items:
-                item_info = item.get('inventory_item_data', {}).get('item')
-                if not item_info:
-                    continue
+                item_info = item.get('inventory_item_data', {}).get('item', {})
                 if {"item_id", "count"}.issubset(set(item_info.keys())):
                     self.inventory.append(item['inventory_item_data']['item'])
 

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -390,6 +390,7 @@ class PokemonGoBot(object):
         self.check_session(self.position[0:2])
 
         for worker in self.workers:
+            # logger.log('[~] Worker: {}'.format(worker.__class__.__name__))
             if worker.work() == WorkerResult.RUNNING:
                 return
 

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -53,7 +53,6 @@ class PokemonGoBot(object):
         self.tick_count = 0
         self.softban = False
         self.start_position = None
-        self.passon = {}
 
         # Make our own copy of the workers for this instance
         self.workers = []

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -380,6 +380,35 @@ class PokemonGoBot(object):
             parameters=('nickname',)
         )
         self.event_manager.register_event('unset_pokemon_nickname')
+        
+        # Move To map pokemon
+        self.event_manager.register_event(
+            'move_to_map_pokemon_fail',
+            parameters=('message')
+        )
+        self.event_manager.register_event(
+            'move_to_map_pokemon_updated_map',
+            parameters=('lat', 'lon')
+        )
+        self.event_manager.register_event(
+            'move_to_map_pokemon_teleport_to',
+            parameters=('poke_name', 'poke_dist', 'poke_lat', 'poke_lon',
+                        'disappears_in')
+        )
+        self.event_manager.register_event(
+            'move_to_map_pokemon_encounter',
+            parameters=('poke_name', 'poke_dist', 'poke_lat', 'poke_lon',
+                        'disappears_in')
+        )
+        self.event_manager.register_event(
+            'move_to_map_pokemon_move_towards',
+            parameters=('poke_name', 'poke_dist', 'poke_lat', 'poke_lon',
+                        'disappears_in')
+        )
+        self.event_manager.register_event(
+            'move_to_map_pokemon_teleport_back',
+            parameters=('last_lat', 'last_lon')
+        )
 
     def tick(self):
         self.health_record.heartbeat()

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -419,7 +419,6 @@ class PokemonGoBot(object):
         self.check_session(self.position[0:2])
 
         for worker in self.workers:
-            # logger.log('[~] Worker: {}'.format(worker.__class__.__name__))
             if worker.work() == WorkerResult.RUNNING:
                 return
 

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -733,7 +733,9 @@ class PokemonGoBot(object):
             'inventory_delta', {}).get('inventory_items', {})
         if inventory_items:
             for item in inventory_items:
-                item_info = item.get('inventory_item_data', {}).get('item', {})
+                item_info = item.get('inventory_item_data', {}).get('item')
+                if not item_info:
+                    continue
                 if {"item_id", "count"}.issubset(set(item_info.keys())):
                     self.inventory.append(item['inventory_item_data']['item'])
 

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -53,9 +53,7 @@ class PokemonGoBot(object):
         self.tick_count = 0
         self.softban = False
         self.start_position = None
-        self.last_map_object = None
-        self.last_time_map_object = 0
-        self.logger = logging.getLogger(type(self).__name__)
+        self.passon = {}
 
         # Make our own copy of the workers for this instance
         self.workers = []

--- a/pokemongo_bot/api_wrapper.py
+++ b/pokemongo_bot/api_wrapper.py
@@ -128,7 +128,7 @@ class ApiRequest(PGoApiRequest):
             if not self.is_response_valid(result, request_callers):
                 try_cnt += 1
                 if try_cnt > 3:
-                    self.logger.warning('Server seems to be busy or offline - try again - {}/{}'.format(try_cnt, max_retry))
+                    logger.log('Server seems to be busy or offline - try again - {}/{}'.format(try_cnt, max_retry), 'red')
                 if try_cnt >= max_retry:
                     raise ServerBusyOrOfflineException()
                 sleep(1)

--- a/pokemongo_bot/cell_workers/__init__.py
+++ b/pokemongo_bot/cell_workers/__init__.py
@@ -6,7 +6,6 @@ from evolve_pokemon import EvolvePokemon
 from incubate_eggs import IncubateEggs
 from move_to_fort import MoveToFort
 from move_to_map_pokemon import MoveToMapPokemon
-from nickname_pokemon import NicknamePokemon
 from pokemon_catch_worker import PokemonCatchWorker
 from transfer_pokemon import TransferPokemon
 from recycle_items import RecycleItems

--- a/pokemongo_bot/cell_workers/catch_visible_pokemon.py
+++ b/pokemongo_bot/cell_workers/catch_visible_pokemon.py
@@ -20,7 +20,6 @@ class CatchVisiblePokemon(BaseTask):
             for pokemon in self.bot.cell['catchable_pokemons']:
                 with open(user_web_catchable, 'w') as outfile:
                     json.dump(pokemon, outfile)
-            self.bot.passon['catched_pokemon'] = self.bot.cell['catchable_pokemons'][0]
             return self.catch_pokemon(self.bot.cell['catchable_pokemons'][0])
 
         if 'wild_pokemons' in self.bot.cell and len(self.bot.cell['wild_pokemons']) > 0:
@@ -29,7 +28,6 @@ class CatchVisiblePokemon(BaseTask):
             self.bot.cell['wild_pokemons'].sort(
                 key=
                 lambda x: distance(self.bot.position[0], self.bot.position[1], x['latitude'], x['longitude']))
-            self.bot.passon['catched_pokemon'] = self.bot.cell['wild_pokemons'][0]
             return self.catch_pokemon(self.bot.cell['wild_pokemons'][0])
 
     def catch_pokemon(self, pokemon):

--- a/pokemongo_bot/cell_workers/catch_visible_pokemon.py
+++ b/pokemongo_bot/cell_workers/catch_visible_pokemon.py
@@ -20,20 +20,8 @@ class CatchVisiblePokemon(BaseTask):
             for pokemon in self.bot.cell['catchable_pokemons']:
                 with open(user_web_catchable, 'w') as outfile:
                     json.dump(pokemon, outfile)
-                self.emit_event(
-                    'catchable_pokemon',
-                    level='debug',
-                    data={
-                        'pokemon_id': pokemon['pokemon_id'],
-                        'spawn_point_id': pokemon['spawn_point_id'],
-                        'encounter_id': pokemon['encounter_id'],
-                        'latitude': pokemon['latitude'],
-                        'longitude': pokemon['longitude'],
-                        'expiration_timestamp_ms': pokemon['expiration_timestamp_ms'],
-                    }
-                )
-
-            return self.catch_pokemon(self.bot.cell['catchable_pokemons'].pop(0))
+            self.bot.passon['catched_pokemon'] = self.bot.cell['catchable_pokemons'][0]
+            return self.catch_pokemon(self.bot.cell['catchable_pokemons'][0])
 
         if 'wild_pokemons' in self.bot.cell and len(self.bot.cell['wild_pokemons']) > 0:
             # Sort all by distance from current pos- eventually this should
@@ -41,7 +29,8 @@ class CatchVisiblePokemon(BaseTask):
             self.bot.cell['wild_pokemons'].sort(
                 key=
                 lambda x: distance(self.bot.position[0], self.bot.position[1], x['latitude'], x['longitude']))
-            return self.catch_pokemon(self.bot.cell['wild_pokemons'].pop(0))
+            self.bot.passon['catched_pokemon'] = self.bot.cell['wild_pokemons'][0]
+            return self.catch_pokemon(self.bot.cell['wild_pokemons'][0])
 
     def catch_pokemon(self, pokemon):
         worker = PokemonCatchWorker(pokemon, self.bot)

--- a/pokemongo_bot/cell_workers/catch_visible_pokemon.py
+++ b/pokemongo_bot/cell_workers/catch_visible_pokemon.py
@@ -20,6 +20,7 @@ class CatchVisiblePokemon(BaseTask):
             for pokemon in self.bot.cell['catchable_pokemons']:
                 with open(user_web_catchable, 'w') as outfile:
                     json.dump(pokemon, outfile)
+
             return self.catch_pokemon(self.bot.cell['catchable_pokemons'][0])
 
         if 'wild_pokemons' in self.bot.cell and len(self.bot.cell['wild_pokemons']) > 0:

--- a/pokemongo_bot/cell_workers/move_to_fort.py
+++ b/pokemongo_bot/cell_workers/move_to_fort.py
@@ -9,11 +9,6 @@ from utils import distance, format_dist, fort_details
 
 
 class MoveToFort(BaseTask):
-    SUPPORTED_TASK_API_VERSION = 1
-
-    def __init__(self, bot, config=None):
-        self.bot = bot
-
     def should_run(self):
         has_space_for_loot = self.bot.has_space_for_loot()
         if not has_space_for_loot:

--- a/pokemongo_bot/cell_workers/move_to_fort.py
+++ b/pokemongo_bot/cell_workers/move_to_fort.py
@@ -11,10 +11,8 @@ from utils import distance, format_dist, fort_details
 class MoveToFort(BaseTask):
     SUPPORTED_TASK_API_VERSION = 1
 
-    def initialize(self):
-        self.lure_distance = 0
-        self.lure_attraction = True #self.config.get("lure_attraction", True)
-        self.lure_max_distance = 2000 #self.config.get("lure_max_distance", 2000)
+    def __init__(self, bot, config=None):
+        self.bot = bot
 
     def should_run(self):
         has_space_for_loot = self.bot.has_space_for_loot()

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -1,11 +1,59 @@
 # -*- coding: utf-8 -*-
+"""
+Moves a trainer to a Pokemon.
+
+Events:
+    move_to_map_pokemon_fail
+        When the worker fails.
+        Returns:
+            message: Failure message.
+    
+    move_to_map_pokemon_updated_map
+        When worker updates the PokemonGo-Map.
+        Returns:
+            lat: Latitude
+            lon: Longitude
+    
+    move_to_map_pokemon_teleport_to
+        When trainer is teleported to a Pokemon.
+        Returns:
+            poke_name: Pokemon's name
+            poke_dist: Distance from the trainer
+            poke_lat: Latitude of the Pokemon
+            poke_lon: Longitude of the Pokemon
+            disappears_in: Number of seconds before the Pokemon disappears
+            
+    move_to_map_pokemon_encounter
+        When a trainer encounters a Pokemon by teleporting or walking.
+        Returns:
+            poke_name: Pokemon's name
+            poke_dist: Distance from the trainer
+            poke_lat: Latitude of the Pokemon
+            poke_lon: Longitude of the Pokemon
+            disappears_in: Number of seconds before the Pokemon disappears
+    
+    move_to_map_pokemon_move_towards
+        When a trainer moves toward a Pokemon.
+        Returns:
+            poke_name: Pokemon's name
+            poke_dist: Distance from the trainer
+            poke_lat: Latitude of the Pokemon
+            poke_lon: Longitude of the Pokemon
+            disappears_in: Number of seconds before the Pokemon disappears
+    
+    move_to_map_pokemon_teleport_back
+        When a trainer teleports back to thier previous location.
+        Returns:
+            last_lat: Trainer's last known latitude
+            last_lon: Trainer's last known longitude
+
+"""
 
 import os
 import time
 import json
 import base64
 import requests
-from pokemongo_bot import logger
 from pokemongo_bot.cell_workers.utils import distance, format_dist, format_time
 from pokemongo_bot.step_walker import StepWalker
 from pokemongo_bot.worker_result import WorkerResult
@@ -13,7 +61,22 @@ from pokemongo_bot.cell_workers.base_task import BaseTask
 from pokemongo_bot.cell_workers.pokemon_catch_worker import PokemonCatchWorker
 
 
+# Update the map if more than N meters away from the center. (AND'd with
+# UPDATE_MAP_MIN_TIME_MINUTES)
+UPDATE_MAP_MIN_DISTANCE_METERS = 500
+
+# Update the map if it hasn't been updated in n seconds. (AND'd with
+# UPDATE_MAP_MIN_DISTANCE_METERS)
+UPDATE_MAP_MIN_TIME_SEC = 120
+
+# Number of seconds to sleep between teleporting to a snipped Pokemon.
+SNIPE_SLEEP_SEC = 2
+
+
 class MoveToMapPokemon(BaseTask):
+    """Task for moving a trainer to a Pokemon."""
+    SUPPORTED_TASK_API_VERSION = 1
+
     def initialize(self):
         self.last_map_update = 0
         self.pokemon_data = self.bot.pokemon_list
@@ -30,13 +93,13 @@ class MoveToMapPokemon(BaseTask):
         try:
             req = requests.get('{}/raw_data?gyms=false&scanned=false'.format(self.config['address']))
         except requests.exceptions.ConnectionError:
-            logger.log('Could not reach PokemonGo-Map Server', 'red')
+            self._emit_failure('Could not reach PokemonGo-Map Server: {}'.format(self.config['address']))
             return []
 
         try:
             raw_data = req.json()
         except ValueError:
-            logger.log('Map data was not valid', 'red')
+            self._emit_failure('Map data was not valid')
             return []
 
         pokemon_list = []
@@ -46,7 +109,7 @@ class MoveToMapPokemon(BaseTask):
             try:
                 pokemon['encounter_id'] = long(base64.b64decode(pokemon['encounter_id']))
             except TypeError:
-                log.logger('base64 error: {}'.format(pokemon['encounter_id']), 'red')
+                self._emit_failure('base64 error: {}'.format(pokemon['encounter_id']))
                 continue
             pokemon['spawn_point_id'] = pokemon['spawnpoint_id']
             pokemon['disappear_time'] = int(pokemon['disappear_time'] / 1000)
@@ -98,14 +161,15 @@ class MoveToMapPokemon(BaseTask):
         try:
             req = requests.get('{}/loc'.format(self.config['address']))
         except requests.exceptions.ConnectionError:
-            logger.log('Could not reach PokemonGo-Map Server', 'red')
+            self._emit_failure('Could not reach PokemonGo-Map Server')
             return
 
         try:
             loc_json = req.json()
         except ValueError:
-            return log.logger('Map location data was not valid', 'red')
-
+            err = 'Map location data was not valid'
+            self._emit_failure(err)
+            return log.logger(err, 'red')
 
         dist = distance(
             self.bot.position[0],
@@ -116,32 +180,33 @@ class MoveToMapPokemon(BaseTask):
 
         # update map when 500m away from center and last update longer than 2 minutes away
         now = int(time.time())
-        if dist > 500 and now - self.last_map_update > 2 * 60:
-            requests.post('{}/next_loc?lat={}&lon={}'.format(self.config['address'], self.bot.position[0], self.bot.position[1]))
-            logger.log('Updated PokemonGo-Map position', 'green')
+        if (dist > UPDATE_MAP_MIN_DISTANCE_METERS and 
+            now - self.last_map_update > UPDATE_MAP_MIN_TIME_SEC):
+            requests.post(
+                '{}/next_loc?lat={}&lon={}'.format(self.config['address'], 
+                                                   self.bot.position[0], 
+                                                   self.bot.position[1]))
+            self.emit_event('move_to_map_pokemon_updated_map', 
+                            lat=self.bot.position[0],
+                            lon=self.bot.position[1])
             self.last_map_update = now
 
     def snipe(self, pokemon):
-        last_position = self.bot.position[0:2]
-
+        """Snipe a Pokemon by teleporting.
+        
+        Args:
+            pokemon: Pokemon to snipe.
+        """
         self.bot.heartbeat()
-
-        logger.log('Teleporting to {} ({})'.format(pokemon['name'], format_dist(pokemon['dist'], self.unit)), 'green')
-        self.bot.api.set_position(pokemon['latitude'], pokemon['longitude'], 0)
-
-        logger.log('Encounter pokemon', 'green')
+        self._teleport_to(pokemon)
         catch_worker = PokemonCatchWorker(pokemon, self.bot)
         api_encounter_response = catch_worker.create_encounter_api_call()
-
-        time.sleep(2)
-        logger.log('Teleporting back to previous location..', 'green')
-        self.bot.api.set_position(last_position[0], last_position[1], 0)
-        time.sleep(2)
+        time.sleep(SNIPE_SLEEP_SEC)
+        self._teleport_back()
+        time.sleep(SNIPE_SLEEP_SEC)
         self.bot.heartbeat()
-
         catch_worker.work(api_encounter_response)
         self.add_caught(pokemon)
-
         return WorkerResult.SUCCESS
 
     def dump_caught_pokemon(self):
@@ -180,18 +245,103 @@ class MoveToMapPokemon(BaseTask):
         if self.config['snipe']:
             return self.snipe(pokemon)
 
+        step_walker = self._move_to(pokemon)
+        if not step_walker.step():
+            return WorkerResult.RUNNING
+        self._encountered(pokemon)
+        self.add_caught(pokemon)
+        return WorkerResult.SUCCESS
+
+    def _emit_failure(self, msg):
+        """Emits failure to event log.
+        
+        Args:
+            msg: Message to emit
+        """
+        self.emit_event('move_to_map_pokemon_fail', message=msg)
+        
+    def _emit_log(self, msg):
+        """Emits log to event log.
+        
+        Args:
+            msg: Message to emit
+        """
+        self.emit_event('move_to_map_pokemon', message=msg)
+        
+    def _pokemon_event_data(self, pokemon):
+        """Generates parameters used for the Bot's event manager.
+        
+        Args:
+            pokemon: Pokemon object
+        
+        Returns:
+            Dictionary with Pokemon's info.
+        """
         now = int(time.time())
-        logger.log('Moving towards {}, {} left ({})'.format(pokemon['name'], format_dist(pokemon['dist'], self.unit), format_time(pokemon['disappear_time'] - now)))
-        step_walker = StepWalker(
+        return {
+            'poke_name': pokemon['name'],
+            'poke_dist': (format_dist(pokemon['dist'], self.unit)),
+            'poke_lat': pokemon['latitude'], 
+            'poke_lon': pokemon['longitude'],
+            'disappears_in': (format_time(pokemon['disappear_time'] - now))
+        }
+    
+    def _teleport_to(self, pokemon):
+        """Teleports trainer to a Pokemon.
+        
+        Args:
+            pokemon: Pokemon to teleport to.
+        """
+        self.emit_event(
+            'move_to_map_pokemon_teleport_to',
+            formatted='Teleporting to {poke_name}. ({poke_dist})',
+            data=self._pokemon_event_data(pokemon)
+        )
+        self.bot.api.set_position(pokemon['latitude'], pokemon['longitude'], 0)
+        self._encountered(pokemon)
+        
+    def _encountered(self, pokemon):
+        """Emit event when trainer encounters a Pokemon.
+
+        Args:
+            pokemon: Pokemon encountered.
+        """
+        self.emit_event(
+            'move_to_map_pokemon_encounter',
+            formatted='Encountered Pokemon: {poke_name}',
+            data=self._pokemon_event_data(pokemon)
+        )
+
+    def _teleport_back(self):
+        """Teleports trainer back to their last position."""        
+        last_position = self.bot.position[0:2]
+        self.emit_event(
+            'move_to_map_pokemon_teleport_back',
+            formatted=('Teleporting back to previous location ({last_lat}, '
+                       '{last_long})'),
+            data={'last_lat': last_position[0], 'last_lon': last_position[1]}
+        )
+        self.bot.api.set_position(last_position[0], last_position[1], 0)
+        
+    def _move_to(self, pokemon):
+        """Moves trainer towards a Pokemon.
+        
+        Args:
+            pokemon: Pokemon to move to.
+        
+        Returns:
+            StepWalker
+        """
+        now = int(time.time())
+        self.emit_event(
+            'move_to_map_pokemon_move_towards',
+            formatted=('Moving towards {poke_name}, {poke_dist}, left ('
+                       '{disappears_in})'),
+            data=self._pokemon_event_data(pokemon)
+        )
+        return StepWalker(
             self.bot,
             self.bot.config.walk,
             pokemon['latitude'],
             pokemon['longitude']
         )
-
-        if not step_walker.step():
-            return WorkerResult.RUNNING
-
-        logger.log('Arrived at {}'.format(pokemon['name']))
-        self.add_caught(pokemon)
-        return WorkerResult.SUCCESS

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -9,16 +9,14 @@ from pokemongo_bot.cell_workers.utils import distance, i2f, format_dist, format_
 from pokemongo_bot.human_behaviour import sleep
 from pokemongo_bot.step_walker import StepWalker
 from pokemongo_bot.worker_result import WorkerResult
+from pokemongo_bot.cell_workers.base_task import BaseTask
 from pokemon_catch_worker import PokemonCatchWorker
 
 
-class MoveToMapPokemon(object):
-
-    def __init__(self, bot, config):
-        self.bot = bot
-        self.config = config
+class MoveToMapPokemon(BaseTask):
+    def initialize(self):
         self.last_map_update = 0
-        self.pokemon_data = bot.pokemon_list
+        self.pokemon_data = self.bot.pokemon_list
         self.caught = []
         self.unit = self.bot.config.distance_unit
 
@@ -38,6 +36,19 @@ class MoveToMapPokemon(object):
             pokemon['encounter_id'] = long(base64.b64decode(pokemon['encounter_id']))
             pokemon['spawn_point_id'] = pokemon['spawnpoint_id']
             pokemon['disappear_time'] = int(pokemon['disappear_time'] / 1000)
+            pokemon['name'] = self.pokemon_data[pokemon['pokemon_id'] - 1]['Name']
+            pokemon['is_vip'] = pokemon['name'] in self.bot.config.vips
+
+            if (pokemon['name'] not in self.config['catch']):
+                continue
+
+            if pokemon['disappear_time'] < (now + self.config['min_time']):
+                continue
+
+            if pokemon['encounter_id'] in self.caught:
+                continue
+
+            pokemon['priority'] = self.config['catch'][pokemon['name']]
 
             pokemon['dist'] = distance(
                 self.bot.position[0],
@@ -46,71 +57,17 @@ class MoveToMapPokemon(object):
                 pokemon['longitude'],
             )
 
-            if pokemon['disappear_time'] < (now + self.config['min_time']):
-                continue
-
-            if pokemon['dist'] > self.config['max_distance'] and self.config['mode'] != 'snipe':
-                continue
-
-            if pokemon['encounter_id'] in self.caught:
+            if pokemon['dist'] > self.config['max_distance'] and not self.config['snipe']:
                 continue
 
             pokemon_list.append(pokemon)
 
         return pokemon_list
 
-    def get_name_from_id(self, pokemon_id):
-        return self.pokemon_data[pokemon_id - 1]['Name']
-
-    def is_vip(self, pokemon_id):
-        return self.get_name_from_id(pokemon_id) in self.bot.config.vips
-
-    def get_config_priority(self, pokemon_id):
-        if (self.get_name_from_id(pokemon_id) in self.config['priority']):
-            return self.config['priority'][self.get_name_from_id(pokemon_id)]
-        else:
-            return 0
-
     def addCaught(self, pokemon):
         if len(self.caught) >= 200:
             self.caught.pop(0)
         self.caught.append(pokemon['encounter_id'])
-
-    def score_pokemon(self, pokemon_list):
-        new_list = []
-        has_vips = False
-        for pokemon in pokemon_list:
-            if self.config['prioritize_vips'] and self.is_vip(pokemon['pokemon_id']):
-                has_vips = True
-                break
-
-        for pokemon in pokemon_list:
-            score = 0
-            if self.is_vip(pokemon['pokemon_id']):
-                score += 10000
-            if self.config['mode'] == 'distance':
-                score -= pokemon['dist']
-            elif self.config['mode'] == 'priority':
-                score += self.get_config_priority(pokemon['pokemon_id'])
-            elif self.config['mode'] == 'hybrid':
-                score += self.get_config_priority(pokemon['pokemon_id'])
-                score -= pokemon['dist']
-
-            pokemon['name'] = self.get_name_from_id(pokemon['pokemon_id'])
-            pokemon['score'] = score
-
-            if self.config['mode'] == 'priority' and pokemon['score'] < 1:
-                continue
-
-            if pokemon['name'] in self.config['ignore']:
-                continue
-
-            if has_vips:
-                if not self.is_vip(pokemon['pokemon_id']):
-                    pokemon['score'] = 0
-
-            new_list.append(pokemon)
-        return new_list
 
     def update_map_location(self):
         try:
@@ -162,24 +119,25 @@ class MoveToMapPokemon(object):
     def work(self):
         self.update_map_location()
 
-        if 'catched_pokemon' in self.bot.passon:
-            self.addCaught(self.bot.passon['catched_pokemon'])
-            del self.bot.passon['catched_pokemon']
+        pokemon_list = self.get_pokemon_from_map()
+        pokemon_list.sort(key=lambda x: x['dist'])
+        if self.config['mode'] == 'priority':
+            pokemon_list.sort(key=lambda x: x['priority'], reverse=True)
+        if self.config['prioritize_vips'] == 'priority':
+            pokemon_list.sort(key=lambda x: x['is_vip'])
+
+        if (len(pokemon_list) < 1):
             return WorkerResult.SUCCESS
 
-        pokemon_on_map = self.get_pokemon_from_map()
-        pokemon_on_map = self.score_pokemon(pokemon_on_map)
-        pokemon_on_map.sort(key=lambda x: x['score'], reverse=True)
+        pokemon = pokemon_list[0]
 
-        if (len(pokemon_on_map) < 1):
-            return WorkerResult.SUCCESS
+        if 'catchable_pokemons' in self.bot.cell and len(self.bot.cell['catchable_pokemons']) > 0:
+            for catchable_pokemon in self.bot.cell['catchable_pokemons']:
+                if pokemon['encounter_id'] == catchable_pokemon['encounter_id']:
+                    self.addCaught(pokemon)
+                    return WorkerResult.SUCCESS
 
-        pokemon = pokemon_on_map[0]
         now = int(time.time())
-
-        if self.bot.config.walk <= 0 or self.config['snipe']:
-            return self.snipe(pokemon)
-
         logger.log('Moving towards {}, {} left ({})'.format(pokemon['name'], format_dist(pokemon['dist'], self.unit), format_time(pokemon['disappear_time'] - now)))
         step_walker = StepWalker(
             self.bot,

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -25,7 +25,7 @@ class MoveToMapPokemon(object):
         self.unit = self.bot.config.distance_unit
 
     def load_db(self):
-        if self.config['db_file'] == None:
+        if not 'db_file' in self.config:
             raise RuntimeError('You need to specify a db file (sqlite)')
 
         try:

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -178,9 +178,6 @@ class MoveToMapPokemon(object):
         if (len(pokemon_on_map) < 1):
             return
 
-        for idx in xrange(5):
-            print pokemon_on_map[0]
-
         pokemon = pokemon_on_map[0]
         now = int(time.time())
 

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -54,10 +54,7 @@ class MoveToMapPokemon(BaseTask):
             if self.was_caught(pokemon):
                 continue
 
-            if pokemon['name'] in self.config['catch']:
-                pokemon['priority'] = self.config['catch'][pokemon['name']]
-            else:
-                pokemon['priority'] = 0
+            pokemon['priority'] = self.config['catch'].get(pokemon['name'], 0)
 
             pokemon['dist'] = distance(
                 self.bot.position[0],
@@ -156,7 +153,7 @@ class MoveToMapPokemon(BaseTask):
         if self.config['mode'] == 'priority':
             pokemon_list.sort(key=lambda x: x['priority'], reverse=True)
         if self.config['prioritize_vips'] == 'priority':
-            pokemon_list.sort(key=lambda x: x['is_vip'])
+            pokemon_list.sort(key=lambda x: x['is_vip'], reverse=True)
 
         if len(pokemon_list) < 1:
             return WorkerResult.SUCCESS

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -75,7 +75,7 @@ class MoveToMapPokemon(object):
     def get_name_from_id(self, pokemon_id):
         return self.pokemon_data[pokemon_id - 1]['Name']
 
-    def is_in_vip(self, pokemon_id):
+    def is_vip(self, pokemon_id):
         return self.get_name_from_id(pokemon_id) in self.bot.config.vips
 
     def get_config_priority(self, pokemon_id):
@@ -91,10 +91,14 @@ class MoveToMapPokemon(object):
 
     def score_pokemon(self, pokemon_list):
         new_list = []
+        has_vips = False
+        for pokemon in pokemon_list:
+            if self.config['prioritize_vips'] and self.is_vip(pokemon['pokemon_id']):
+                has_vips = True
+                break
+
         for pokemon in pokemon_list:
             score = 0
-            if self.config['prioritize_vips'] and self.is_in_vip(pokemon['pokemon_id']):
-                score += 10000
             if self.config['mode'] == 'distance':
                 score -= pokemon['dist']
             elif self.config['mode'] == 'priority':
@@ -111,6 +115,10 @@ class MoveToMapPokemon(object):
 
             if pokemon['name'] in self.config['ignore']:
                 continue
+
+            if has_vips:
+                if not self.is_vip(pokemon['pokemon_id']):
+                pokemon['score'] = 0
 
             new_list.append(pokemon)
         return new_list

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -1,199 +1,129 @@
 # -*- coding: utf-8 -*-
 
-import os
-import time
 import json
-import base64
-import requests
+import time
+import sqlite3
 from pokemongo_bot import logger
-from pokemongo_bot.cell_workers.utils import distance, format_dist, format_time
+from pokemongo_bot.cell_workers.utils import distance, i2f, format_dist
+from pokemongo_bot.human_behaviour import sleep
 from pokemongo_bot.step_walker import StepWalker
 from pokemongo_bot.worker_result import WorkerResult
-from pokemongo_bot.base_task import BaseTask
-from pokemongo_bot.cell_workers.pokemon_catch_worker import PokemonCatchWorker
 
 
-class MoveToMapPokemon(BaseTask):
-    SUPPORTED_TASK_API_VERSION = 1
+class MoveToMapPokemon(object):
 
-    def initialize(self):
-        self.last_map_update = 0
-        self.pokemon_data = self.bot.pokemon_list
-        self.unit = self.bot.config.distance_unit
+    def __init__(self, bot):
+        self.bot = bot
+        self.ptr = 0
+        self.db = self.load_db()
+        self.pokemon_data = bot.pokemon_list
         self.caught = []
 
-        data_file = 'data/map-caught-{}.json'.format(self.bot.config.username)
-        if os.path.isfile(data_file):
-            self.caught = json.load(
-                open(data_file)
-            )
+    def load_db(self):
+        if self.bot.config.map_db_file == None:
+            raise RuntimeError('You need to specify a db file (sqlite)')
+
+        try:
+            conn = sqlite3.connect(self.bot.config.map_db_file)
+        except:
+            raise RuntimeError('Could not open db file "{}"'.format(self.bot.config.map.db_file))
+        return conn
 
     def get_pokemon_from_map(self):
-        try:
-            req = requests.get('{}/raw_data?gyms=false&scanned=false'.format(self.config['address']))
-        except requests.exceptions.ConnectionError:
-            logger.log('Could not reach PokemonGo-Map Server', 'red')
-            return []
-
-        try:
-            raw_data = req.json()
-        except ValueError:
-            logger.log('Map data was not valid', 'red')
-            return []
+        cursor = self.db.cursor()
 
         pokemon_list = []
-        now = int(time.time())
 
-        for pokemon in raw_data['pokemons']:
-            try:
-                pokemon['encounter_id'] = long(base64.b64decode(pokemon['encounter_id']))
-            except TypeError:
-                log.logger('base64 error: {}'.format(pokemon['encounter_id']), 'red')
-                continue
-            pokemon['spawn_point_id'] = pokemon['spawnpoint_id']
-            pokemon['disappear_time'] = int(pokemon['disappear_time'] / 1000)
-            pokemon['name'] = self.pokemon_data[pokemon['pokemon_id'] - 1]['Name']
-            pokemon['is_vip'] = pokemon['name'] in self.bot.config.vips
+        now = int(time.time() + self.bot.config.map_min_time)
+        for row in cursor.execute('SELECT * FROM pokemon WHERE datetime(disappear_time) > datetime(?, "unixepoch");', (now, )):
+            encounter_id = row[1]
+            pokemon_id = row[2]
+            lat = row[3]
+            lon = row[4]
 
-            if pokemon['name'] not in self.config['catch'] and not pokemon['is_vip']:
-                continue
-
-            if pokemon['disappear_time'] < (now + self.config['min_time']):
-                continue
-
-            if self.was_caught(pokemon):
-                continue
-
-            pokemon['priority'] = self.config['catch'].get(pokemon['name'], 0)
-
-            pokemon['dist'] = distance(
+            dist = distance(
                 self.bot.position[0],
                 self.bot.position[1],
-                pokemon['latitude'],
-                pokemon['longitude'],
+                lat,
+                lon
             )
 
-            if pokemon['dist'] > self.config['max_distance'] and not self.config['snipe']:
+            if dist > self.bot.config.map_max_distance:
                 continue
 
-            pokemon_list.append(pokemon)
+            if encounter_id in self.caught:
+                continue
 
+            pokemon_list.append({
+                'encounter_id': encounter_id,
+                'pokemon_id': pokemon_id,
+                'lat': lat,
+                'lon': lon,
+                'dist': dist
+            })
+
+        cursor.close()
         return pokemon_list
 
-    def add_caught(self, pokemon):
-        for caught_pokemon in self.caught:
-            if caught_pokemon['encounter_id'] == pokemon['encounter_id']:
-                return
+    def get_name_from_id(self, pokemon_id):
+        return self.pokemon_data[pokemon_id - 1]['Name']
+
+    def is_in_vip(self, pokemon_id):
+        return self.get_name_from_id(pokemon_id) in self.bot.config.vips
+
+    def get_config_priority(self, pokemon_id):
+        if (self.get_name_from_id(pokemon_id) in self.bot.config.map_priority):
+            return self.bot.config.map_priority[self.get_name_from_id(pokemon_id)]
+        else:
+            return 0
+
+    def addCaught(self, pokemon):
         if len(self.caught) >= 200:
             self.caught.pop(0)
-        self.caught.append(pokemon)
+        self.caught.append(pokemon['encounter_id'])
 
-    def was_caught(self, pokemon):
-        for caught_pokemon in self.caught:
-            if pokemon['encounter_id'] == caught_pokemon['encounter_id']:
-                return True
-        return False
+    def score_pokemon(self, pokemon_list):
+        new_list = []
+        for pokemon in pokemon_list:
+            score = 0
+            if self.bot.config.map_prioritize_vips and self.is_in_vip(pokemon['pokemon_id']):
+                score += 1000
+            if self.bot.config.map_mode == 'distance':
+                score -= pokemon['dist']
+            elif self.bot.config.map_mode == 'priority':
+                score += self.get_config_priority(pokemon['pokemon_id'])
 
-    def update_map_location(self):
-        if not self.config['update_map']:
-            return
-        try:
-            req = requests.get('{}/loc'.format(self.config['address']))
-        except requests.exceptions.ConnectionError:
-            logger.log('Could not reach PokemonGo-Map Server', 'red')
-            return
+            pokemon['name'] = self.get_name_from_id(pokemon['pokemon_id'])
+            pokemon['score'] = score
 
-        try:
-            loc_json = req.json()
-        except ValueError:
-            return log.logger('Map location data was not valid', 'red')
-
-
-        dist = distance(
-            self.bot.position[0],
-            self.bot.position[1],
-            loc_json['lat'],
-            loc_json['lng']
-        )
-
-        # update map when 500m away from center and last update longer than 2 minutes away
-        now = int(time.time())
-        if dist > 500 and now - self.last_map_update > 2 * 60:
-            requests.post('{}/next_loc?lat={}&lon={}'.format(self.config['address'], self.bot.position[0], self.bot.position[1]))
-            logger.log('Updated PokemonGo-Map position')
-            self.last_map_update = now
-
-    def snipe(self, pokemon):
-        last_position = self.bot.position[0:2]
-
-        self.bot.heartbeat()
-
-        logger.log('Teleporting to {} ({})'.format(pokemon['name'], format_dist(pokemon['dist'], self.unit)), 'green')
-        self.bot.api.set_position(pokemon['latitude'], pokemon['longitude'], 0)
-
-        logger.log('Encounter pokemon', 'green')
-        catch_worker = PokemonCatchWorker(pokemon, self.bot)
-        api_encounter_response = catch_worker.create_encounter_api_call()
-
-        time.sleep(2)
-        logger.log('Teleporting back to previous location..', 'green')
-        self.bot.api.set_position(last_position[0], last_position[1], 0)
-        time.sleep(2)
-        self.bot.heartbeat()
-
-        catch_worker.work(api_encounter_response)
-        self.add_caught(pokemon)
-
-        return WorkerResult.SUCCESS
-
-    def dump_caught_pokemon(self):
-        user_data_map_caught = 'data/map-caught-{}.json'.format(self.bot.config.username)
-        with open(user_data_map_caught, 'w') as outfile:
-            json.dump(self.caught, outfile)
+            if self.bot.config.map_mode == 'priority' and pokemon['score'] < 1:
+                continue
+            new_list.append(pokemon)
+        return new_list
 
     def work(self):
-        # check for pokeballs (excluding masterball)
-        pokeballs = self.bot.item_inventory_count(1)
-        superballs = self.bot.item_inventory_count(2)
-        ultraballs = self.bot.item_inventory_count(3)
+        unit = self.bot.config.distance_unit
+        pokemon_on_map = self.get_pokemon_from_map()
+        pokemon_on_map = self.score_pokemon(pokemon_on_map)
+        pokemon_on_map.sort(key=lambda x: x['score'], reverse=True)
 
-        if (pokeballs + superballs + ultraballs) < 1:
-            return WorkerResult.SUCCESS
+        if (len(pokemon_on_map) < 1):
+            return
 
-        self.update_map_location()
-        self.dump_caught_pokemon()
+        pokemon = pokemon_on_map[0]
+        logger.log('Moving towards {}, {} left'.format(pokemon['name'], format_dist(pokemon['dist'], unit)))
 
-        pokemon_list = self.get_pokemon_from_map()
-        pokemon_list.sort(key=lambda x: x['dist'])
-        if self.config['mode'] == 'priority':
-            pokemon_list.sort(key=lambda x: x['priority'], reverse=True)
-        if self.config['prioritize_vips']:
-            pokemon_list.sort(key=lambda x: x['is_vip'], reverse=True)
-
-        if len(pokemon_list) < 1:
-            return WorkerResult.SUCCESS
-
-        pokemon = pokemon_list[0]
-
-        # if we only have ultraballs and the target is not a vip don't snipe/walk
-        if (pokeballs + superballs) < 1 and not pokemon['is_vip']:
-            return WorkerResult.SUCCESS
-
-        if self.config['snipe']:
-            return self.snipe(pokemon)
-
-        now = int(time.time())
-        logger.log('Moving towards {}, {} left ({})'.format(pokemon['name'], format_dist(pokemon['dist'], self.unit), format_time(pokemon['disappear_time'] - now)))
         step_walker = StepWalker(
-            self.bot,
-            self.bot.config.walk,
-            pokemon['latitude'],
-            pokemon['longitude']
-        )
+                self.bot,
+                self.bot.config.walk,
+                pokemon['lat'],
+                pokemon['lon']
+            )
 
         if not step_walker.step():
             return WorkerResult.RUNNING
 
         logger.log('Arrived at {}'.format(pokemon['name']))
-        self.add_caught(pokemon)
+        self.addCaught(pokemon)
+
         return WorkerResult.SUCCESS

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -74,7 +74,7 @@ class MoveToMapPokemon(BaseTask):
                 return
         if len(self.caught) >= 200:
             self.caught.pop(0)
-        self.caught.append(pokemon['encounter_id'])
+        self.caught.append(pokemon)
 
     def addSeen(self, pokemon):
         for seen_pokemon in self.seen:
@@ -82,7 +82,7 @@ class MoveToMapPokemon(BaseTask):
                 return
         if len(self.seen) >= 200:
             self.seen.pop(0)
-        self.seen.append(pokemon['encounter_id'])
+        self.seen.append(pokemon)
 
     def removeSeen(self, pokemon):
         for idx in xrange(len(self.seen)):
@@ -142,8 +142,7 @@ class MoveToMapPokemon(BaseTask):
         # remove caught pokemon from candidates
         if 'catchable_pokemons' in self.bot.cell and len(self.bot.cell['catchable_pokemons']) > 0:
             for catchable_pokemon in self.bot.cell['catchable_pokemons']:
-                if pokemon['encounter_id'] == catchable_pokemon['encounter_id']:
-                    self.addSeen(pokemon)
+                self.addSeen(catchable_pokemon)
 
             for seen_pokemon in self.seen:
                 for catchable_pokemon in self.bot.cell['catchable_pokemons']:

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -152,7 +152,7 @@ class MoveToMapPokemon(object):
         logger.log('Moving towards {}, {} left'.format(pokemon['name'], format_dist(pokemon['dist'], unit)))
 
 
-        if self.bot.config.walk > 0:
+        if self.bot.config.walk > 0 and not self.config['snipe']:
             step_walker = StepWalker(
                     self.bot,
                     self.bot.config.walk,

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -48,7 +48,10 @@ class MoveToMapPokemon(BaseTask):
             if pokemon['encounter_id'] in self.caught:
                 continue
 
-            pokemon['priority'] = self.config['catch'][pokemon['name']]
+            if pokemon['name'] in self.config['catch']:
+                pokemon['priority'] = self.config['catch'][pokemon['name']]
+            else:
+                pokemon['priority'] = 0
 
             pokemon['dist'] = distance(
                 self.bot.position[0],

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -83,7 +83,6 @@ class MoveToMapPokemon(object):
     def addCaught(self, pokemon):
         if len(self.caught) >= 200:
             self.caught.pop(0)
-        logger.log('e_id: {}'.format(pokemon['encounter_id']))
         self.caught.append(pokemon['encounter_id'])
 
     def score_pokemon(self, pokemon_list):

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -5,7 +5,7 @@ import time
 import requests
 import base64
 from pokemongo_bot import logger
-from pokemongo_bot.cell_workers.utils import distance, i2f, format_dist
+from pokemongo_bot.cell_workers.utils import distance, i2f, format_dist, format_time
 from pokemongo_bot.human_behaviour import sleep
 from pokemongo_bot.step_walker import StepWalker
 from pokemongo_bot.worker_result import WorkerResult
@@ -37,6 +37,7 @@ class MoveToMapPokemon(object):
         for pokemon in raw_data['pokemons']:
             pokemon['encounter_id'] = long(base64.b64decode(pokemon['encounter_id']))
             pokemon['spawn_point_id'] = pokemon['spawnpoint_id']
+            pokemon['disappear_time'] = int(pokemon['disappear_time'] / 1000)
 
             pokemon['dist'] = distance(
                 self.bot.position[0],
@@ -179,7 +180,7 @@ class MoveToMapPokemon(object):
         if self.bot.config.walk <= 0 or self.config['snipe']:
             return self.snipe(pokemon)
 
-        logger.log('Moving towards {}, {} left'.format(pokemon['name'], format_dist(pokemon['dist'], self.unit)))
+        logger.log('Moving towards {}, {} left ({})'.format(pokemon['name'], format_dist(pokemon['dist'], self.unit), format_time(pokemon['disappear_time'] - now)))
         step_walker = StepWalker(
             self.bot,
             self.bot.config.walk,

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -95,6 +95,9 @@ class MoveToMapPokemon(object):
                 score -= pokemon['dist']
             elif self.config['mode'] == 'priority':
                 score += self.get_config_priority(pokemon['pokemon_id'])
+            elif self.config['mode'] == 'hybrid':
+                score += self.get_config_priority(pokemon['pokemon_id'])
+                score -= pokemon['dist']
 
             pokemon['name'] = self.get_name_from_id(pokemon['pokemon_id'])
             pokemon['score'] = score
@@ -145,14 +148,19 @@ class MoveToMapPokemon(object):
             return
 
         pokemon = pokemon_on_map[0]
+        now = int(time.time())
         logger.log('Moving towards {}, {} left'.format(pokemon['name'], format_dist(pokemon['dist'], unit)))
 
-        step_walker = StepWalker(
-                self.bot,
-                self.bot.config.walk,
-                pokemon['lat'],
-                pokemon['lon']
-            )
+
+        if self.bot.config.walk > 0:
+            step_walker = StepWalker(
+                    self.bot,
+                    self.bot.config.walk,
+                    pokemon['lat'],
+                    pokemon['lon']
+                )
+        else:
+            self.bot.api.set_position(pokemon['lat'], pokemon['lon'])
 
         if not step_walker.step():
             return WorkerResult.RUNNING

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
+import os
 import time
+import json
 import base64
 import requests
 from pokemongo_bot import logger
@@ -15,8 +17,14 @@ class MoveToMapPokemon(BaseTask):
     def initialize(self):
         self.last_map_update = 0
         self.pokemon_data = self.bot.pokemon_list
-        self.caught = []
         self.unit = self.bot.config.distance_unit
+        self.caught = []
+
+        data_file = 'data/map-caught-{}.json'.format(self.bot.config.username)
+        if os.path.isfile(data_file):
+            self.caught = json.load(
+                open(data_file)
+            )
 
     def get_pokemon_from_map(self):
         try:
@@ -126,9 +134,14 @@ class MoveToMapPokemon(BaseTask):
 
         return WorkerResult.SUCCESS
 
+    def dump_caught_pokemon(self):
+        user_data_map_caught = 'data/map-caught-{}.json'.format(self.bot.config.username)
+        with open(user_data_map_caught, 'w') as outfile:
+            json.dump(self.caught, outfile)
 
     def work(self):
         self.update_map_location()
+        self.dump_caught_pokemon()
 
         pokemon_list = self.get_pokemon_from_map()
         pokemon_list.sort(key=lambda x: x['dist'])

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -30,10 +30,14 @@ class MoveToMapPokemon(BaseTask):
         try:
             req = requests.get('{}/raw_data?gyms=false&scanned=false'.format(self.config['address']))
         except requests.exceptions.ConnectionError:
-            logger.log('Could not reach PokemonGo-Map Server', color='red')
+            logger.log('Could not reach PokemonGo-Map Server', 'red')
             return []
 
-        raw_data = req.json()
+        try:
+            raw_data = req.json()
+        except ValueError:
+            logger.log('Map data was not valid', 'red')
+            return []
 
         pokemon_list = []
         now = int(time.time())
@@ -90,9 +94,14 @@ class MoveToMapPokemon(BaseTask):
         try:
             req = requests.get('{}/loc'.format(self.config['address']))
         except requests.exceptions.ConnectionError:
-            logger.log('Could not reach PokemonGo-Map Server', color='red')
+            logger.log('Could not reach PokemonGo-Map Server', 'red')
             return
-        loc_json = req.json()
+
+        try:
+            loc_json = req.json()
+        except ValueError:
+            return log.logger('Map location data was not valid', 'red')
+
 
         dist = distance(
             self.bot.position[0],
@@ -110,7 +119,7 @@ class MoveToMapPokemon(BaseTask):
 
     def snipe(self, pokemon):
         last_position = self.bot.position[0:2]
-        self.bot.check_session(last_position)
+
         self.bot.heartbeat()
 
         logger.log('Teleporting to {} ({})'.format(pokemon['name'], format_dist(pokemon['dist'], self.unit)), 'green')

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -101,6 +101,10 @@ class MoveToMapPokemon(object):
 
             if self.config['mode'] == 'priority' and pokemon['score'] < 1:
                 continue
+
+            if pokemon['name'] in self.config['ignore']:
+                continue
+
             new_list.append(pokemon)
         return new_list
 

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -118,7 +118,7 @@ class MoveToMapPokemon(BaseTask):
         now = int(time.time())
         if dist > 500 and now - self.last_map_update > 2 * 60:
             requests.post('{}/next_loc?lat={}&lon={}'.format(self.config['address'], self.bot.position[0], self.bot.position[1]))
-            logger.log('Updated PokemonGo-Map position')
+            logger.log('Updated PokemonGo-Map position', 'green')
             self.last_map_update = now
 
     def snipe(self, pokemon):

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -97,6 +97,8 @@ class MoveToMapPokemon(BaseTask):
                 return
 
     def update_map_location(self):
+        if not self.config['update_map']:
+            return
         try:
             r = requests.get('{}/loc'.format(self.config['address']))
         except:

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -147,7 +147,7 @@ class MoveToMapPokemon(BaseTask):
         pokeballs += self.bot.item_inventory_count(3)
 
         if pokeballs < 1:
-            return
+            return WorkerResult.SUCCESS
 
         self.update_map_location()
         self.dump_caught_pokemon()

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -54,7 +54,7 @@ class MoveToMapPokemon(object):
                 lon
             )
 
-            if dist > self.config['max_distance']:
+            if dist > self.config['max_distance'] and self.config['mode'] != 'snipe':
                 continue
 
             if encounter_id in self.caught:

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -39,7 +39,7 @@ class MoveToMapPokemon(BaseTask):
             pokemon['name'] = self.pokemon_data[pokemon['pokemon_id'] - 1]['Name']
             pokemon['is_vip'] = pokemon['name'] in self.bot.config.vips
 
-            if (pokemon['name'] not in self.config['catch']):
+            if pokemon['name'] not in self.config['catch'] and pokemon['name'] not in self.bot.config.vips:
                 continue
 
             if pokemon['disappear_time'] < (now + self.config['min_time']):

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -98,7 +98,6 @@ class MoveToMapPokemon(BaseTask):
 
         logger.log('Teleporting to {} ({})'.format(pokemon['name'], format_dist(pokemon['dist'], self.unit)), 'green')
         self.bot.api.set_position(pokemon['latitude'], pokemon['longitude'], 0)
-        cell = self.bot.get_meta_cell()
 
         logger.log('Encounter pokemon', 'green')
         catchWorker = PokemonCatchWorker(pokemon, self.bot)
@@ -136,6 +135,9 @@ class MoveToMapPokemon(BaseTask):
                 if pokemon['encounter_id'] == catchable_pokemon['encounter_id']:
                     self.addCaught(pokemon)
                     return WorkerResult.SUCCESS
+
+        if self.config['snipe']:
+            return self.snipe(pokemon)
 
         now = int(time.time())
         logger.log('Moving towards {}, {} left ({})'.format(pokemon['name'], format_dist(pokemon['dist'], self.unit), format_time(pokemon['disappear_time'] - now)))

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -146,7 +146,6 @@ class MoveToMapPokemon(BaseTask):
         pokeballs += self.bot.item_inventory_count(2)
         pokeballs += self.bot.item_inventory_count(3)
 
-        print pokeballs
         if pokeballs < 1:
             return
 

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -78,7 +78,7 @@ class MoveToMapPokemon(BaseTask):
 
     def wasCaught(self, pokemon):
         for caught_pokemon in self.caught:
-            if pokemon['encounter_id'] == caught['encounter_id']:
+            if pokemon['encounter_id'] == caught_pokemon['encounter_id']:
                 return True
         return False
 

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -138,8 +138,12 @@ class MoveToMapPokemon(object):
 
     def snipe(self, pokemon):
         last_position = self.bot.position[0:2]
-        logger.log('Teleporting to {} ({})'.format(pokemon['name'], format_dist(pokemon['dist'], self.unit)))
+        self.bot.check_session(last_position)
+        self.bot.heartbeat()
+
+        logger.log('Teleporting to {} ({})'.format(pokemon['name'], format_dist(pokemon['dist'], self.unit)), 'green')
         self.bot.api.set_position(pokemon['lat'], pokemon['lon'], 0)
+        cell = self.bot.get_meta_cell()
 
         logger.log('Encounter pokemon', 'green')
         pokemon['latitude'] = pokemon['lat']
@@ -148,12 +152,13 @@ class MoveToMapPokemon(object):
         apiEncounterResponse = catchWorker.create_encounter_api_call()
 
         time.sleep(2)
-        logger.log('Teleport back previous location..', 'green')
+        logger.log('Teleport back to previous location..', 'green')
         self.bot.api.set_position(last_position[0], last_position[1], 0)
         time.sleep(2)
         self.bot.heartbeat()
 
         catchWorker.work(apiEncounterResponse)
+        self.addCaught(pokemon)
 
         return WorkerResult.SUCCESS
 
@@ -172,6 +177,9 @@ class MoveToMapPokemon(object):
 
         if (len(pokemon_on_map) < 1):
             return
+
+        for idx in xrange(5):
+            print pokemon_on_map[0]
 
         pokemon = pokemon_on_map[0]
         now = int(time.time())

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -46,7 +46,7 @@ class MoveToMapPokemon(BaseTask):
             if pokemon['disappear_time'] < (now + self.config['min_time']):
                 continue
 
-            if pokemon['encounter_id'] in self.caught:
+            if self.wasCaught(pokemon):
                 continue
 
             if pokemon['name'] in self.config['catch']:
@@ -75,6 +75,12 @@ class MoveToMapPokemon(BaseTask):
         if len(self.caught) >= 200:
             self.caught.pop(0)
         self.caught.append(pokemon)
+
+    def wasCaught(self, pokemon):
+        for caught_pokemon in self.caught:
+            if pokemon['encounter_id'] == caught['encounter_id']:
+                return True
+        return False
 
     def addSeen(self, pokemon):
         for seen_pokemon in self.seen:

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -118,7 +118,7 @@ class MoveToMapPokemon(object):
 
             if has_vips:
                 if not self.is_vip(pokemon['pokemon_id']):
-                pokemon['score'] = 0
+                    pokemon['score'] = 0
 
             new_list.append(pokemon)
         return new_list

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -140,6 +140,16 @@ class MoveToMapPokemon(BaseTask):
             json.dump(self.caught, outfile)
 
     def work(self):
+        # check for pokeballs (excluding masterball)
+        pokeballs = 0
+        pokeballs += self.bot.item_inventory_count(1)
+        pokeballs += self.bot.item_inventory_count(2)
+        pokeballs += self.bot.item_inventory_count(3)
+
+        print pokeballs
+        if pokeballs < 1:
+            return
+
         self.update_map_location()
         self.dump_caught_pokemon()
 

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -43,7 +43,11 @@ class MoveToMapPokemon(BaseTask):
         now = int(time.time())
 
         for pokemon in raw_data['pokemons']:
-            pokemon['encounter_id'] = long(base64.b64decode(pokemon['encounter_id']))
+            try:
+                pokemon['encounter_id'] = long(base64.b64decode(pokemon['encounter_id']))
+            except TypeError:
+                log.logger('base64 error: {}'.format(pokemon['encounter_id']), 'red')
+                continue
             pokemon['spawn_point_id'] = pokemon['spawnpoint_id']
             pokemon['disappear_time'] = int(pokemon['disappear_time'] / 1000)
             pokemon['name'] = self.pokemon_data[pokemon['pokemon_id'] - 1]['Name']

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -152,7 +152,7 @@ class MoveToMapPokemon(BaseTask):
         pokemon_list.sort(key=lambda x: x['dist'])
         if self.config['mode'] == 'priority':
             pokemon_list.sort(key=lambda x: x['priority'], reverse=True)
-        if self.config['prioritize_vips'] == 'priority':
+        if self.config['prioritize_vips']:
             pokemon_list.sort(key=lambda x: x['is_vip'], reverse=True)
 
         if len(pokemon_list) < 1:

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -141,12 +141,11 @@ class MoveToMapPokemon(BaseTask):
 
     def work(self):
         # check for pokeballs (excluding masterball)
-        pokeballs = 0
-        pokeballs += self.bot.item_inventory_count(1)
-        pokeballs += self.bot.item_inventory_count(2)
-        pokeballs += self.bot.item_inventory_count(3)
+        pokeballs = self.bot.item_inventory_count(1)
+        superballs = self.bot.item_inventory_count(2)
+        ultraballs = self.bot.item_inventory_count(3)
 
-        if pokeballs < 1:
+        if (pokeballs + superballs + ultraballs) < 1:
             return WorkerResult.SUCCESS
 
         self.update_map_location()
@@ -163,6 +162,10 @@ class MoveToMapPokemon(BaseTask):
             return WorkerResult.SUCCESS
 
         pokemon = pokemon_list[0]
+
+        # if we only have ultraballs and the target is not a vip don't snipe/walk
+        if (pokeballs + superballs) < 1 and not pokemon['is_vip']:
+            return WorkerResult.SUCCESS
 
         if self.config['snipe']:
             return self.snipe(pokemon)

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -99,6 +99,8 @@ class MoveToMapPokemon(object):
 
         for pokemon in pokemon_list:
             score = 0
+            if self.is_vip(pokemon['pokemon_id']):
+                score += 10000
             if self.config['mode'] == 'distance':
                 score -= pokemon['dist']
             elif self.config['mode'] == 'priority':

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -94,7 +94,7 @@ class MoveToMapPokemon(object):
         for pokemon in pokemon_list:
             score = 0
             if self.config['prioritize_vips'] and self.is_in_vip(pokemon['pokemon_id']):
-                score += 1000
+                score += 10000
             if self.config['mode'] == 'distance':
                 score -= pokemon['dist']
             elif self.config['mode'] == 'priority':

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -186,9 +186,14 @@ class MoveToMapPokemon(BaseTask):
                 '{}/next_loc?lat={}&lon={}'.format(self.config['address'], 
                                                    self.bot.position[0], 
                                                    self.bot.position[1]))
-            self.emit_event('move_to_map_pokemon_updated_map', 
-                            lat=self.bot.position[0],
-                            lon=self.bot.position[1])
+            self.emit_event(
+                'move_to_map_pokemon_updated_map',
+                formatted='Updated PokemonGo-Map to {lat}, {lon}',
+                data={
+                    'lat': self.bot.position[0],
+                    'lon': self.bot.position[1]
+                }
+            )
             self.last_map_update = now
 
     def snipe(self, pokemon):

--- a/pokemongo_bot/logger.py
+++ b/pokemongo_bot/logger.py
@@ -13,8 +13,27 @@ def log(msg, color=None):
         "server but it's really necessary, use the self.logger variable "
         "inside any class inheriting from BaseTask to log."
 
-    )
-
-    logger = logging.getLogger('generic')
-    logger.info(msg)
-    warnings.warn(message, DeprecationWarning)
+def log(string, color='white'):
+    color_hex = {
+        'red': '91m',
+        'green': '92m',
+        'yellow': '93m',
+        'blue': '94m',
+        'cyan': '96m'
+    }
+    if color not in color_hex:
+        print('[{time}] {string}'.format(
+            time=time.strftime("%H:%M:%S"),
+            string=string.decode('utf-8')
+        ))
+    else:
+        print(
+            '[{time}]\033[{color} {string} \033[0m'.format(
+                time=time.strftime("%H:%M:%S"),
+                color=color_hex[color],
+                string=string.decode('utf-8')
+            )
+        )
+    if lcd:
+        if string:
+            lcd.message(string)


### PR DESCRIPTION
Short Description: 

Update `MoveToMapPokemon` to use events instead of logger. Same as [PR 2867](https://github.com/PokemonGoF/PokemonGo-Bot/pull/2867) but includes documentation and a refactor of the module.

Fixes:
- Deprecation warnings emitted by MoveToMapPokemon.

