### PR TITLE
MoveToMapPokemon will not run if total amount of balls is too low

### DIFF
--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -58,6 +58,7 @@
           "address": "http://localhost:5000",
           "max_distance": 500,
           "min_time": 60,
+          "min_ball": 1,
           "prioritize_vips": true,
           "snipe": false,
           "update_map": true,

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -230,8 +230,13 @@ class MoveToMapPokemon(BaseTask):
         pokeballs = self.bot.item_inventory_count(1)
         superballs = self.bot.item_inventory_count(2)
         ultraballs = self.bot.item_inventory_count(3)
+    
+        min_ball = 1
+        #Load the minnimum amount of ball from configuration file
+        if self.config['min_ball']:
+            min_ball = self.config['min_ball']
 
-        if (pokeballs + superballs + ultraballs) < 1:
+        if (pokeballs + superballs + ultraballs) < min_ball:
             return WorkerResult.SUCCESS
 
         self.update_map_location()


### PR DESCRIPTION
* Add ability to skip the MoveToMapPokemon task if total amount of balls is too low

Sometimes, MoveToMapPokemon task will eat your balls very quickly without enough spin_fort. With this setting, MoveToMapPokemon will not run unless you have total amount of balls (combination of Pokeballs, Greatballs and Ultraballs) higher than your desired number. Otherwise, It will run the MoveToFort task.

