### PR TITLE
Quick bug fix for removing forts on cool down in  SpinFort

### DIFF
--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -149,7 +149,7 @@ class SpinFort(BaseTask):
     def get_forts_in_range(self):
         forts = self.bot.get_forts(order_by_distance=True)
 
-        for fort in forts:
+        for fort in reversed(forts):
             if 'cooldown_complete_timestamp_ms' in fort:
                 self.bot.fort_timeouts[fort["id"]] = fort['cooldown_complete_timestamp_ms']
                 forts.remove(fort)


### PR DESCRIPTION
## Short Description:

Quick bug fix for when SpinFort loops through forts and removes those forts.

Makes #3897 redundant.  Could be solved more cleanly by @Anakin5's solution here #3931.

Will close/please close this and #3897 when something is accepted

## Fixes (provide links to github issues if you can):
-Bot spins fort on cooldown after restart