### PR TITLE
remove unused code in evolve_pokemon worker

### DIFF
--- a/pokemongo_bot/cell_workers/evolve_pokemon.py
+++ b/pokemongo_bot/cell_workers/evolve_pokemon.py
@@ -117,8 +117,3 @@ class EvolvePokemon(BaseTask):
             cache[pokemon.name] = 1
             sleep(0.7)
             return False
-
-    def _compute_iv(self, pokemon):
-        total_iv = pokemon.get("individual_attack", 0) + pokemon.get("individual_stamina", 0) + pokemon.get(
-            "individual_defense", 0)
-        return round((total_iv / 45.0), 2)


### PR DESCRIPTION
## Short Description:
Previously IV was computed in each worker. Now its fetched from inventory. This was left over and not called in the worker at all.

## Fixes (provide links to github issues if you can):
NOTHING!


