### PR TITLE
Revert "moving_to_fort and moving_to_lured_fort now also emit current_position"

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -183,8 +183,7 @@ class PokemonGoBot(object):
             'moving_to_fort',
             parameters=(
                 'fort_name',
-                'distance',
-                'current_position'
+                'distance'
             )
         )
         self.event_manager.register_event(
@@ -192,8 +191,7 @@ class PokemonGoBot(object):
             parameters=(
                 'fort_name',
                 'distance',
-                'lure_distance',
-                'current_position'
+                'lure_distance'
             )
         )
         self.event_manager.register_event(
@@ -219,12 +217,7 @@ class PokemonGoBot(object):
             parameters=('status_code',)
         )
         self.event_manager.register_event('pokestop_searching_too_often')
-        self.event_manager.register_event(
-            'arrived_at_fort',
-            parameters=(
-                'current_position'
-            )
-        )
+        self.event_manager.register_event('arrived_at_fort')
 
         # pokemon stuff
         self.event_manager.register_event(

--- a/pokemongo_bot/cell_workers/move_to_fort.py
+++ b/pokemongo_bot/cell_workers/move_to_fort.py
@@ -61,7 +61,6 @@ class MoveToFort(BaseTask):
             fort_event_data = {
                 'fort_name': u"{}".format(fort_name),
                 'distance': format_dist(dist, unit),
-                'current_position': self.bot.position
             }
 
             if self.is_attracted() > 0:
@@ -88,13 +87,9 @@ class MoveToFort(BaseTask):
             if not step_walker.step():
                 return WorkerResult.RUNNING
 
-        arrived_at_fort_data = {
-            'current_position': self.bot.position
-        }
         self.emit_event(
             'arrived_at_fort',
-            formatted='Arrived at fort.',
-            data=arrived_at_fort_data
+            formatted='Arrived at fort.'
         )
         return WorkerResult.SUCCESS
 


### PR DESCRIPTION
Reverts PokemonGoF/PokemonGo-Bot#3614. 

It doesn't implement the proper solution and it send events with play position before the actual player position is set the the `StepWalker`. This will trick user to thing the bot has moved when it hasn't.