### PR TITLE
Typo fix: show new catch rate after berry throw.

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -251,7 +251,7 @@ class PokemonCatchWorker(BaseTask):
                     data={
                         'berry_name': self.item_list[str(berry_id)],
                         'ball_name': self.item_list[str(current_ball)],
-                        'new_catch_rate': self._pct(catch_rate_by_ball[current_ball])
+                        'new_catch_rate': self._pct(new_catch_rate_by_ball[current_ball])
                     }
                 )
 


### PR DESCRIPTION
Fixed typo.
Catch rate showed after berry throw was the same as before throwing. New catch rate calculated but not showed.