### PR TITLE
move data which changes to web directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,10 +106,6 @@ out/
 # Personal load details
 src/
 web/
-data/last-location*.json
-data/cells-*.json
-data/map-caught-*.json
-data/recent-forts-*.json
 user_web_catchable
 
 # Multiple config

--- a/pokecli.py
+++ b/pokecli.py
@@ -150,7 +150,7 @@ def main():
         if bot:
             if bot.recent_forts[-1] is not None and bot.config.forts_cache_recent_forts:
                 cached_forts_path = os.path.join(
-                    _base_dir, 'data', 'recent-forts-%s.json' % bot.config.username
+                    _base_dir, 'web', 'recent-forts-%s.json' % bot.config.username
                 )
                 try:
                     with open(cached_forts_path, 'w') as outfile:

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -527,7 +527,7 @@ class PokemonGoBot(object):
             location = self.position[0:2]
             cells = self.find_close_cells(*location)
 
-        user_data_cells = os.path.join(_base_dir, 'data', 'cells-%s.json' % self.config.username)
+        user_data_cells = os.path.join(_base_dir, 'web', 'cells-%s.json' % self.config.username)
         with open(user_data_cells, 'w') as outfile:
             json.dump(cells, outfile)
 
@@ -547,7 +547,7 @@ class PokemonGoBot(object):
             self.logger.info('[x] Error while opening location file: %s' % e)
 
         user_data_lastlocation = os.path.join(
-            _base_dir, 'data', 'last-location-%s.json' % self.config.username
+            _base_dir, 'web', 'last-location-%s.json' % self.config.username
         )
         try:
             with open(user_data_lastlocation, 'w') as outfile:
@@ -931,7 +931,7 @@ class PokemonGoBot(object):
                     level='debug',
                     formatted='Loading cached location...'
                 )
-                with open(os.path.join(_base_dir, 'data', 'last-location-%s.json' %
+                with open(os.path.join(_base_dir, 'web', 'last-location-%s.json' %
                     self.config.username)) as f:
                     location_json = json.load(f)
                 location = (
@@ -1113,7 +1113,7 @@ class PokemonGoBot(object):
             return
 
 
-        cached_forts_path = os.path.join(_base_dir, 'data', 'recent-forts-%s.json' % self.config.username)
+        cached_forts_path = os.path.join(_base_dir, 'web', 'recent-forts-%s.json' % self.config.username)
         try:
             # load the cached recent forts
             with open(cached_forts_path) as f:

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -224,7 +224,7 @@ class MoveToMapPokemon(BaseTask):
         return WorkerResult.SUCCESS
 
     def dump_caught_pokemon(self):
-        user_data_map_caught = os.path.join(_base_dir, 'data', 'map-caught-{}.json'.format(self.bot.config.username))
+        user_data_map_caught = os.path.join(_base_dir, 'web', 'map-caught-{}.json'.format(self.bot.config.username))
         with open(user_data_map_caught, 'w') as outfile:
             json.dump(self.caught, outfile)
 


### PR DESCRIPTION
## Short Description:
Put data which changes into the `web`  directory.

## Fixes:
- #3709 

Differentiate between data files which do not change at runtime and those which do.
Leave the un-changing data in the `data` directory.
Move json files which change under `web` with other data which changes.
This solves the problem of docker restarts losing data which was intended to persist.
