### PR TITLE
Fix update title exception when running using nohup

### DIFF
--- a/pokemongo_bot/cell_workers/update_live_stats.py
+++ b/pokemongo_bot/cell_workers/update_live_stats.py
@@ -148,16 +148,25 @@ class UpdateLiveStats(BaseTask):
         :raise: RuntimeError: When the given platform isn't supported.
         """
 
-        if platform == "linux" or platform == "linux2" or platform == "cygwin":
-            stdout.write("\x1b]2;{}\x07".format(title))
-            stdout.flush()
-        elif platform == "darwin":
-            stdout.write("\033]0;{}\007".format(title))
-            stdout.flush()
-        elif platform == "win32":
-            ctypes.windll.kernel32.SetConsoleTitleA(title.encode())
-        else:
-            raise RuntimeError("unsupported platform '{}'".format(platform))
+        try:
+            if platform == "linux" or platform == "linux2" or platform == "cygwin":
+                stdout.write("\x1b]2;{}\x07".format(title))
+                stdout.flush()
+            elif platform == "darwin":
+                stdout.write("\033]0;{}\007".format(title))
+                stdout.flush()
+            elif platform == "win32":
+                ctypes.windll.kernel32.SetConsoleTitleA(title.encode())
+            else:
+                raise RuntimeError("unsupported platform '{}'".format(platform))
+        except AttributeError:
+            self.emit_event(
+                'log_stats',
+                level = 'error',
+                formatted = "Unable to write window title"              
+            )
+            self.terminal_title = False
+            
         self._compute_next_update()
 
     def _get_stats_line(self, player_stats):


### PR DESCRIPTION
Fixing:

```
Traceback (most recent call last):
  File "pokecli.py", line 595, in <module>
    main()
  File "pokecli.py", line 104, in main
    bot.tick()
  File "pokemongo_bot/__init__.py", line 483, in tick
    if worker.work() == WorkerResult.RUNNING:
  File "pokemongo_bot/cell_workers/update_live_stats.py", line 98, in work
    self._update_title(line, _platform)
  File "pokemongo_bot/cell_workers/update_live_stats.py", line 152, in _update_title
    stdout.write("\x1b]2;{}\x07".format(title))
  File "/usr/local/lib/python2.7/dist-packages/colorama/ansitowin32.py", line 40, in write
    self.__convertor.write(text)
  File "/usr/local/lib/python2.7/dist-packages/colorama/ansitowin32.py", line 141, in write
    self.write_and_convert(text)
  File "/usr/local/lib/python2.7/dist-packages/colorama/ansitowin32.py", line 163, in write_and_convert
    text = self.convert_osc(text)
  File "/usr/local/lib/python2.7/dist-packages/colorama/ansitowin32.py", line 235, in convert_osc
    winterm.set_title(params[1])
AttributeError: 'NoneType' object has no attribute 'set_title'
```

When you run the bot in background using nohup and the update title flag is setted to true