### PR TITLE
Do not spin fort on timeout when restarting the bot

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -474,6 +474,15 @@ class PokemonGoBot(object):
     def tick(self):
         self.health_record.heartbeat()
         self.cell = self.get_meta_cell()
+
+        now = time.time() * 1000
+
+        for fort in self.cell["forts"]:
+            timeout = fort.get("cooldown_complete_timestamp_ms", 0)
+
+            if timeout >= now:
+                self.fort_timeouts[fort["id"]] = timeout
+
         self.tick_count += 1
 
         # Check if session token has expired

--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -57,15 +57,14 @@ class SpinFort(BaseTask):
             player_latitude=f2i(self.bot.position[0]),
             player_longitude=f2i(self.bot.position[1])
         )
-        if 'responses' in response_dict and 'FORT_SEARCH' in response_dict['responses']:
 
+        if ('responses' in response_dict) and ('FORT_SEARCH' in response_dict['responses']):
             spin_details = response_dict['responses']['FORT_SEARCH']
             spin_result = spin_details.get('result', -1)
-            if spin_result == SPIN_REQUEST_RESULT_SUCCESS:
+
+            if (spin_result == SPIN_REQUEST_RESULT_SUCCESS) or (spin_result == SPIN_REQUEST_RESULT_INVENTORY_FULL):
                 self.bot.softban = False
                 experience_awarded = spin_details.get('experience_awarded', 0)
-
-
                 items_awarded = self.get_items_awarded_from_fort_spinned(response_dict)
 
                 if experience_awarded or items_awarded:
@@ -108,12 +107,6 @@ class SpinFort(BaseTask):
                         formatted="Pokestop {pokestop} on cooldown. Time left: {minutes_left}.",
                         data={'pokestop': fort_name, 'minutes_left': minutes_left}
                     )
-            elif spin_result == SPIN_REQUEST_RESULT_INVENTORY_FULL:
-                if not self.ignore_item_count:
-                    self.emit_event(
-                        'inventory_full',
-                        formatted="Inventory is full!"
-                    )
             else:
                 self.emit_event(
                     'unknown_spin_result',
@@ -148,12 +141,6 @@ class SpinFort(BaseTask):
 
     def get_forts_in_range(self):
         forts = self.bot.get_forts(order_by_distance=True)
-
-        for fort in reversed(forts):
-            if 'cooldown_complete_timestamp_ms' in fort:
-                self.bot.fort_timeouts[fort["id"]] = fort['cooldown_complete_timestamp_ms']
-                forts.remove(fort)
-
         forts = filter(lambda fort: fort["id"] not in self.bot.fort_timeouts, forts)
         forts = filter(lambda fort: distance(
             self.bot.position[0],
@@ -186,4 +173,3 @@ class SpinFort(BaseTask):
     # TODO : Refactor this class, hide the inventory update right after the api call
     def _update_inventory(self, item_awarded):
         inventory.items().get(item_awarded['item_id']).add(item_awarded['item_count'])
-


### PR DESCRIPTION
This is the changes explained here: https://github.com/PokemonGoF/PokemonGo-Bot/pull/3897
and also related to this: https://github.com/PokemonGoF/PokemonGo-Bot/pull/3916

> The server is returning the timeout, but at the start of the bot, the fort_timeouts list is not filled.
> The fort_timeouts list is only filled after spinning a fort, that is why you have an issue when restarting the bot.
> 
> The first part of the solution, I think, is to fill the fort_timeouts list when the bot start. Which should be easy thing since we get the list of forts in the get_meta_cell function.
> 
> After done with that, this loop in spin_forts can be removed because there will never be any fort on timeout that is not in the fort_timeouts list.
> 
> Last thing, once the 2 previous thing are done, is to fix the behavior when the inventory is full. When spinning a fort and getting the inventory full response, that fort is not added to the fort_timeout list. This cause the bot to loop over forts when inventory is full.

Need to be tested a bit more, I only have been running it today so far.
