### PR TITLE
Dockerfile: fix missing backslashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN cd /tmp && wget "http://pgoapi.com/pgoencrypt.tar.gz" \
     && tar zxvf pgoencrypt.tar.gz \
     && cd pgoencrypt/src \
     && make \
-    && cp libencrypt.so /usr/src/app/encrypt.so
-    && cd /tmp
+    && cp libencrypt.so /usr/src/app/encrypt.so \
+    && cd /tmp \
     && rm -rf /tmp/pgoencrypt*
 
 VOLUME ["/usr/src/app/web"]


### PR DESCRIPTION
Short Description: 

Fixes:
- Backslashes missing in Dockerfiles, otherwise image couldn't be built correctly

