### PR TITLE
User configurable delay when spinning fort

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -75,6 +75,10 @@
       },
       {
         "type": "SpinFort"
+        "config": {
+          "spin_wait_min": 2,
+          "spin_wait_max": 3
+        }
       },
       {
         "type": "FollowCluster",

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -87,6 +87,10 @@
       },
       {
         "type": "SpinFort"
+        "config": {
+          "spin_wait_min": 2,
+          "spin_wait_max": 3
+        }
       },
       {
         "type": "MoveToFort",

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -72,6 +72,10 @@
       },
       {
         "type": "SpinFort"
+        "config": {
+          "spin_wait_min": 2,
+          "spin_wait_max": 3
+        }
       },
       {
         "type": "MoveToMapPokemon",

--- a/configs/config.json.optimizer.example
+++ b/configs/config.json.optimizer.example
@@ -119,7 +119,9 @@
         {
             "type": "SpinFort",
             "config": {
-                "ignore_item_count": true
+                "ignore_item_count": true,
+			          "spin_wait_min": 2,
+			          "spin_wait_max": 3
             }
         },
         {

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -75,6 +75,10 @@
       },
       {
         "type": "SpinFort"
+        "config": {
+          "spin_wait_min": 2,
+          "spin_wait_max": 3
+        }
       },
       {
         "type": "FollowPath",

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -75,6 +75,10 @@
       },
       {
         "type": "SpinFort"
+        "config": {
+          "spin_wait_min": 2,
+          "spin_wait_max": 3
+        }
       },
       {
         "type": "MoveToFort",

--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -26,8 +26,8 @@ class SpinFort(BaseTask):
 
     def initialize(self):
         self.ignore_item_count = self.config.get("ignore_item_count", False)
-        self.spin_wait_min = self.config.get('spin_wait_min', 2)
-        self.spin_wait_max = self.config.get('spin_wait_max', 2)
+        self.spin_wait_min = self.config.get("spin_wait_min", 2)
+        self.spin_wait_max = self.config.get("spin_wait_max", 3)
 
     def should_run(self):
         has_space_for_loot = inventory.Items.has_space_for_loot()
@@ -124,7 +124,7 @@ class SpinFort(BaseTask):
                 )
             if 'chain_hack_sequence_number' in response_dict['responses'][
                     'FORT_SEARCH']:
-                time.sleep(2)
+                action_delay(self.spin_wait_min, self.spin_wait_max)
                 return response_dict['responses']['FORT_SEARCH'][
                     'chain_hack_sequence_number']
             else:

--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -9,7 +9,7 @@ from pgoapi.utilities import f2i
 from pokemongo_bot import inventory
 
 from pokemongo_bot.constants import Constants
-from pokemongo_bot.human_behaviour import sleep
+from pokemongo_bot.human_behaviour import action_delay
 from pokemongo_bot.worker_result import WorkerResult
 from pokemongo_bot.base_task import BaseTask
 from pokemongo_bot.base_dir import _base_dir
@@ -26,6 +26,8 @@ class SpinFort(BaseTask):
 
     def initialize(self):
         self.ignore_item_count = self.config.get("ignore_item_count", False)
+        self.spin_wait_min = self.config.get('spin_wait_min', 2)
+        self.spin_wait_max = self.config.get('spin_wait_max', 2)
 
     def should_run(self):
         has_space_for_loot = inventory.Items.has_space_for_loot()
@@ -139,7 +141,7 @@ class SpinFort(BaseTask):
                 else:
                     self.bot.fort_timeouts[fort["id"]] = (time.time() + 300) * 1000  # Don't spin for 5m
                 return WorkerResult.ERROR
-        sleep(2)
+        action_delay(self.spin_wait_min, self.spin_wait_max)
 
         if len(forts) > 1:
             return WorkerResult.RUNNING


### PR DESCRIPTION
## Short Description:
Same as #4050 but request merge to correct branch.

This PR allows the user to set min and max time spent spinning a pokestop and replaces the previous 2 second pause.

```
      {
        "type": "SpinFort"
        "config": {
          "spin_wait_min": 2,
          "spin_wait_max": 3
        }
      }
```

With #3872 and #4048 everything should have a user configurable delay in it's own task config.