### PR TITLE
PokemonGo-Bot/issues#3366: use self.logger.warning instead of log.logger

### DIFF
--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -176,7 +176,7 @@ class MoveToMapPokemon(BaseTask):
         except ValueError:
             err = 'Map location data was not valid'
             self._emit_failure(err)
-            return log.logger(err, 'red')
+            return self.logger.warning(err)
 
         dist = distance(
             self.bot.position[0],


### PR DESCRIPTION
## Short Description:
[MoveToMap Task](https://github.com/PokemonGoF/PokemonGo-Bot/blob/master/pokemongo_bot/cell_workers/move_to_map_pokemon.py#L177) is using the incorrect function to log warnings. I've updated to use `self.logger.warning` included in `BaseTask`.

## Fixes (provide links to github issues if you can):
Closes #3366 
