### PR TITLE
User configurable delay when spinning fort

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -87,6 +87,10 @@
       },
       {
         "type": "SpinFort"
+        "config": {
+          "spin_wait_min": 2,
+          "spin_wait_max": 3
+        }
       },
       {
         "type": "MoveToFort",

--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -26,8 +26,8 @@ class SpinFort(BaseTask):
 
     def initialize(self):
         self.ignore_item_count = self.config.get("ignore_item_count", False)
-        self.spin_wait_min = self.config.get('spin_wait_min', 2)
-        self.spin_wait_max = self.config.get('spin_wait_max', 2)
+        self.spin_wait_min = self.config.get("spin_wait_min", 2)
+        self.spin_wait_max = self.config.get("spin_wait_max", 3)
 
     def should_run(self):
         has_space_for_loot = inventory.Items.has_space_for_loot()
@@ -124,7 +124,7 @@ class SpinFort(BaseTask):
                 )
             if 'chain_hack_sequence_number' in response_dict['responses'][
                     'FORT_SEARCH']:
-                time.sleep(2)
+                action_delay(self.spin_wait_min, self.spin_wait_max)
                 return response_dict['responses']['FORT_SEARCH'][
                     'chain_hack_sequence_number']
             else:

--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -9,7 +9,7 @@ from pgoapi.utilities import f2i
 from pokemongo_bot import inventory
 
 from pokemongo_bot.constants import Constants
-from pokemongo_bot.human_behaviour import sleep
+from pokemongo_bot.human_behaviour import action_delay
 from pokemongo_bot.worker_result import WorkerResult
 from pokemongo_bot.base_task import BaseTask
 from pokemongo_bot.base_dir import _base_dir
@@ -26,6 +26,8 @@ class SpinFort(BaseTask):
 
     def initialize(self):
         self.ignore_item_count = self.config.get("ignore_item_count", False)
+        self.spin_wait_min = self.config.get('spin_wait_min', 2)
+        self.spin_wait_max = self.config.get('spin_wait_max', 2)
 
     def should_run(self):
         has_space_for_loot = inventory.Items.has_space_for_loot()
@@ -139,7 +141,7 @@ class SpinFort(BaseTask):
                 else:
                     self.bot.fort_timeouts[fort["id"]] = (time.time() + 300) * 1000  # Don't spin for 5m
                 return WorkerResult.ERROR
-        sleep(2)
+        action_delay(self.spin_wait_min, self.spin_wait_max)
 
         if len(forts) > 1:
             return WorkerResult.RUNNING


### PR DESCRIPTION
## Short Description:
***Needs example configs updating & docs***

This PR allows the user to set min and max time spent spinning a pokestop and replaces the previous 2 second pause.

```
      {
        "type": "SpinFort"
        "config": {
          "spin_wait_min": 2,
          "spin_wait_max": 3
        }
      }
```

With #3872 and #4048 everything should have a user configurable delay in it's own task config.