### PR TITLE
When JSON parsing fails, give a rough indication of why

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -42,6 +42,12 @@ from pokemongo_bot import PokemonGoBot, TreeConfigBuilder
 from pokemongo_bot.health_record import BotEvent
 from pokemongo_bot.plugin_loader import PluginLoader
 
+try:
+    from demjson import jsonlint
+except ImportError:
+    # Run `pip install -r requirements.txt` to fix this
+    jsonlint = None
+
 if sys.version_info >= (2, 7, 9):
     ssl._create_default_https_context = ssl._create_unverified_context
 
@@ -162,16 +168,28 @@ def init_config():
     # If config file exists, load variables from json
     load = {}
 
+    def _json_loader(filename):
+        try:
+            with open(filename, 'rb') as data:
+                load.update(json.load(data))
+        except ValueError:
+            if jsonlint:
+                with open(filename, 'rb') as data:
+                    lint = jsonlint()
+                    rc = lint.main(['-v', filename])
+
+            logger.critical('Error with configuration file')
+            sys.exit(-1)
+
     # Select a config file code
     parser.add_argument("-cf", "--config", help="Config File to use")
     config_arg = parser.parse_known_args() and parser.parse_known_args()[0].config or None
+
     if config_arg and os.path.isfile(config_arg):
-        with open(config_arg) as data:
-            load.update(json.load(data))
+        _json_loader(config_arg)
     elif os.path.isfile(config_file):
         logger.info('No config argument specified, checking for /configs/config.json')
-        with open(config_file) as data:
-            load.update(json.load(data))
+        _json_loader(config_file)
     else:
         logger.info('Error: No /configs/config.json or specified config')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ gpxpy==1.1.1
 mock==2.0.0
 timeout-decorator==0.3.2
 raven==5.23.0
+-e git+https://github.com/dmeranda/demjson.git@5bc65974e7141746acc88c581f5d2dfb8ea14064#egg=demjson

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ gpxpy==1.1.1
 mock==2.0.0
 timeout-decorator==0.3.2
 raven==5.23.0
--e git+https://github.com/dmeranda/demjson.git@5bc65974e7141746acc88c581f5d2dfb8ea14064#egg=demjson
+demjson==2.2.4


### PR DESCRIPTION
Try to report back any problems with the provided JSON config file to the user.

Here is an example of the output:

```
user@machine:~/git/PokemonGo-Bot$ python pokecli.py -cf configs/duff.json
2016-08-08 20:25:01,880 [       cli] [INFO] PokemonGO Bot v1.0
configs/duff.json:2:20: Error: Can not decode value starting with character u'\u201c'
   |  At line 2, column 20, offset 22
configs/duff.json:2:25: Info: Recovering parsing after character u','
   |  At line 2, column 25, offset 27
configs/duff.json: has errors
2016-08-08 20:25:01,946 [       cli] [CRITICAL] Error with configuration file
```
Made possible thanks to the demjson module.