### PR TITLE
Added caching of fort timeouts similar to caching recent forts.

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -102,7 +102,8 @@
     "forts": {
       "avoid_circles": true,
       "max_circle_size": 50,
-      "cache_recent_forts": true
+      "cache_recent_forts": true,
+      "cache_fort_timeouts": true
     },
     "websocket_server": false,
     "walk": 4.16,

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -328,7 +328,9 @@
     "map_object_cache_time": 5,
     "forts": {
       "avoid_circles": true,
-      "max_circle_size": 50
+      "max_circle_size": 50,
+      "cache_recent_forts": true,
+      "cache_fort_timeouts": true
     },
     "websocket_server": false,
     "walk": 4.16,

--- a/configs/config.json.optimizer.example
+++ b/configs/config.json.optimizer.example
@@ -134,7 +134,9 @@
     "map_object_cache_time": 5,
     "forts": {
         "avoid_circles": true,
-        "max_circle_size": 50
+        "max_circle_size": 50,
+      "cache_recent_forts": true,
+      "cache_fort_timeouts": true
     },
     "websocket_server": true,
     "walk": 4.16,

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -88,7 +88,9 @@
     "map_object_cache_time": 5,
     "forts": {
       "avoid_circles": true,
-      "max_circle_size": 50
+      "max_circle_size": 50,
+      "cache_recent_forts": true,
+      "cache_fort_timeouts": true
     },
     "websocket_server": false,
     "walk": 4.16,

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -94,7 +94,9 @@
     "map_object_cache_time": 5,
     "forts": {
       "avoid_circles": true,
-      "max_circle_size": 50
+      "max_circle_size": 50,
+      "cache_recent_forts": true,
+      "cache_fort_timeouts": true
     },
     "websocket_server": false,
     "walk": 4.16,

--- a/pokecli.py
+++ b/pokecli.py
@@ -161,7 +161,7 @@ def main():
                         level='debug',
                         formatted='Forts cached.',
                     )
-                except IOError as e:
+                except IOError:
                     bot.event_manager.emit(
                         'error_caching_forts',
                         sender=bot,
@@ -169,7 +169,25 @@ def main():
                         formatted='Error caching forts for {path}',
                         data={'path': cached_forts_path}
                         )
-
+            if bot.fort_timeouts and bot.config.forts_cache_fort_timeouts:
+                fort_timeouts_path = os.path.join(_base_dir, 'data', 'fort-timeouts-%s.json' % bot.config.username)
+                try:
+                    with open(fort_timeouts_path, 'w') as outfile:
+                        json.dump(bot.fort_timeouts, outfile)
+                        bot.event_manager.emit(
+                            'cached_fort',
+                            sender=bot,
+                            level='debug',
+                            formatted='Fort timeouts cached.',
+                        )
+                except IOError:
+                    bot.event_manager.emit(
+                        'error_caching_forts',
+                        sender=bot,
+                        level='debug',
+                        formatted='Error caching fort timeouts for {path}',
+                        data={'path': fort_timeouts_path}
+                        )
 
 
 def report_summary(bot):
@@ -401,6 +419,15 @@ def init_config():
         short_flag="-crf",
         long_flag="--forts.cache_recent_forts",
         help="Caches recent forts used by max_circle_size",
+        type=bool,
+        default=True,
+    )
+    add_config(
+        parser,
+        load,
+        short_flag="-cft",
+        long_flag="--forts.cache_fort_timeouts",
+        help="Caches fort timeouts",
         type=bool,
         default=True,
     )

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -85,6 +85,7 @@ class PokemonGoBot(object):
         self._setup_logging()
         self._setup_api()
         self._load_recent_forts()
+        self._load_fort_timeouts()
 
         random.seed()
 
@@ -1112,7 +1113,6 @@ class PokemonGoBot(object):
         if not self.config.forts_cache_recent_forts:
             return
 
-
         cached_forts_path = os.path.join(_base_dir, 'data', 'recent-forts-%s.json' % self.config.username)
         try:
             # load the cached recent forts
@@ -1136,13 +1136,38 @@ class PokemonGoBot(object):
                 'loaded_cached_forts',
                 sender=self,
                 level='debug',
-                formatted='Loaded cached forts...'
+                formatted='Loaded recent forts...'
             )
         except IOError:
             self.event_manager.emit(
                 'no_cached_forts',
                 sender=self,
                 level='debug',
-                formatted='Starting new cached forts for {path}',
+                formatted='Starting new recent forts for {path}',
                 data={'path': cached_forts_path}
             )
+
+    def _load_fort_timeouts(self):
+        if not self.config.forts_cache_fort_timeouts:
+            return
+
+        fort_timeouts_path = os.path.join(_base_dir, 'data', 'fort-timeouts-%s.json' % self.config.username)
+        try:
+            with open(fort_timeouts_path) as f:
+                self.fort_timeouts = json.load(f)
+
+            self.event_manager.emit(
+                'loaded_cached_forts',
+                sender=self,
+                level='debug',
+                formatted='Loaded fort timeouts...'
+            )
+        except IOError:
+            self.event_manager.emit(
+                'no_cached_forts',
+                sender=self,
+                level='debug',
+                formatted='Starting new fort timeouts for {path}',
+                data={'path': fort_timeouts_path}
+            )
+


### PR DESCRIPTION
## Short Description:
Caching of fort timeouts similar to how recent_forts are cached and with option to disable this feature.

@douglascamata please review =]

## Fixes (provide links to github issues if you can):
-Prevents bot from trying to spin fort still on cool down after restarting bot