### PR TITLE
Return RUNNING if there are more forts to spin

### DIFF
--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -27,10 +27,12 @@ class SpinFort(BaseTask):
         return self.ignore_item_count or self.bot.has_space_for_loot()
 
     def work(self):
-        fort = self.get_fort_in_range()
+        forts = self.get_forts_in_range()
 
-        if not self.should_run() or fort is None:
+        if not self.should_run() or len(forts) == 0:
             return WorkerResult.SUCCESS
+
+        fort = forts[0]
 
         lat = fort['latitude']
         lng = fort['longitude']
@@ -134,11 +136,15 @@ class SpinFort(BaseTask):
                     )
                 else:
                     self.bot.fort_timeouts[fort["id"]] = (time.time() + 300) * 1000  # Don't spin for 5m
-                return 11
+                return WorkerResult.ERROR
         sleep(2)
-        return 0
 
-    def get_fort_in_range(self):
+        if len(forts) > 1:
+            return WorkerResult.RUNNING
+
+        return WorkerResult.SUCCESS
+
+    def get_forts_in_range(self):
         forts = self.bot.get_forts(order_by_distance=True)
 
         for fort in forts:
@@ -146,21 +152,12 @@ class SpinFort(BaseTask):
                 self.bot.fort_timeouts[fort["id"]] = fort['cooldown_complete_timestamp_ms']
                 forts.remove(fort)
 
-        forts = filter(lambda x: x["id"] not in self.bot.fort_timeouts, forts)
-
-        if len(forts) == 0:
-            return None
-
-        fort = forts[0]
-
-        distance_to_fort = distance(
+        forts = filter(lambda fort: fort["id"] not in self.bot.fort_timeouts, forts)
+        forts = filter(lambda fort: distance(
             self.bot.position[0],
             self.bot.position[1],
             fort['latitude'],
             fort['longitude']
-        )
+        ) <= Constants.MAX_DISTANCE_FORT_IS_REACHABLE, forts)
 
-        if distance_to_fort <= Constants.MAX_DISTANCE_FORT_IS_REACHABLE:
-            return fort
-
-        return None
+        return forts


### PR DESCRIPTION
## Short Description:
Previously, SpinForts only looked at a single fort. It would spin it, and then the task list would continue, causing us to walk, possibly out of range of other forts.

Now when there are more forts to spin, we return RUNNING to cause the tick loop to start over.

This fix should have a relatively large impact if you are in a place with lots of pokestops close together.