### PR TITLE
recycle items in cascading

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -64,6 +64,10 @@
         "type": "RecycleItems",
         "config": {
           "min_empty_space": 15,
+          "max_balls_keep": 150,
+          "max_potions_keep": 50,
+          "max_berries_keep": 70,
+          "max_revives_keep": 70,
           "item_filter": {
             "Pokeball":       { "keep" : 100 },
             "Potion":         { "keep" : 10 },
@@ -164,6 +168,5 @@
         "Muk": {},
         "Weezing": {},
         "Flareon": {}
-
     }
 }


### PR DESCRIPTION
# Please Note (you may remove this section before opening your PR):
We receive lots of PRs and it is hard to give proper review to PRs. Please make it easy on us by following these guidelines:

1. We do not accept changes to `master`. Please make sure your pull request is aimed at `dev`.
2. If you changed a bunch of files (that aren't config files) or multiple workers to implement your feature, it probably won't get proper attention. Please split it up into multiple, smaller, more focused, and iterative PRs if you can.
3. If you are adding a config value to something, make sure you update the appropriate `config.json` example files.


## Short Description:
Enhance the recycle function so that it will consider the total number in a category. If set to keep the maximum of balls as 100. When the total balls excess 100, it will recycle Pokeball, then Greatball, then Ultraball. This function can apply to pokeball, berries, potions & revives

## Fixes (provide links to github issues if you can):
-
-
-


