### PR TITLE
Improve Docker Image and `docker-compose.yml`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:2.7-onbuild
+FROM python:2.7
+
+WORKDIR /usr/src/app
+VOLUME ["/usr/app/configs", "/usr/src/app/web"]
 
 ARG timezone=Etc/UTC
 RUN echo $timezone > /etc/timezone \
@@ -15,8 +18,11 @@ RUN cd /tmp && wget "http://pgoapi.com/pgoencrypt.tar.gz" \
     && cd /tmp \
     && rm -rf /tmp/pgoencrypt*
 
-VOLUME ["/usr/src/app/web"]
-
 ENV LD_LIBRARY_PATH /usr/src/app
+
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /usr/src/app
 
 ENTRYPOINT ["python", "pokecli.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ services:
   bot1-pokego:
     build: .
     volumes:
-     - ./configs/config.json:/usr/src/app/configs/config.json
+     - ./configs:/usr/src/app/configs
+     - ./web:/usr/src/app/web
     stdin_open: true
     tty: true
   bot1-pokegoweb:
@@ -11,9 +12,9 @@ services:
     ports:
      - "8000:8000"
     volumes_from:
-     - bot1-pokego
+      - bot1-pokego
     volumes:
-     - ./configs/userdata.js:/usr/src/app/web/config/userdata.js
+      - ./configs:/usr/src/app/web/config
     working_dir: /usr/src/app/web
     command: bash -c "echo 'Serving HTTP on 0.0.0.0 port 8000' && python -m SimpleHTTPServer > /dev/null 2>&1"
     depends_on:


### PR DESCRIPTION
 - Use the non-`onbuild` variant of the python base image to better make use of Docker image caching when rebuilding images
 - Update some volumes in `docker-compose.yml` for pogoweb