### PR TITLE
[FIX] Evolve pokemon before transfer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -60,3 +60,4 @@
  * thebigjc
  * JaapMoolenaar
  * eevee-github
+ * Quantra

--- a/pokemongo_bot/cell_workers/evolve_pokemon.py
+++ b/pokemongo_bot/cell_workers/evolve_pokemon.py
@@ -83,7 +83,7 @@ class EvolvePokemon(BaseTask):
             'and': lambda pokemon: pokemon.cp >= self.evolve_above_cp and pokemon.iv >= self.evolve_above_iv
         }
 
-        for pokemon in inventory.pokemons().all():
+        for pokemon in inventory.pokemons(True).all():
             if pokemon.id > 0 and pokemon.has_next_evolution() and (logic_to_function[self.cp_iv_logic](pokemon)):
                 pokemons.append(pokemon)
 


### PR DESCRIPTION
## Short Description:

Evolve worker refreshes inventory when getting pokemon in inventory to evolve.

Pokemon can be evolved before transfer.

Not sure if bug or feature!  https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Configuration-files#evolve-all-configuration

If not plug please comment and will add config support.



## Fixes (provide links to github issues if you can):
-#3292
-
-