### PR TITLE
Log stats on terminal

### DIFF
--- a/pokemongo_bot/cell_workers/update_title_stats.py
+++ b/pokemongo_bot/cell_workers/update_title_stats.py
@@ -71,7 +71,7 @@ class UpdateTitleStats(BaseTask):
         self.displayed_stats = self.DEFAULT_DISPLAYED_STATS
 
         self.bot.event_manager.register_event('update_title', parameters=('title'))
-
+        self.bot.event_manager.register_event('log_stats',parameters=('title'))
         self._process_config()
 
     def initialize(self):
@@ -90,6 +90,7 @@ class UpdateTitleStats(BaseTask):
         if not title:
             return WorkerResult.SUCCESS
         self._update_title(title, _platform)
+        self._log_on_terminal(title)
         return WorkerResult.SUCCESS
 
     def _should_display(self):
@@ -99,6 +100,16 @@ class UpdateTitleStats(BaseTask):
         :rtype: bool
         """
         return self.next_update is None or datetime.now() >= self.next_update
+
+    def _log_on_terminal(self, title):
+        self.emit_event(
+            'log_stats',
+            formatted="{title}",
+            data={
+                'title': title
+            }
+        )
+        self.next_update = datetime.now() + timedelta(seconds=self.min_interval)
 
     def _update_title(self, title, platform):
         """
@@ -119,7 +130,7 @@ class UpdateTitleStats(BaseTask):
                 'title': title
             }
         )
-  
+
         if platform == "linux" or platform == "linux2" or platform == "cygwin":
             stdout.write("\x1b]2;{}\x07".format(title))
             stdout.flush()

--- a/pokemongo_bot/cell_workers/update_title_stats.py
+++ b/pokemongo_bot/cell_workers/update_title_stats.py
@@ -55,6 +55,7 @@ class UpdateTitleStats(BaseTask):
 
     DEFAULT_MIN_INTERVAL = 10
     DEFAULT_DISPLAYED_STATS = []
+    TERMINAL = False
 
     def __init__(self, bot, config):
         """
@@ -69,6 +70,7 @@ class UpdateTitleStats(BaseTask):
         self.next_update = None
         self.min_interval = self.DEFAULT_MIN_INTERVAL
         self.displayed_stats = self.DEFAULT_DISPLAYED_STATS
+        self.terminal = self.TERMINAL
 
         self.bot.event_manager.register_event('update_title', parameters=('title'))
         self.bot.event_manager.register_event('log_stats',parameters=('title'))
@@ -90,7 +92,8 @@ class UpdateTitleStats(BaseTask):
         if not title:
             return WorkerResult.SUCCESS
         self._update_title(title, _platform)
-        self._log_on_terminal(title)
+        if(self.terminal is True):
+            self._log_on_terminal(title)
         return WorkerResult.SUCCESS
 
     def _should_display(self):
@@ -152,6 +155,7 @@ class UpdateTitleStats(BaseTask):
         """
         self.min_interval = int(self.config.get('min_interval', self.DEFAULT_MIN_INTERVAL))
         self.displayed_stats = self.config.get('stats', self.DEFAULT_DISPLAYED_STATS)
+        self.terminal = self.config.get('terminal', self.TERMINAL)
 
     def _get_stats_title(self, player_stats):
         """

--- a/pokemongo_bot/cell_workers/update_title_stats.py
+++ b/pokemongo_bot/cell_workers/update_title_stats.py
@@ -102,10 +102,10 @@ class UpdateTitleStats(BaseTask):
         if not title:
             return WorkerResult.SUCCESS
 
-        if self.terminal_title is True:
+        if self.terminal_title:
             self._update_title(title, _platform)
 
-        if self.terminal_log is True:
+        if self.terminal_log:
             self._log_on_terminal(title)
         return WorkerResult.SUCCESS
 

--- a/pokemongo_bot/cell_workers/update_title_stats.py
+++ b/pokemongo_bot/cell_workers/update_title_stats.py
@@ -83,8 +83,8 @@ class UpdateTitleStats(BaseTask):
         self.terminal_log = self.config.get('terminal_log', False)
         self.terminal_title = self.config.get('terminal_title', True)
 
-        self.bot.event_manager.register_event('update_title', parameters=('title'))
-        self.bot.event_manager.register_event('log_stats',parameters=('title'))
+        self.bot.event_manager.register_event('update_title', parameters=('title',))
+        self.bot.event_manager.register_event('log_stats',parameters=('title',))
 
     def initialize(self):
         pass


### PR DESCRIPTION
Short Description: 
Update title stats not working on Git bash users 
Fixes:
- Show a terminal log

EDIT: Maybe add a config parameter to enable this behavior?
EDIT2: Config enable already pushed

If you want to enable stats logging on terminal just add a "terminal_log" parameter set to true on your config file.
Aswell, if you want to disable the title changing, just add an "terminal_title" set to false and it will disable this behavior.
Fe: 
```
{
       "type": "UpdateTitleStats",
       "config": {
           "min_interval": 120,
           "stats": [
             "uptime",
             "xp_earned",
             "xp_per_hour",
             "stardust_earned"
           ],
           "terminal_log": true,
           "terminal_title": false
       }
     },
```