### PR TITLE
Dev

### DIFF
--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -61,7 +61,9 @@
           "min_time": 60,
           "min_ball": 50,
           "prioritize_vips": true,
-          "snipe": false,
+          "snipe": true,
+          "snipe_high_prio_only": true,
+          "snipe_high_prio_threshold": 400,
           "update_map": true,
           "mode": "priority",
           "catch": {

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -255,7 +255,11 @@ class MoveToMapPokemon(BaseTask):
             return WorkerResult.SUCCESS
 
         if self.config['snipe']:
-            return self.snipe(pokemon)
+            if self.config['snipe_high_prio_only']:
+                if self.config['snipe_high_prio_threshold'] < pokemon['priority'] or pokemon['is_vip']:
+                    self.snipe(pokemon)
+            else:
+                return self.snipe(pokemon)
 
         step_walker = self._move_to(pokemon)
         if not step_walker.step():


### PR DESCRIPTION
New config values for sniping only filtered pokemon. Reasoning of this feature is to reduce sniping to only important stuff and minimize inhuman behavior - teleporting.

if "snipe_high_prio_only" is true, only VIP pokemon and pokemon with priority higher than "snipe_high_prio_threshold" will be sniped