### PR TITLE
Fix error when MoveToFort called from handle_soft_ban.py

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -61,3 +61,4 @@
  * JaapMoolenaar
  * eevee-github
  * g0vanish
+ * cmezh

--- a/pokemongo_bot/cell_workers/move_to_fort.py
+++ b/pokemongo_bot/cell_workers/move_to_fort.py
@@ -13,9 +13,13 @@ class MoveToFort(BaseTask):
 
     def initialize(self):
         self.lure_distance = 0
-        self.lure_attraction = self.config.get("lure_attraction", True)
-        self.lure_max_distance = self.config.get("lure_max_distance", 2000)
-        self.ignore_item_count = self.config.get("ignore_item_count", False)
+        if self.config:
+            self.lure_attraction = self.config.get("lure_attraction", True)
+            self.lure_max_distance = self.config.get("lure_max_distance", 2000)
+            self.ignore_item_count = self.config.get("ignore_item_count", False)
+        else:
+            self.lure_attraction = None
+            self.ignore_item_count = True
 
     def should_run(self):
         has_space_for_loot = self.bot.has_space_for_loot()


### PR DESCRIPTION
Here is error. Appears when MoveToFort called from handle_soft_ban with param config=None.
![screenshot_2016-08-11-01-18-14](https://cloud.githubusercontent.com/assets/20733365/17566293/01a85b9e-5f65-11e6-9199-b73c66b597dc.png)
#3361 
