### PR TITLE
Change word usage: "fled" to "escaped"

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -324,8 +324,8 @@ class PokemonCatchWorker(BaseTask):
                                     'CATCH_POKEMON']['status']
                                 if status is 2:
                                     self.emit_event(
-                                        'pokemon_fled',
-                                        formatted="{pokemon} fled.",
+                                        'pokemon_escaped',
+                                        formatted="{pokemon} escaped.",
                                         data={'pokemon': pokemon_name}
                                     )
                                     sleep(2)


### PR DESCRIPTION
Short Description: 

Fixes:
- 
- 
- #3117 


"fled" is confusing to lot of people and is easily confused with pokemon vanishing. "escaped" is a better term.