### PR TITLE
Option to release the last pokemon catched if pokemon bag reach a limit (intended to never stop catching if got full bag)

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -82,6 +82,8 @@
     "catch_randomize_spin_factor": 1.0,
     "logging_color": true,
     "catch": {
+      "never_stop": true,
+      "max_pokemon": 248,
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},
       "// Rattata": { "always_catch" : true }

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -97,6 +97,8 @@
     "catch_randomize_spin_factor": 1.0,
     "logging_color": true,
     "catch": {
+      "never_stop": true,
+      "max_pokemon": 248,
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},
       "// Rattata": { "always_catch" : true }

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -68,6 +68,8 @@
           "mode": "priority",
           "map_path": "raw_data",
           "catch": {
+            "never_stop": true,
+            "max_pokemon": 248,
             "==========Legendaries==========": 0,
             "Aerodactyl": 1000,
             "Snorlax": 1000,

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -84,6 +84,8 @@
     "catch_randomize_spin_factor": 1.0,
     "logging_color": true,
     "catch": {
+      "never_stop": true,
+      "max_pokemon": 248,
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},
       "// Rattata": { "always_catch" : true }

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -90,6 +90,8 @@
     "catch_randomize_spin_factor": 1.0,
     "logging_color": true,
     "catch": {
+      "never_stop": true,
+      "max_pokemon": 248,
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or" },
 
       "// Pokemons with example": { "always_catch": true },


### PR DESCRIPTION
## Short Description:
On the moment you get full inventory and your rules are not enough to release the required number of pokemon, you get stucked on a status in which you will stop catching and getting experience.

 When PokemonCatchWorker get a response  status ENCOUNTER_STATUS_POKEMON_INVENTORY_FULL it just stop catching pokemons, which is not a good behavior if you want this to non-stop taking exp.

So Before this request response is checked, we first check if "catch" config param:"never_stop" is true, if it is, then we will release the last pokemon we catched, so the bot will never get full of pokemon and will continue taking exp. (This behaviour atm will delete ANY POKEMON you catch but on the other side yo will get non-stop experience atleast).

Maybe later we can configure this to priorize on which pokemon should be deleted if the last pokemon catched was a "vip".

I added another parameter "max_pokemon" which is default set to 248. Note you can choose any number so it don't depends on pokemon bag size.


NOTE: Maybe is not the best way to handle with the dictionary of pokemons, any recomendation is good for me