### PR TITLE
Add missing special skill for Venonat Pokemon

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -61,3 +61,4 @@
  * JaapMoolenaar
  * eevee-github
  * g0vanish
+ * pmquan

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -1996,7 +1996,8 @@
       "Dazzling Gleam",
       "Psybeam",
       "Poison Fang",
-      "Shadow Ball"
+      "Shadow Ball",
+      "Signal Beam"
     ],
     "BaseAttack": 108,
     "BaseDefense": 120,


### PR DESCRIPTION
Fix the problem "Exception: Unexpected moveset [Confusion, Signal Beam] for #48 Venonat"