### PR TITLE
Fix an incorrect variable name in pokemon_catch_worker that makes bot unusable

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -68,4 +68,4 @@
  * joaodragao
  * extink
  * Quantra
-
+ * pmquan

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -367,7 +367,7 @@ class PokemonCatchWorker(BaseTask):
                         'encounter_id': self.pokemon['encounter_id'],
                         'latitude': self.pokemon['latitude'],
                         'longitude': self.pokemon['longitude'],
-                        'pokemon_id': pokemon.num
+                        'pokemon_id': pokemon.pokemon_id
                     }
                 )
                 if self._pct(catch_rate_by_ball[current_ball]) == 100:


### PR DESCRIPTION
Fix an incorrect variable that caused this error:
  File "/PokemonGo-Bot/pokemongo_bot/cell_workers/pokemon_catch_worker.py", line 370, in _do_catch
    'pokemon_id': pokemon.num
AttributeError: 'Pokemon' object has no attribute 'num'