### PR TITLE
Show detailed sleep info

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -159,7 +159,10 @@ class PokemonGoBot(object):
         )
         self.event_manager.register_event(
             'bot_sleep',
-            parameters=('time_in_seconds',)
+            parameters=(
+                'time_hms',
+                'wake'
+            )
         )
 
         # fort stuff

--- a/pokemongo_bot/cell_workers/sleep_schedule.py
+++ b/pokemongo_bot/cell_workers/sleep_schedule.py
@@ -93,11 +93,20 @@ class SleepSchedule(BaseTask):
 
     def _sleep(self):
         sleep_to_go = self._next_duration
+
+        sleep_m, sleep_s = divmod(sleep_to_go, 60)
+        sleep_h, sleep_m = divmod(sleep_m, 60)
+        sleep_hms = '%02d:%02d:%02d' % (sleep_h, sleep_m, sleep_s)
+
+        now = datetime.now()
+        wake = str(now + timedelta(seconds=sleep_to_go))
+
         self.emit_event(
             'bot_sleep',
-            formatted="Sleeping for {time_in_seconds}",
+            formatted="Sleeping for {time_hms}, wake at {wake}",
             data={
-                'time_in_seconds': sleep_to_go
+                'time_hms': sleep_hms,
+                'wake': wake
             }
         )
         while sleep_to_go > 0:


### PR DESCRIPTION
Show detailed sleep info (duration in H:M:S instead of seconds and wake date/time)
Tested:
```
2016-08-16 11:56:19,589 [SleepSchedule] [INFO] [bot_sleep] Sleeping for 07:46:00, wake at 2016-08-16 19:42:19.589055
```