### PR TITLE
Fix: Be able to evolve pokemon after caught

### DIFF
--- a/pokemongo_bot/cell_workers/evolve_pokemon.py
+++ b/pokemongo_bot/cell_workers/evolve_pokemon.py
@@ -83,7 +83,7 @@ class EvolvePokemon(BaseTask):
             'and': lambda pokemon: pokemon.cp >= self.evolve_above_cp and pokemon.iv >= self.evolve_above_iv
         }
 
-        for pokemon in inventory.pokemons().all():
+        for pokemon in inventory.pokemons(True).all():
             if pokemon.id > 0 and pokemon.has_next_evolution() and (logic_to_function[self.cp_iv_logic](pokemon)):
                 pokemons.append(pokemon)
 


### PR DESCRIPTION
Caught Pokemon won't be found in order to evolve because `EvolvePokemon` class doesn't get there current list of Pokemon. This bug leads to caught Pokemon being released without evolving.