### PR TITLE
Fixed #3000 #2998

### DIFF
--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -335,7 +335,7 @@ class MoveToMapPokemon(BaseTask):
         self.emit_event(
             'move_to_map_pokemon_teleport_back',
             formatted=('Teleporting back to previous location ({last_lat}, '
-                       '{last_long})'),
+                       '{last_lon})'),
             data={'last_lat': last_position[0], 'last_lon': last_position[1]}
         )
         self.bot.api.set_position(last_position[0], last_position[1], 0)


### PR DESCRIPTION
Fixes:
- Fixed "move_to_map_pokemon.py" syntax error.



Fixed syntax error on "move_to_map_pokemon.py" that makes the client crash when using this feature.