### PR TITLE
Fix unexpected egg incubation retry

### DIFF
--- a/pokemongo_bot/cell_workers/incubate_eggs.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs.py
@@ -49,6 +49,8 @@ class IncubateEggs(BaseTask):
 
     def _apply_incubators(self):
         for incubator in self.ready_incubators:
+            if incubator.get('used', False):
+                continue
             for egg in self.eggs:
                 if egg["used"] or egg["km"] == -1:
                     continue


### PR DESCRIPTION
Short Description:
---
- Fix repeated `Incubator in use.` log messages after egg hatched.
- This is caused by logic error related to `incubator["used"]` flag. This flag is set when hatched, but not used at all.

Fixes:
---
- Bot attempts to incubate egg with "already-in-use" incubator repeatedly after hatch.
