### PR TITLE
Fix stdout is not a terminal

### DIFF
--- a/pokemongo_bot/event_handlers/colored_logging_handler.py
+++ b/pokemongo_bot/event_handlers/colored_logging_handler.py
@@ -125,7 +125,7 @@ class ColoredLoggingHandler(EventHandler):
             message = 'Something rustles nearby!'
 
         # Truncate previous line if same event continues
-        if event in ColoredLoggingHandler.CONTINUOUS_EVENT_NAMES and self._last_event == event:
+        if event in ColoredLoggingHandler.CONTINUOUS_EVENT_NAMES and self._last_event == event and sys.stdout.isatty():
             # Filling with "' ' * terminal_width" in order to completely clear last line
             terminal_width = self._terminal_width()
             if terminal_width:


### PR DESCRIPTION
Do not use terms related syscall when stdout is not a term (may be a pipe or a log file)

Fix #3508 
