### PR TITLE
Send bot through Tor

### DIFF
--- a/docker-compose_tor.yml
+++ b/docker-compose_tor.yml
@@ -11,6 +11,7 @@ services:
       - torproxy
     expose:
       - "8118"
+    restart: "always"
   bot1-pokego:
     build: .
     links: 

--- a/docker-compose_tor.yml
+++ b/docker-compose_tor.yml
@@ -13,6 +13,8 @@ services:
       - "8118"
   bot1-pokego:
     build: .
+    links: 
+      - privoxy
     environment:
       - HTTPS_PROXY=privoxy:8118
       - HTTP_PROXY=privoxy:8118

--- a/docker-compose_tor.yml
+++ b/docker-compose_tor.yml
@@ -1,0 +1,35 @@
+version: '2'
+services:
+  torproxy:
+    image: jess/tor-proxy
+    expose:
+      - "9050"
+    restart: "always"
+  privoxy:
+    image: jess/privoxy
+    links:
+      - torproxy
+    expose:
+      - "8118"
+  bot1-pokego:
+    build: .
+    environment:
+      - HTTPS_PROXY=privoxy:8118
+      - HTTP_PROXY=privoxy:8118
+    volumes:
+     - ./configs:/usr/src/app/configs
+     - ./web:/usr/src/app/web
+    stdin_open: true
+    tty: true
+  bot1-pokegoweb:
+    image: python:2.7
+    ports:
+     - "8000:8000"
+    volumes_from:
+      - bot1-pokego
+    volumes:
+      - ./configs:/usr/src/app/web/config
+    working_dir: /usr/src/app/web
+    command: bash -c "echo 'Serving HTTP on 0.0.0.0 port 8000' && python -m SimpleHTTPServer > /dev/null 2>&1"
+    depends_on:
+     - bot1-pokego


### PR DESCRIPTION
All of the bot's API requests go through tor. Use by specifying this as the docker-compose file.

docker-compose -f docker-compose_tor.yml up -d