### PR TITLE
Fixed EventManager handlers to be list instead of tuple

### DIFF
--- a/pokemongo_bot/event_manager.py
+++ b/pokemongo_bot/event_manager.py
@@ -23,7 +23,7 @@ class EventManager(object):
 
     def __init__(self, *handlers):
         self._registered_events = dict()
-        self._handlers = handlers or []
+        self._handlers = list(handlers) or []
 
     def event_report(self):
         for event, parameters in self._registered_events.iteritems():


### PR DESCRIPTION
Allow custom plugins to add event handlers with `bot.event_manager.add_handler()`.

## Fixes
- Passing `*handlers` as a list will unpack as a tuple.


``` File "/home/user/git/PokemonGo-Bot/pokemongo_bot/event_manager.py", line 38, in add_handler
    self._handlers.append(event_handler)
AttributeError: 'tuple' object has no attribute 'append'```



