### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ mock==2.0.0
 timeout-decorator==0.3.2
 raven==5.23.0
 demjson==2.2.4
+greenlet==0.4.9


### PR DESCRIPTION
Greenlet 0.4.10 error _PyTrash_thread_deposit_object

Closes #3855
Closes #3947
Closes #3793
Closes #2006

Issue with Python 2.7.3 on Debian/Ubuntu.
Try: 
source bin/activate
pip freeze | grep "greenlet" | xargs pip uninstall -y
pip install greenlet==0.4.9
pip install -r requirements.txt
