### PR TITLE
#3932 - Fix nicknaming task exception with non ascii characters

### DIFF
--- a/pokemongo_bot/cell_workers/nickname_pokemon.py
+++ b/pokemongo_bot/cell_workers/nickname_pokemon.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 import os
 import json
 from pokemongo_bot.base_task import BaseTask


### PR DESCRIPTION
Fix ticket #3932 when the nicknaming task throw an exception with
pokemon's name containing non ascii characters.