### PR TITLE
Add Items option live stats (such as Pokeballs and Potions)

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -33,7 +33,22 @@
         "config": {
           "enabled": false,
           "min_interval": 10,
-          "stats": ["uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],
+          "stats": [
+            "uptime",
+            "stardust_earned",
+            "xp_earned",
+            "xp_per_hour",
+            "stops_visited"
+            {
+              "type": "items_short",
+              "config": [
+                "Pokeball",
+                "Greatball",
+                "Ultraball",
+                "Razz Berry"
+              ]
+            }
+          ],
           "terminal_log": true,
           "terminal_title": true
         }
@@ -98,8 +113,6 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-    "catch_randomize_reticle_factor": 1.0,
-    "catch_randomize_spin_factor": 1.0,
     "min_ultraball_to_keep": 10,
     "logging_color": true,
     "catch": {

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -33,7 +33,22 @@
         "config": {
           "enabled": false,
           "min_interval": 10,
-          "stats": ["uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],
+          "stats": [
+            "uptime",
+            "stardust_earned",
+            "xp_earned",
+            "xp_per_hour",
+            "stops_visited"
+            {
+              "type": "items_short",
+              "config": [
+                "Pokeball",
+                "Greatball",
+                "Ultraball",
+                "Razz Berry"
+              ]
+            }
+          ],
           "terminal_log": true,
           "terminal_title": true
         }

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -129,8 +129,6 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-    "catch_randomize_reticle_factor": 1.0,
-    "catch_randomize_spin_factor": 1.0,
     "min_ultraball_to_keep": 10,
     "logging_color": true,
     "catch": {

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -33,7 +33,22 @@
         "config": {
           "enabled": false,
           "min_interval": 10,
-          "stats": ["uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],
+          "stats": [
+            "uptime",
+            "stardust_earned",
+            "xp_earned",
+            "xp_per_hour",
+            "stops_visited"
+            {
+              "type": "items_short",
+              "config": [
+                "Pokeball",
+                "Greatball",
+                "Ultraball",
+                "Razz Berry"
+              ]
+            }
+          ],
           "terminal_log": true,
           "terminal_title": true
         }

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -355,8 +355,6 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-    "catch_randomize_reticle_factor": 1.0,
-    "catch_randomize_spin_factor": 1.0,
     "min_ultraball_to_keep": 10,
     "logging_color": true,
     "catch": {

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -33,7 +33,22 @@
         "config": {
           "enabled": false,
           "min_interval": 10,
-          "stats": ["uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],
+          "stats": [
+            "uptime",
+            "stardust_earned",
+            "xp_earned",
+            "xp_per_hour",
+            "stops_visited"
+            {
+              "type": "items_short",
+              "config": [
+                "Pokeball",
+                "Greatball",
+                "Ultraball",
+                "Razz Berry"
+              ]
+            }
+          ],
           "terminal_log": true,
           "terminal_title": true
         }

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -115,8 +115,6 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-    "catch_randomize_reticle_factor": 1.0,
-    "catch_randomize_spin_factor": 1.0,
     "min_ultraball_to_keep": 10,
     "logging_color": true,
     "catch": {

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -33,7 +33,22 @@
         "config": {
           "enabled": false,
           "min_interval": 10,
-          "stats": ["uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],
+          "stats": [
+            "uptime",
+            "stardust_earned",
+            "xp_earned",
+            "xp_per_hour",
+            "stops_visited"
+            {
+              "type": "items_short",
+              "config": [
+                "Pokeball",
+                "Greatball",
+                "Ultraball",
+                "Razz Berry"
+              ]
+            }
+          ],
           "terminal_log": true,
           "terminal_title": true
         }

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -121,8 +121,6 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-    "catch_randomize_reticle_factor": 1.0,
-    "catch_randomize_spin_factor": 1.0,
     "min_ultraball_to_keep": 10,
     "logging_color": true,
     "catch": {

--- a/pokemongo_bot/cell_workers/update_live_stats.py
+++ b/pokemongo_bot/cell_workers/update_live_stats.py
@@ -317,8 +317,8 @@ class UpdateLiveStats(BaseTask):
         stat_type = stat.get('type', '')
         if stat_type not in available_stats:
             raise ConfigException("stat '{}' isn't available for displaying".format(stat_type))
-        stat_config = stat.get('config', [])
-        if stat_config is None:
+        stat_config = stat.get('config', None)
+        if not stat_config:
             return available_stats[stat_type]
         stat_items = available_stats[stat_type]
         if stat_items is None or type(stat_items) is not dict:
@@ -327,10 +327,13 @@ class UpdateLiveStats(BaseTask):
         # TODO: Generalize
         # this is the case for items only!
         content = ''
-        if stat_type == 'items':
-            for item in stat_config:
-                content += '{} x {}, '.format(item, stat_items[item][1])
-        elif stat_type == 'items_short':
-            for item in stat_config:
-                content += '{}x{}, '.format(stat_items[item][0], stat_items[item][1])
-        return content[:-2]
+        try:
+            if stat_type == 'items':
+                for item in stat_config:
+                    content += '{} x {}, '.format(item, stat_items[item][1])
+            elif stat_type == 'items_short':
+                for item in stat_config:
+                    content += '{}x{}, '.format(stat_items[item][0], stat_items[item][1])
+            return content[:-2]
+        except KeyError as e:
+            raise ConfigException("stat '{}' isn't available for displaying. {}".format(stat_type, e))


### PR DESCRIPTION
# "How many pokeballs do I have?"
This is something missing in live stats or maybe this is the feature I want the most.

This update will allow users to see number of items in the bag storage.

`... | Pokeball x 145, Greatball x 5, Ultraball x 0, Razz Berry x 85 | ...`

or in abbreviation mode:

`... | Px149, Gx4, Ux0, Bx83 | ...`

(Sorry if I break the code.)

In the `stats` of `UpdateLiveStats` task, you just add a dictionary with providing `type` and `config` as shown in example below.

```
        {
            "type": "UpdateLiveStats",
            "config": {
                "min_interval": 120,
                "stats": [
                    "uptime",
                    ...
                    {
                        "type": "items_short",
                        "config": [
                            "Pokeball",
                            "Greatball",
                            "Ultraball",
                            "Razz Berry"
                        ]
                    }
                ],
            }
        },
```

 I want to generalize all stats. Thus, you also can put just only `type` without `config` which is equal to stats's name alone.

```
                    {
                        "type": "uptime"
                    }
```

These are all available items:

```
                            "Pokeball",
                            "Greatball",
                            "Ultraball",
                            "Masterball",
                            "Razz Berry",
                            "Potion",
                            "Super Potion",
                            "Hyper Potion",
                            "Max Potion",
                            "Revive",
                            "Max Revive"
```