### PR TITLE
Enabled location update for the web plugin

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -66,3 +66,4 @@
  * kestel
  * joaodragao
  * extink
+ * chuparCh0pper

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -1002,10 +1002,10 @@ class PokemonGoBot(object):
             pass
 
     def update_web_location_worker(self):
-        pass
-        # while True:
-        #     self.web_update_queue.get()
-        #     self.update_web_location()
+        #pass
+        while True:
+            self.web_update_queue.get()
+            self.update_web_location()
 
     def get_inventory_count(self, what):
         response_dict = self.get_inventory()


### PR DESCRIPTION
## Short Description:
Enabled location update for the web plugin, so you can see the player move again

## Fixes (provide links to github issues if you can):
- https://github.com/OpenPoGo/OpenPoGoWeb/issues/183
- https://github.com/OpenPoGo/OpenPoGoWeb/issues/184
- https://github.com/PokemonGoF/PokemonGo-Bot/issues/3546


