### PR TITLE
Added a configuration option "path_startmode" (conflict merge #2489)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -57,3 +57,4 @@
  * nikofil
  * bigkraig
  * nikhil-pandey
+ * JaapMoolenaar

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -60,6 +60,7 @@
         "type": "FollowPath",
         "config": {
           "path_mode": "loop",
+          "path_startmode": "first",
           "path_file": "configs/path.example.json"
         }
       }

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -60,7 +60,7 @@
         "type": "FollowPath",
         "config": {
           "path_mode": "loop",
-          "path_startmode": "first",
+          "path_start_mode": "first",
           "path_file": "configs/path.example.json"
         }
       }

--- a/pokemongo_bot/cell_workers/follow_path.py
+++ b/pokemongo_bot/cell_workers/follow_path.py
@@ -3,8 +3,7 @@
 import gpxpy
 import gpxpy.gpx
 import json
-import pokemongo_bot.logger as logger
-from pokemongo_bot.cell_workers.base_task import BaseTask
+from pokemongo_bot.base_task import BaseTask
 from pokemongo_bot.cell_workers.utils import distance, i2f, format_dist
 from pokemongo_bot.human_behaviour import sleep
 from pokemongo_bot.step_walker import StepWalker
@@ -138,7 +137,5 @@ class FollowPath(BaseTask):
                     self.points = list(reversed(self.points))
             else:
                 self.ptr += 1
-
-            logger.log("Moving to next point in path #{}".format(self.ptr+1))
 
         return [lat, lng]

--- a/pokemongo_bot/cell_workers/follow_path.py
+++ b/pokemongo_bot/cell_workers/follow_path.py
@@ -17,7 +17,7 @@ class FollowPath(BaseTask):
         self._process_config()
         self.points = self.load_path()
 
-        if self.path_startmode == 'closest':
+        if self.path_start_mode == 'closest':
             self.ptr = self.find_closest_point_idx(self.points)
         
         else:
@@ -26,7 +26,7 @@ class FollowPath(BaseTask):
     def _process_config(self):
         self.path_file = self.config.get("path_file", None)
         self.path_mode = self.config.get("path_mode", "linear")
-        self.path_startmode = self.config.get("path_startmode", "first")
+        self.path_start_mode = self.config.get("path_start_mode", "first")
 
     def load_path(self):
         if self.path_file is None:

--- a/pokemongo_bot/cell_workers/follow_path.py
+++ b/pokemongo_bot/cell_workers/follow_path.py
@@ -74,7 +74,6 @@ class FollowPath(BaseTask):
         return points
 
     def find_closest_point_idx(self, points):
-        logger.log("Finding closest point in path")
 
         return_idx = 0
         min_distance = float("inf");
@@ -84,9 +83,6 @@ class FollowPath(BaseTask):
             botlng = self.bot.api._position_lng
             lat = float(point['lat'])
             lng = float(point['lng'])
-
-            if self.bot.config.debug:
-                logger.log("Checking if point {}, {} is closest to {}, {}".format(lat, lng, botlat, botlng))
             
             dist = distance(
                 botlat,
@@ -98,8 +94,6 @@ class FollowPath(BaseTask):
             if dist < min_distance:
                 min_distance = dist
                 return_idx = index
-
-        logger.log("Chose closest point in path #{}: {}, {}".format(return_idx+1, points[return_idx]['lat'], points[return_idx]['lng']))
 
         return return_idx
 


### PR DESCRIPTION
_I recreated the fork/repo for easy merging_

_Python is most definitely not my main programming language, however, I thought this was a nice addition to the path walker nonetheless._

Short Description: 
Updates the FollowPath walker to allow a "path_startmode" configuration option. Setting it to "first" mimics the current behavior: move to the first point in the list and walk through them from there. Setting it to the "new" value of "closest" will try to find the closest point to the bots position and first move there before continuing along the other point in the path.

I also added a log message to see which point the bot is walking to (so one can tell it's still walking).

In future updates I imagine having an option to continue to the "next" point in the path using some kind of persisted storage (If it still exists, since path files can change).