### PR TITLE
add xxhash to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ timeout-decorator==0.3.2
 raven==5.23.0
 demjson==2.2.4
 greenlet==0.4.9
+xxhash==0.6.1


### PR DESCRIPTION
# Please Note (you may remove this section before opening your PR):
We receive lots of PRs and it is hard to give proper review to PRs. Please make it easy on us by following these guidelines:


## Short Description:
Add xxhash to requirements.txt

## Fixes (provide links to github issues if you can):
#3999 

A number of issues have pointed to needing xxhash, and have been resolved by installing it explicitly after the fact with `pip install xxhash`. latest example was #3999.

Has this been excluded from requirements.txt for a specific reason?

Seems to me this should be in the requirements.txt no? Incidentally I don't know what version of xxhash pip installs by default with the above command because investigating xxhash.__version__ returns no attribute - so others might know?