### PR TITLE
Detect and alert for permaban

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -69,3 +69,4 @@
  * extink
  * Quantra
  * pmquan
+ * net8q

--- a/pokecli.py
+++ b/pokecli.py
@@ -43,6 +43,7 @@ from pokemongo_bot import PokemonGoBot, TreeConfigBuilder
 from pokemongo_bot.base_dir import _base_dir
 from pokemongo_bot.health_record import BotEvent
 from pokemongo_bot.plugin_loader import PluginLoader
+from pokemongo_bot.api_wrapper import PermaBannedException
 
 try:
     from demjson import jsonlint
@@ -137,6 +138,13 @@ def main():
                 )
                 time.sleep(30)
 
+    except PermaBannedException:
+         bot.event_manager.emit(
+            'api_error',
+            sender=bot,
+            level='info',
+            formatted='Probably permabanned, Game Over ! Play again at https://club.pokemon.com/us/pokemon-trainer-club/sign-up/'
+         )
     except GeocoderQuotaExceeded:
         raise Exception("Google Maps API key over requests limit.")
     except Exception as e:

--- a/pokemongo_bot/api_wrapper.py
+++ b/pokemongo_bot/api_wrapper.py
@@ -10,6 +10,9 @@ from pgoapi.protos.POGOProtos.Networking.Requests_pb2 import RequestType
 
 from human_behaviour import sleep
 
+class PermaBannedException(Exception):
+    pass
+
 class ApiWrapper(PGoApi):
     def __init__(self):
         PGoApi.__init__(self)
@@ -75,6 +78,14 @@ class ApiRequest(PGoApiRequest):
             return False
 
         if not isinstance(result['responses'], dict):
+            return False
+
+        try:
+            # Permaban symptom is empty response to GET_INVENTORY and status_code = 3
+            if result['status_code'] == 3 and 'GET_INVENTORY' in request_callers and not result['responses']['GET_INVENTORY']:
+                raise PermaBannedException
+        except KeyError:
+            # Still wrong
             return False
 
         # the response can still programatically be valid at this point


### PR DESCRIPTION
## Short Description:
Detect for permaban

Example of permaban proto response : 
1: 3
2: request_id
100: ""

GET_INVENTORY is the first affected in the login sequence, GET_PLAYER is not.