### PR TITLE
Adding support for disabling sleeps intended for app delay parity

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -93,6 +93,7 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
+    "enable_app_emulation_delay": false,
     "evolve_captured": "NONE",
     "catch_randomize_reticle_factor": 1.0,
     "catch_randomize_spin_factor": 1.0,

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -320,6 +320,7 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
+    "enable_app_emulation_delay": false,
     "evolve_captured": "NONE",
     "catch_randomize_reticle_factor": 1.0,
     "catch_randomize_spin_factor": 1.0,

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -80,6 +80,7 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
+    "enable_app_emulation_delay": false,
     "evolve_captured": "NONE",
     "catch_randomize_reticle_factor": 1.0,
     "catch_randomize_spin_factor": 1.0,

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -86,6 +86,7 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
+    "enable_app_emulation_delay": false,
     "evolve_captured": "NONE",
     "catch_randomize_reticle_factor": 1.0,
     "catch_randomize_spin_factor": 1.0,

--- a/pokecli.py
+++ b/pokecli.py
@@ -404,6 +404,15 @@ def init_config():
         default=True
     )
 
+    add_config(
+        parser,
+        load,
+        long_flag="--enable_app_emulation_delay",
+        help="If enable_app_emulation_delay is set to true, the bot will sleep between actions as if you were using the real app",
+        type=bool,
+        default=False
+    )
+
     # Start to parse other attrs
     config = parser.parse_args()
     if not config.username and 'username' not in load:

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -105,8 +105,8 @@ class PokemonCatchWorker(BaseTask):
             }
         )
 
-        # simulate app
-        sleep(3)
+        if self.bot.config.enable_app_emulation_delay:
+            sleep(3)
 
         # check for VIP pokemon
         is_vip = self._is_vip_pokemon(pokemon)
@@ -118,8 +118,8 @@ class PokemonCatchWorker(BaseTask):
         catch_rate_by_ball = [0] + response['capture_probability']['capture_probability']  # offset so item ids match indces
         self._do_catch(pokemon, encounter_id, catch_rate_by_ball, is_vip=is_vip)
 
-        # simulate app
-        time.sleep(5)
+        if self.bot.config.enable_app_emulation_delay:
+            time.sleep(5)
 
     def create_encounter_api_call(self):
         encounter_id = self.pokemon['encounter_id']


### PR DESCRIPTION
We believe the likelihood that Niantic will detect and ban botters will be via the length of time between specific requests is very low.

We have lots of sleeps in the bot that make things run much slower. Some people want the added delay to feel more safe with the bot, others want this bot to crank out as much xp/hr as possible. 

This PR adds a flag that will enable or disable all sleeps intended for app delay parity. This PR disables those delays be default.

