### PR TITLE
recycle items in cascading way

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -64,6 +64,10 @@
         "type": "RecycleItems",
         "config": {
           "min_empty_space": 15,
+          "max_balls_keep": 150,
+          "max_potions_keep": 50,
+          "max_berries_keep": 70,
+          "max_revives_keep": 70,
           "item_filter": {
             "Pokeball":       { "keep" : 100 },
             "Potion":         { "keep" : 10 },

--- a/pokemongo_bot/cell_workers/recycle_items.py
+++ b/pokemongo_bot/cell_workers/recycle_items.py
@@ -23,6 +23,10 @@ class RecycleItems(BaseTask):
       "type": "RecycleItems",
       "config": {
         "min_empty_space": 6,           # 6 by default
+        "max_balls_keep": 150,
+        "max_potions_keep": 50,
+        "max_berries_keep": 70,
+        "max_revives_keep": 70,
         "item_filter": {
           "Pokeball": {"keep": 20},
           "Greatball": {"keep": 50},
@@ -44,6 +48,10 @@ class RecycleItems(BaseTask):
     def initialize(self):
         self.items_filter = self.config.get('item_filter', {})
         self.min_empty_space = self.config.get('min_empty_space', None)
+        self.max_balls_keep = self.config.get('max_balls_keep', None)
+        self.max_potions_keep = self.config.get('max_potions_keep', None)
+        self.max_berries_keep = self.config.get('max_berries_keep', None)
+        self.max_revives_keep = self.config.get('max_revives_keep', None)
         self._validate_item_filter()
 
     def _validate_item_filter(self):
@@ -84,6 +92,17 @@ class RecycleItems(BaseTask):
         worker_result = WorkerResult.SUCCESS
         if self.should_run():
 
+            if not (self.max_balls_keep is None):
+                worker_result = self.recycle_excess_category_max(self.max_balls_keep, [1,2,3,4])
+            if not (self.max_potions_keep is None):
+                worker_result = self.recycle_excess_category_max(self.max_potions_keep, [101,102,103,104])
+            if not (self.max_berries_keep is None):
+                worker_result = self.recycle_excess_category_max(self.max_berries_keep, [701,702,703,704,705])
+            if not (self.max_revives_keep is None):
+                worker_result = self.recycle_excess_category_max(self.max_revives_keep, [201,202])
+
+            inventory.refresh_inventory()
+
             for item_in_inventory in inventory.items().all():
 
                 if self.item_should_be_recycled(item_in_inventory):
@@ -94,6 +113,71 @@ class RecycleItems(BaseTask):
                         worker_result = WorkerResult.ERROR
 
         return worker_result
+
+    def recycle_excess_category_max(self, category_max, category_items_list):
+        """
+        Recycle the item which excess the category max
+        :param category_max:
+        :param category_items_list:
+        :return: none:
+        :rtype: None
+        """
+        worker_result = WorkerResult.SUCCESS
+        category_inventory = self.get_category_inventory_list(category_items_list)
+        category_count = 0
+        for i in category_inventory:
+           category_count = category_count + i[1]
+        items_to_recycle = self.get_category_items_to_recycle(category_inventory, category_count, category_max)
+        for item in items_to_recycle:
+            action_delay(self.bot.config.action_wait_min, self.bot.config.action_wait_max)
+            if ItemRecycler(self.bot, inventory.items().get(item[0]), item[1]).work() == WorkerResult.ERROR:
+                worker_result = WorkerResult.ERROR
+        return worker_result
+
+    def get_category_inventory_list(self, category_inventory):
+        """
+        Returns an array of items with the item id and item count.
+        :param category_inventory:
+        :return: array of items within a category:
+        :rtype: array
+        """
+        x = 0
+        category_inventory_list = []
+        for c in category_inventory:
+            category_inventory_list.append([])
+            category_inventory_list[x].append(c)
+            category_inventory_list[x].append(inventory.items().get(c).count)
+            x = x + 1
+        return category_inventory_list
+
+    def get_category_items_to_recycle(self, category_inventory, category_count, category_max):
+        """
+        Returns an array to be recycle within a category of items with the item id and item count.
+        :param category_inventory:
+        :param category_count:
+        :param category_max:
+        :return: array of items to be recycle.
+        :rtype: array
+        """
+        x = 0
+        items_to_recycle = []
+        if category_count > self.max_balls_keep:
+            items_to_be_recycled = category_count - category_max
+
+            for item in category_inventory:
+                if items_to_be_recycled == 0: 
+                    break
+                if items_to_be_recycled >= item[1]:
+                    items_to_recycle.append([])
+                    items_to_recycle[x].append(item[0])
+                    items_to_recycle[x].append(item[1])
+                else:
+                    items_to_recycle.append([])
+                    items_to_recycle[x].append(item[0])
+                    items_to_recycle[x].append(items_to_be_recycled)
+                items_to_be_recycled = items_to_be_recycled - items_to_recycle[x][1]      
+                x = x + 1
+        return items_to_recycle
 
     def item_should_be_recycled(self, item):
         """


### PR DESCRIPTION
# Please Note (you may remove this section before opening your PR):
We receive lots of PRs and it is hard to give proper review to PRs. Please make it easy on us by following these guidelines:

1. We do not accept changes to `master`. Please make sure your pull request is aimed at `dev`.
2. If you changed a bunch of files (that aren't config files) or multiple workers to implement your feature, it probably won't get proper attention. Please split it up into multiple, smaller, more focused, and iterative PRs if you can.
3. If you are adding a config value to something, make sure you update the appropriate `config.json` example files.


## Short Description:
Enhance the recycle function so that it will consider the total number in a category. If set to keep the maximum of balls as 100. When the total balls excess 100, it will recycle Pokeball, then Greatball, then Ultraball. This function can apply to pokeball, berries, potions & revives

## Fixes (provide links to github issues if you can):
-
-
-


