### PR TITLE
Add missing submodule update to setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,7 @@ function Pokebotupdate () {
 cd $pokebotpath
 git pull
 git submodule init
+git submodule update
 git submodule foreach git pull origin master
 virtualenv .
 source bin/activate


### PR DESCRIPTION
## Short Description:
Currently script is only doing `git submodule init`, but it needs to do `git submodule update` before attempting to pull master or the `web` submodule will not be checked out.