### PR TITLE
Setting Library path to work with encrypt.so

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,6 @@ RUN cd /tmp && wget "http://pgoapi.com/pgoencrypt.tar.gz" \
 
 VOLUME ["/usr/src/app/web"]
 
+ENV LD_LIBRARY_PATH /usr/src/app
+
 ENTRYPOINT ["python", "pokecli.py"]


### PR DESCRIPTION
**Short Description**: Setting up `LD_LIBRARY_PATH` Environment variable on Dockerfile

**Fixes**: This was the only way to start the container smoothly with the new `encrypt.so` requirement.