### PR TITLE
Cleaned old catch parameters

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -407,22 +407,6 @@ def init_config():
     add_config(
         parser,
         load,
-        long_flag="--catch_randomize_reticle_factor",
-        help="Randomize factor for pokeball throwing accuracy (DEFAULT 1.0 means no randomize: always 'Excellent' throw. 0.0 randomizes between normal and 'Excellent' throw)",
-        type=float,
-        default=1.0
-    )
-    add_config(
-        parser,
-        load,
-        long_flag="--catch_randomize_spin_factor",
-        help="Randomize factor for pokeball curve throwing (DEFAULT 1.0 means no randomize: always perfect 'Super Spin' curve ball. 0.0 randomizes between normal and 'Super Spin' curve ball)",
-        type=float,
-        default=1.0
-    )
-    add_config(
-        parser,
-        load,
         long_flag="--map_object_cache_time",
         help="Amount of seconds to keep the map object in cache (bypass Niantic throttling)",
         type=float,
@@ -537,14 +521,6 @@ def init_config():
 
     if not (config.location or config.location_cache):
         parser.error("Needs either --use-location-cache or --location.")
-        return None
-
-    if config.catch_randomize_reticle_factor < 0 or 1 < config.catch_randomize_reticle_factor:
-        parser.error("--catch_randomize_reticle_factor is out of range! (should be 0 <= catch_randomize_reticle_factor <= 1)")
-        return None
-
-    if config.catch_randomize_spin_factor < 0 or 1 < config.catch_randomize_spin_factor:
-        parser.error("--catch_randomize_spin_factor is out of range! (should be 0 <= catch_randomize_spin_factor <= 1)")
         return None
 
     plugin_loader = PluginLoader()


### PR DESCRIPTION
Removed `catch_randomize_reticle_factor` and `catch_randomize_spin_factor` from `pokecli.py`. We don't need them anymore.