### PR TITLE
Update pgoapi to a newer version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.11.0
 networkx==1.11
--e git+https://github.com/keyphact/pgoapi.git@249d3be7fbbdabc7f9adea17cbc899d6549e47a2#egg=pgoapi
+-e git+https://github.com/keyphact/pgoapi.git@a2755eb42dfe49e359798d2f4defefc97fb8163d#egg=pgoapi
 geopy==1.11.0
 protobuf==3.0.0b4
 requests==2.10.0


### PR DESCRIPTION
Short Description: 
Updates the pgoapi in requirements.txt

Fixes:
Hopefully it fixes these issues:
- #3181
- #3098
- #2874
and possibly more, I haven't checked them all, but it should fix those that ends with this after a certain time:

`File "/usr/local/lib/python2.7/site-packages/google/protobuf/internal/type_checkers.py", line 176, in CheckValue
    raise TypeError(message)
TypeError: None has type <type 'NoneType'>, but expected one of: (<type 'str'>, <type 'unicode'>)`

Needs testing/verification. I am running now, but it does take about an
hour to trigger.