### PR TITLE
Tiny formatting update - transfer_pokemon.py

### DIFF
--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -120,7 +120,7 @@ class TransferPokemon(BaseTask):
         if logic_to_function[cp_iv_logic](*release_results.values()):
             self.emit_event(
                 'future_pokemon_release',
-                formatted="Releasing {pokemon} (CP {cp}/IV {iv}) based on rule: CP < {below_cp} {cp_iv_logic} IV < {below_iv}",
+                formatted="Releasing {pokemon} [CP {cp}] [IV {iv}] based on rule: CP < {below_cp} {cp_iv_logic} IV < {below_iv}",
                 data={
                     'pokemon': pokemon.name,
                     'cp': pokemon.cp,


### PR DESCRIPTION
## Short Description:
An extremely small update to the transfer_pokemon cell worker to make the formatting more consistent with line 192

## Fixes (provide links to github issues if you can):
- n/a