### PR TITLE
Nickname Pokemon IVs in hex (0..F) #3803

### DIFF
--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -215,6 +215,7 @@ Key | Info
 **{iv_defense}** |  Individial Defense *(0-15)* of the current specific pokemon
 **{iv_stamina}** |  Individial Stamina *(0-15)* of the current specific pokemon
 **{iv_ads}**     |  Joined IV values in `(attack)/(defense)/(stamina)` format (*e.g. 4/12/9*, matches web UI format -- A/D/S)
+**{iv_ads_hex}** |  Joined IV values of `(attack)(defense)(stamina)` in HEX (*e.g. 4C9* for A/D/S = 4/12/9)
 **{iv_sum}**     |  Sum of the Individial Values *(0-45, e.g. 45 when 3 perfect 15 IVs)*
  |  **Basic Values of the pokemon (identical for all of one kind)**
 **{base_attack}**   |  Basic Attack *(40-284)* of the current pokemon kind

--- a/pokemongo_bot/cell_workers/nickname_pokemon.py
+++ b/pokemongo_bot/cell_workers/nickname_pokemon.py
@@ -2,6 +2,8 @@ from pokemongo_bot.base_task import BaseTask
 from pokemongo_bot.human_behaviour import sleep
 from pokemongo_bot.inventory import pokemons, Pokemon, Attack
 
+import re
+
 
 DEFAULT_IGNORE_FAVORITES = False
 DEFAULT_GOOD_ATTACK_THRESHOLD = 0.7
@@ -277,7 +279,8 @@ class NicknamePokemon(BaseTask):
         """
 
         # Filter template
-        template = template.lower().strip()
+        # only convert the keys to lowercase, leaving the format specifier alone
+        template = re.sub(r"{[\w_\d]*", lambda x:x.group(0).lower(), template).strip()
 
         # Individial Values of the current specific pokemon (different for each)
         iv_attack = pokemon.iv_attack

--- a/pokemongo_bot/cell_workers/nickname_pokemon.py
+++ b/pokemongo_bot/cell_workers/nickname_pokemon.py
@@ -80,6 +80,7 @@ class NicknamePokemon(BaseTask):
     {iv_pct2}    IV perfection (in 00-99 format - 2 chars)
                     So 99 is best (it's a 100% perfection)
     {iv_pct1}    IV perfection (in 0-9 format - 1 char)
+    {iv_ads_hex} Joined IV values in HEX (e.g. 4C9)
 
     # Basic Values of the pokemon (identical for all of one kind)
     {base_attack}   Basic Attack (40-284) of the current pokemon kind
@@ -324,6 +325,8 @@ class NicknamePokemon(BaseTask):
             iv_stamina=iv_stamina,
             # Joined IV values like: 4/12/9
             iv_ads='/'.join(map(str, iv_list)),
+            # Joined IV values in HEX like: 4C9
+            iv_ads_hex = ''.join(map(lambda x: format(x, 'X'), iv_list)),
             # Sum of the Individial Values
             iv_sum=iv_sum,
             # IV perfection (in 000-100 format - 3 chars)

--- a/tests/nickname_test.py
+++ b/tests/nickname_test.py
@@ -18,6 +18,7 @@ class NicknamePokemonTest(unittest.TestCase):
         self.assertNicks('{iv_defense}', ['4', '14'])
         self.assertNicks('{iv_stamina}', ['8', '0'])
         self.assertNicks('{iv_ads}', ['9/4/8', '6/14/0'])
+        self.assertNicks('{iv_ads_hex}', ['948', '6E0'])
         self.assertNicks('{iv_sum}', ['21', '20'])
         self.assertNicks('{iv_pct}', ['047', '044'])
         self.assertNicks('{iv_pct2}', ['46', '44'])
@@ -52,9 +53,13 @@ class NicknamePokemonTest(unittest.TestCase):
         self.assertNicks('{pokemon.fast_attack.dps:.2f}', ['12.00', '10.91'])
         self.assertNicks('{pokemon.fast_attack.dps:.0f}', ['12', '11'])
         self.assertNicks('{iv_pct}_{iv_ads}', ['047_9/4/8', '044_6/14/0'])
+        self.assertNicks('{iv_pct}_{iv_ads_hex}', ['047_948', '044_6E0'])
         self.assertNicks(
             '{ivcp_pct2}_{iv_pct2}_{iv_ads}',
             ['48_46_9/4/8', '38_44_6/14/0'])
+        self.assertNicks(
+            '{ivcp_pct2}_{iv_pct2}_{iv_ads_hex}',
+            ['48_46_948', '38_44_6E0'])
         self.assertNicks(
             '{attack_code}{attack_pct1}{defense_pct1}{ivcp_pct1}{name}',
             ['Lh474Golbat', 'nn853Rattata'])


### PR DESCRIPTION
## Short Description:
allow using both lowercase and uppercase hex in displaying IV.
added iv_ads_hex to keys. 
only convert keys to lower case, leaving format specifiers alone.

## Fixes (provide links to github issues if you can):
- Fixes #3803 


