### PR TITLE
Don't use sudo when running brew on osx

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -60,8 +60,8 @@ cd $pokebotpath
 if [ "$(uname -s)" == "Darwin" ]
 then
 echo "You are on Mac os"
-sudo brew update 
-sudo brew install --devel protobuf
+brew update 
+brew install --devel protobuf
 elif [ $(uname -s) == CYGWIN* ]
 then
 echo "You are on Cygwin"


### PR DESCRIPTION
When using `sudo` with homebrew we get this message:

```
Error: Cowardly refusing to 'sudo brew update'
You can use brew with sudo, but only if the brew executable is owned by root.
However, this is both not recommended and completely unsupported so do so at
your own risk.
```