### PR TITLE
Add colored logs

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -127,5 +127,12 @@
         "Weezing": {},
         "Flareon": {}
 
+    },
+    "logger": {
+        "colors": {
+            "info": "green",
+            "warning": "yellow",
+            "error": "red"
+        }
     }
 }

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -353,5 +353,12 @@
         "Weezing": {},
         "Flareon": {}
 
+    },
+    "logger": {
+        "colors": {
+            "info": "green",
+            "warning": "yellow",
+            "error": "red"
+        }
     }
 }

--- a/pokecli.py
+++ b/pokecli.py
@@ -29,6 +29,7 @@ import argparse
 import codecs
 import json
 import logging
+import coloredlogs
 import os
 import ssl
 import sys
@@ -45,11 +46,7 @@ from pokemongo_bot.plugin_loader import PluginLoader
 if sys.version_info >= (2, 7, 9):
     ssl._create_default_https_context = ssl._create_unverified_context
 
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s [%(name)10s] [%(levelname)s] %(message)s')
-logger = logging.getLogger('cli')
-logger.setLevel(logging.INFO)
+    logger = logging.getLogger('cli')
 
 def main():
     try:
@@ -382,6 +379,12 @@ def init_config():
         config.username = raw_input("Username: ")
     if not config.password and 'password' not in load:
         config.password = getpass("Password: ")
+
+    # Logger colors
+    config.logger = load.get('logger', {})
+    coloredlogs.DEFAULT_LEVEL_STYLES = {'info': {'color': config.logger["colors"]["info"]}, 'critical': {'color': config.logger["colors"]["error"], 'bold': True}, 'verbose': {'color': 'blue'}, 'error': {'color': config.logger["colors"]["error"]}, 'debug': {'color': 'green'}, 'warning': {'color': config.logger["colors"]["warning"]}}
+    coloredlogs.DEFAULT_LOG_FORMAT='%(asctime)s [%(name)10s] [%(levelname)s] %(message)s'
+    coloredlogs.install(level='INFO')
 
     config.catch = load.get('catch', {})
     config.release = load.get('release', {})

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ gpxpy==1.1.1
 mock==2.0.0
 timeout-decorator==0.3.2
 raven==5.23.0
+coloredlogs


### PR DESCRIPTION
Adds colored logs back.
Can be reverted when a "real" solution is found.

+ Colored logs
+ Colors configurable through config

Supported colors:
black, red, green, yellow, blue, magenta, cyan, white