### PR TITLE
small fix in VOLUME in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:2.7
 
 WORKDIR /usr/src/app
-VOLUME ["/usr/app/configs", "/usr/src/app/web"]
+VOLUME ["/usr/src/app/configs", "/usr/src/app/web"]
 
 ARG timezone=Etc/UTC
 RUN echo $timezone > /etc/timezone \


### PR DESCRIPTION

## Short Description:

The Dockerfile have a bug.
the VOLUME is pointing to a folder outside the project

## Fixes (provide links to github issues if you can):
- VOLUME /usr/src/app/configs   now its pointing to the right place



