### PR TITLE
Keep track of how many pokemon released

### DIFF
--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -187,6 +187,7 @@ class TransferPokemon(BaseTask):
 
     def release_pokemon(self, pokemon_name, cp, iv, pokemon_id):
         response_dict = self.bot.api.release_pokemon(pokemon_id=pokemon_id)
+        self.bot.metrics.released_pokemon()
         self.emit_event(
             'pokemon_release',
             formatted='Exchanged {pokemon} [CP {cp}] [IV {iv}] for candy.',


### PR DESCRIPTION
Short Description: 

The number of pokemon released is always 0 in the summary upon exit. This RP fix that.