### PR TITLE
Keeping a cache of gym information

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -25,6 +25,7 @@ from event_manager import EventManager
 from human_behaviour import sleep
 from item_list import Item
 from metrics import Metrics
+from gym_cache import GymCache
 from pokemongo_bot.event_handlers import LoggingHandler, SocketIoHandler
 from pokemongo_bot.socketio_server.runner import SocketIoRunner
 from pokemongo_bot.websocket_remote_control import WebsocketRemoteControl
@@ -58,6 +59,7 @@ class PokemonGoBot(object):
         )
         self.item_list = json.load(open(os.path.join('data', 'items.json')))
         self.metrics = Metrics(self)
+        self.gym_cache = GymCache(self)
         self.latest_inventory = None
         self.cell = None
         self.recent_forts = [None] * config.forts_max_circle_size
@@ -496,7 +498,7 @@ class PokemonGoBot(object):
                 if 'forts' in cell:
                     for fort in cell['forts']:
                         if fort.get('type') != 1:
-                            response_gym_details = self.api.get_gym_details(
+                            response_gym_details = self.gym_cache.get(
                                 gym_id=fort.get('id'),
                                 player_latitude=lng,
                                 player_longitude=lat,

--- a/pokemongo_bot/gym_cache.py
+++ b/pokemongo_bot/gym_cache.py
@@ -1,0 +1,32 @@
+import time
+
+class GymCache(object):
+    def __init__(self, bot):
+        self.bot = bot
+        self.cache = {}
+        self.cache_length_seconds = 60 * 10
+
+    def get(self, gym_id, player_latitude, player_longitude, gym_latitude, gym_longitude):
+        if gym_id not in self.cache:
+            response_gym_details = self.bot.api.get_gym_details(
+                gym_id=gym_id,
+                player_latitude=player_latitude,
+                player_longitude=player_longitude,
+                gym_latitude=gym_latitude,
+                gym_longitude=gym_longitude
+            )
+
+            self.cache[gym_id] = response_gym_details
+
+        gym_info = self.cache[gym_id]
+        gym_info['last_accessed'] = time.time()
+
+        self._remove_stale_gyms()
+        return gym_info
+
+    def _remove_stale_gyms(self):
+        for gym_id, gym_details in self.cache.items():
+            if gym_details['last_accessed'] < time.time() - self.cache_length_seconds:
+                del self.cache[gym_id]
+
+


### PR DESCRIPTION
Before this change, I was fetching the details of 16 gyms every tick. Since we throttle api requests to two a second, this was 8 seconds of requests every tick to fetch gym information. Now that we are caching it, we essentially remove the entirety of that time. This should have significant impacts to xp/hr.

@douglascamata 