### PR TITLE
added account name to WindowTitle

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -31,6 +31,7 @@
       {
         "type": "UpdateLiveStats",
         "config": {
+          "username",
           "enabled": false,
           "min_interval": 10,
           "stats": ["uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -31,10 +31,10 @@
       {
         "type": "UpdateLiveStats",
         "config": {
-          "username",
+         
           "enabled": false,
           "min_interval": 10,
-          "stats": ["uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],
+          "stats": [ "username", "uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],
           "terminal_log": true,
           "terminal_title": true
         }

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -31,10 +31,9 @@
       {
         "type": "UpdateLiveStats",
         "config": {
-         
           "enabled": false,
           "min_interval": 10,
-          "stats": [ "username", "uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],
+          "stats": ["username", "uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],
           "terminal_log": true,
           "terminal_title": true
         }


### PR DESCRIPTION
added account name to the WindowTitle in "UpdateLiveStats" task, easier to manage multiple bots and their outputs.