### PR TITLE
Configurable minimum balls to run MoveToMap task

### DIFF
--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -58,6 +58,7 @@
           "address": "http://localhost:5000",
           "max_distance": 500,
           "min_time": 60,
+          "min_ball": 50,
           "prioritize_vips": true,
           "snipe": false,
           "update_map": true,

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -82,6 +82,7 @@ class MoveToMapPokemon(BaseTask):
         self.pokemon_data = self.bot.pokemon_list
         self.unit = self.bot.config.distance_unit
         self.caught = []
+        self.min_ball = self.config.get('min_ball', 1)
 
         data_file = 'data/map-caught-{}.json'.format(self.bot.config.username)
         if os.path.isfile(data_file):
@@ -250,7 +251,7 @@ class MoveToMapPokemon(BaseTask):
         pokemon = pokemon_list[0]
 
         # if we only have ultraballs and the target is not a vip don't snipe/walk
-        if (pokeballs + superballs) < 1 and not pokemon['is_vip']:
+        if (pokeballs + superballs) < self.min_ball and not pokemon['is_vip']:
             return WorkerResult.SUCCESS
 
         if self.config['snipe']:


### PR DESCRIPTION
* Bot only runs MoveToMap task when it has more than the minimum amount of balls (pokeballs+superballs) or the target is VIP's pokemon.


