### PR TITLE
Fix Struct() argument 1 must be string, not unicode.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -60,3 +60,4 @@
  * thebigjc
  * JaapMoolenaar
  * eevee-github
+ * g0vanish

--- a/pokemongo_bot/event_handlers/colored_logging_handler.py
+++ b/pokemongo_bot/event_handlers/colored_logging_handler.py
@@ -166,7 +166,7 @@ class ColoredLoggingHandler(EventHandler):
         if self._ioctl is None or self._TIOCGWINSZ is None:
             return None
 
-        h, w, hp, wp = struct.unpack('HHHH',
+        h, w, hp, wp = struct.unpack(str('HHHH'),
             self._ioctl(0, self._TIOCGWINSZ,
-            struct.pack('HHHH', 0, 0, 0, 0)))
+            struct.pack(str('HHHH'), 0, 0, 0, 0)))
         return w


### PR DESCRIPTION
## Short Description:
Fix Struct() argument 1 must be string, not unicode:
```
Traceback (most recent call last):
  File "pokecli.py", line 530, in <module>
    main()
  File "pokecli.py", line 96, in main
    bot.tick()
  File "/home/pi/PokemonGo-Bot/pokemongo_bot/__init__.py", line 458, in tick
    if worker.work() == WorkerResult.RUNNING:
  File "/home/pi/PokemonGo-Bot/pokemongo_bot/cell_workers/move_to_fort.py", line 67, in work
    data=fort_event_data
  File "/home/pi/PokemonGo-Bot/pokemongo_bot/base_task.py", line 27, in emit_event
    data=data
  File "/home/pi/PokemonGo-Bot/pokemongo_bot/event_manager.py", line 65, in emit
    handler.handle_event(event, sender, level, formatted_msg, data)
  File "/home/pi/PokemonGo-Bot/pokemongo_bot/event_handlers/colored_logging_handler.py", line 130, in handle_event
    terminal_width = self._terminal_width()
  File "/home/pi/PokemonGo-Bot/pokemongo_bot/event_handlers/colored_logging_handler.py", line 171, in _terminal_width
    struct.pack('HHHH', 0, 0, 0, 0)))
TypeError: Struct() argument 1 must be string, not unicode
```
Basically convert 
```
struct.pack('HHHH', 0, 0, 0, 0)
```
to
```
struct.pack(str('HHHH'), 0, 0, 0, 0)
```

## Fixes (provide links to github issues if you can):
https://github.com/PokemonGoF/PokemonGo-Bot/issues/3373


