### PR TITLE
remove Debian python-protobuf dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ RUN echo $timezone > /etc/timezone \
     && ln -sfn /usr/share/zoneinfo/$timezone /etc/localtime \
     && dpkg-reconfigure -f noninteractive tzdata
 
-RUN apt-get update \
-    && apt-get install -y python-protobuf
 RUN cd /tmp && wget "http://pgoapi.com/pgoencrypt.tar.gz" \
     && tar zxvf pgoencrypt.tar.gz \
     && cd pgoencrypt/src \

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ if [ -f /etc/debian_version ]
 then
 echo "You are on Debian/Ubuntu"
 sudo apt-get update
-sudo apt-get -y install python python-pip python-dev build-essential git python-protobuf virtualenv 
+sudo apt-get -y install python python-pip python-dev build-essential git virtualenv 
 elif [ -f /etc/redhat-release ]
 then
 echo "You are on CentOS/RedHat"

--- a/setup.sh
+++ b/setup.sh
@@ -55,7 +55,7 @@ if [ -f /etc/debian_version ]
 then
 echo "You are on Debian/Ubuntu"
 sudo apt-get update
-sudo apt-get -y install python python-pip python-dev build-essential git python-protobuf virtualenv 
+sudo apt-get -y install python python-pip python-dev build-essential git virtualenv 
 elif [ -f /etc/redhat-release ]
 then
 echo "You are on CentOS/RedHat"


### PR DESCRIPTION
## Short Description:

Debian `python-protobuf` dependency removed (install.sh/setup.sh);
docs/installation.md not synced

## Fixes (provide links to github issues if you can):

- during installation of pgoapi, protobuf will automatically be a
dependency (confirmed with `pip show pgoapi`)

- Even for Ubuntu 16.04 LTS, python-protobuf version is
2.6.1-1.3, which is too old
  + confirmed with `apt-cache show python-protobuf`
  + see issue #1815
  (https://github.com/PokemonGoF/PokemonGo-Bot/issues/1815)