### PR TITLE
Format iv_pct on 3 digits

### DIFF
--- a/pokemongo_bot/cell_workers/nickname_pokemon.py
+++ b/pokemongo_bot/cell_workers/nickname_pokemon.py
@@ -50,7 +50,7 @@ class NicknamePokemon(BaseTask):
         iv_list = [iv_attack,iv_defense,iv_stamina]
         iv_ads = "/".join(map(str,iv_list))
         iv_sum = sum(iv_list)
-        iv_pct = "{:0.0f}".format(100*iv_sum/45.0)
+        iv_pct = "{:03.0f}".format(100*iv_sum/45.0)
         log_color = 'red'
         try:
             new_name = self.template.format(name=name,


### PR DESCRIPTION
For better sorting on pokemon's name, format iv_pct on 3 digits.