### PR TITLE
Fix flooding of keep_best_release

### DIFF
--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -50,15 +50,16 @@ class TransferPokemon(BaseTask):
                                                                         True)]
 
                     if transfer_pokemons:
-                        self.emit_event(
-                            'keep_best_release',
-                            formatted="Keeping best {amount} {pokemon}, based on {criteria}",
-                            data={
-                                'amount': len(best_pokemons),
-                                'pokemon': pokemon_name,
-                                'criteria': order_criteria
-                            }
-                        )
+                        if best_pokemons:
+                            self.emit_event(
+                                'keep_best_release',
+                                formatted="Keeping best {amount} {pokemon}, based on {criteria}",
+                                data={
+                                    'amount': len(best_pokemons),
+                                    'pokemon': pokemon_name,
+                                    'criteria': order_criteria
+                                }
+                            )
                         for pokemon in transfer_pokemons:
                             self.release_pokemon(pokemon_name, pokemon['cp'], pokemon['iv'], pokemon['pokemon_data']['id'])
                 else:

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -43,7 +43,13 @@ class TransferPokemon(BaseTask):
                                 all_pokemons.remove(pokemon)
                                 best_pokemons.append(pokemon)
 
-                    if best_pokemons and all_pokemons:
+                    transfer_pokemons = [pokemon for pokemon in all_pokemons
+                                         if self.should_release_pokemon(pokemon_name,
+                                                                        pokemon['cp'],
+                                                                        pokemon['iv'],
+                                                                        True)]
+
+                    if transfer_pokemons:
                         self.emit_event(
                             'keep_best_release',
                             formatted="Keeping best {amount} {pokemon}, based on {criteria}",
@@ -53,14 +59,6 @@ class TransferPokemon(BaseTask):
                                 'criteria': order_criteria
                             }
                         )
-
-                    transfer_pokemons = [pokemon for pokemon in all_pokemons
-                                         if self.should_release_pokemon(pokemon_name,
-                                                                        pokemon['cp'],
-                                                                        pokemon['iv'],
-                                                                        True)]
-
-                    if transfer_pokemons:
                         for pokemon in transfer_pokemons:
                             self.release_pokemon(pokemon_name, pokemon['cp'], pokemon['iv'], pokemon['pokemon_data']['id'])
                 else:


### PR DESCRIPTION
### Short Description: 
Only log `'keep_best_release'` when there are some pokemons to release. The previous version keeps flooding `'keep_best_release'` whenever there are some pokemons which is not in the `best_pokemons` list but still don't satisfy the condition to be released.

This fixes the log flooding issue in #2790, #2753, #2559, #3064, #2787, #3082, #2621 

