### PR TITLE
Avoid GET_INVENTORY on every tick

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -31,7 +31,7 @@ from pokemongo_bot.websocket_remote_control import WebsocketRemoteControl
 from pokemongo_bot.base_dir import _base_dir
 from worker_result import WorkerResult
 from tree_config_builder import ConfigException, MismatchTaskApiVersion, TreeConfigBuilder
-from inventory import init_inventory
+from inventory import init_inventory,refresh_inventory
 from sys import platform as _platform
 import struct
 
@@ -780,6 +780,7 @@ class PokemonGoBot(object):
         self.logger.info('')
 
     def use_lucky_egg(self):
+        inventory.refresh_inventory()
         return self.api.use_item_xp_boost(item_id=301)
 
     def get_inventory(self):

--- a/pokemongo_bot/cell_workers/incubate_eggs.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs.py
@@ -1,6 +1,6 @@
 from pokemongo_bot.human_behaviour import sleep
 from pokemongo_bot.base_task import BaseTask
-
+from pokemongo_bot import inventory
 
 class IncubateEggs(BaseTask):
     SUPPORTED_TASK_API_VERSION = 1
@@ -67,6 +67,7 @@ class IncubateEggs(BaseTask):
                     item_id=incubator["id"],
                     pokemon_id=egg["id"]
                 )
+                inventory.refresh_inventory()
                 if ret:
                     code = ret.get("responses", {}).get("USE_ITEM_EGG_INCUBATOR", {}).get("result", 0)
                     if code == 1:

--- a/pokemongo_bot/cell_workers/incubate_eggs.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs.py
@@ -67,7 +67,6 @@ class IncubateEggs(BaseTask):
                     item_id=incubator["id"],
                     pokemon_id=egg["id"]
                 )
-                inventory.refresh_inventory()
                 if ret:
                     code = ret.get("responses", {}).get("USE_ITEM_EGG_INCUBATOR", {}).get("result", 0)
                     if code == 1:
@@ -170,6 +169,7 @@ class IncubateEggs(BaseTask):
         xp = result.get('experience_awarded', "error")
         sleep(self.hatching_animation_delay)
         self.bot.latest_inventory = None
+        inventory.refresh_inventory()
         try:
             pokemon_data = self._check_inventory(pokemon_ids)
             for pokemon in pokemon_data:

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -215,6 +215,7 @@ class PokemonCatchWorker(BaseTask):
             encounter_id=encounter_id,
             spawn_point_id=self.spawn_point_guid
         )
+	inventory.refresh_inventory()
         responses = response_dict['responses']
 
         if response_dict and response_dict['status_code'] == 1:

--- a/pokemongo_bot/cell_workers/recycle_items.py
+++ b/pokemongo_bot/cell_workers/recycle_items.py
@@ -77,9 +77,8 @@ class RecycleItems(BaseTask):
         :rtype: WorkerResult
         """
         # TODO: Use new inventory everywhere and then remove the inventory update
-        # Updating inventory
-        inventory.refresh_inventory()
         worker_result = WorkerResult.SUCCESS
+        should_update_inventory=False
         if self.should_run():
 
             # For each user's item in inventory recycle it if needed
@@ -89,6 +88,10 @@ class RecycleItems(BaseTask):
                 if self.item_should_be_recycled(item_in_inventory, amount_to_recycle):
                     if ItemRecycler(self.bot, item_in_inventory, amount_to_recycle).work() == WorkerResult.ERROR:
                         worker_result = WorkerResult.ERROR
+                    else:
+                        should_update_inventory=True
+        if should_update_inventory==True:
+            inventory.refresh_inventory()
 
         return worker_result
 

--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -10,6 +10,7 @@ from pokemongo_bot.human_behaviour import sleep
 from pokemongo_bot.worker_result import WorkerResult
 from pokemongo_bot.base_task import BaseTask
 from utils import distance, format_time, fort_details
+from pokemongo_bot import inventory
 
 
 class SpinFort(BaseTask):
@@ -58,6 +59,8 @@ class SpinFort(BaseTask):
                 items_awarded = spin_details.get('items_awarded', {})
                 if items_awarded:
                     self.bot.latest_inventory = None
+                    inventory.refresh_inventory()
+
                     tmp_count_items = {}
                     for item in items_awarded:
                         item_id = item['item_id']


### PR DESCRIPTION

## Short Description:

Currently transfer_pokemon and recycle items do an inventory refresh on every run. Instead of this, rely on previously updated inventory and if changes are made, trigger a refresh

## Fixes (provide links to github issues if you can):
-
-
-

