### PR TITLE
Return an empty list if no pokemon are available.

### DIFF
--- a/pokemongo_bot/cell_workers/catch_lured_pokemon.py
+++ b/pokemongo_bot/cell_workers/catch_lured_pokemon.py
@@ -27,7 +27,7 @@ class CatchLuredPokemon(BaseTask):
         forts = self.bot.get_forts(order_by_distance=True)
 
         if len(forts) == 0:
-            return False
+            return []
 
         for fort in forts:
             distance_to_fort = distance(


### PR DESCRIPTION
Short Description: The current dev branch is crashing when trying to catch lured pokemon.

The changes introduced in 4c95259 expose this bug.

The line that triggers the bug is the following:
https://github.com/PokemonGoF/PokemonGo-Bot/commit/4c95259c25543b483a539a928ae67e7e590778f3#diff-900c950b761cc9227d14af60ae8ee987R16

