### PR TITLE
Spin Fort- Move to Fort : add timedout forts to recent_forts

### DIFF
--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -153,6 +153,8 @@ class SpinFort(BaseTask):
             if 'cooldown_complete_timestamp_ms' in fort:
                 self.bot.fort_timeouts[fort["id"]] = fort['cooldown_complete_timestamp_ms']
                 forts.remove(fort)
+                if fort['id'] not in self.bot.recent_forts:
+                    self.bot.recent_forts = self.bot.recent_forts[1:] + [fort['id']]
 
         forts = filter(lambda fort: fort["id"] not in self.bot.fort_timeouts, forts)
         forts = filter(lambda fort: distance(


### PR DESCRIPTION

When restarting the bot, movetofort might pick a fort that spinfort will not spin due to cooldown. 
When iterating cooldown forts in spinfort, add them to to recent_forts if not already contained, to guide 
movetofort to other fort
