### PR TITLE
Make PokemonOptimizer calculate correct transfer / evolve groups

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_optimizer.py
+++ b/pokemongo_bot/cell_workers/pokemon_optimizer.py
@@ -201,7 +201,7 @@ class PokemonOptimizer(BaseTask):
             next_pid = pokemon.next_evolution_ids[0]
             next_evo = copy.copy(pokemon)
             next_evo.pokemon_id = next_pid
-            next_evo._static_data = inventory.pokemons().data_for(next_pid)
+            next_evo.static = inventory.pokemons().data_for(next_pid)
             next_evo.name = inventory.pokemons().name_for(next_pid)
             evolve_best.append(next_evo)
 


### PR DESCRIPTION
## Short Description: 
The pokemon optimizer was replacing the one it wanted to evolve with the new pokemon it would evolve to, but it wasn't setting the correct key on the object which caused the optimizer to always be trying to evolve the same pokemon.

The correct key in the inventory class is `static`: https://github.com/PokemonGoF/PokemonGo-Bot/blob/master/pokemongo_bot/inventory.py#L743

![screen shot 2016-08-16 at 11 11 43 am](https://cloud.githubusercontent.com/assets/249164/17710473/3e3b95d0-63a2-11e6-86eb-23a0b70b628b.png)