### PR TITLE
Assign VIP status based on NCP

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -5,6 +5,8 @@
     "location": "SOME_LOCATION",
     "gmapkey": "GOOGLE_MAPS_API_KEY",
     "encrypt_location": "",
+    "websocket_server": false,
+    "heartbeat_threshold": 10,
     "tasks": [
       {
         "type": "HandleSoftBan"
@@ -39,7 +41,18 @@
         }
       },
       {
-        "type": "TransferPokemon"
+        "type": "TransferPokemon",
+        "config": {
+          "transfer_wait_min": 1,
+          "transfer_wait_max": 4
+        }
+      },
+      {
+        "type": "NicknamePokemon",
+        "config": {
+          "enabled": false,
+          "nickname_template": "{iv_pct}_{iv_ads}"
+        }
       },
       {
         "type": "EvolvePokemon",
@@ -57,6 +70,10 @@
         "type": "RecycleItems",
         "config": {
           "min_empty_space": 15,
+          "max_balls_keep": 150,
+          "max_potions_keep": 50,
+          "max_berries_keep": 70,
+          "max_revives_keep": 70,
           "item_filter": {
             "Pokeball":       { "keep" : 100 },
             "Potion":         { "keep" : 10 },
@@ -64,7 +81,9 @@
             "Hyper Potion":   { "keep" : 30 },
             "Revive":         { "keep" : 30 },
             "Razz Berry":     { "keep" : 100 }
-          }
+          },
+          "recycle_wait_min": 1,
+          "recycle_wait_max": 4
         }
       },
 	    {
@@ -93,7 +112,7 @@
 	      }
 	    },
       {
-        "type": "SpinFort"
+        "type": "SpinFort",
         "config": {
           "spin_wait_min": 2,
           "spin_wait_max": 3
@@ -109,13 +128,11 @@
     ],
     "forts": {
       "avoid_circles": true,
-      "max_circle_size": 50
+      "max_circle_size": 50,
+      "cache_recent_forts": true
     },
-    "websocket_server": false,
     "walk_max": 4.16,
     "walk_min": 2.16,
-    "action_wait_min": 1,
-    "action_wait_max": 4,
     "debug": false,
     "test": false,
     "health_record": true,

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -41,7 +41,7 @@
         }
       },
       {
-        "type": "TransferPokemon"
+        "type": "TransferPokemon",
         "config": {
 	        "transfer_wait_min": 1,
 	        "transfer_wait_max": 4
@@ -81,7 +81,7 @@
             "Hyper Potion":   { "keep" : 30 },
             "Revive":         { "keep" : 30 },
             "Razz Berry":     { "keep" : 100 }
-          }
+          },
           "recycle_wait_min": 1,
           "recycle_wait_max": 4
         }
@@ -112,7 +112,7 @@
 	      }
 	    },
       {
-        "type": "SpinFort"
+        "type": "SpinFort",
         "config": {
           "spin_wait_min": 2,
           "spin_wait_max": 3

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -5,6 +5,7 @@
     "location": "SOME_LOCATION",
     "gmapkey": "GOOGLE_MAPS_API_KEY",
     "encrypt_location": "",
+    "websocket_server": false,
     "heartbeat_threshold": 10,
     "tasks": [
       {
@@ -40,21 +41,39 @@
         }
       },
       {
-        "type": "TransferPokemon"
+        "type": "TransferPokemon",
+        "config": {
+          "transfer_wait_min": 1,
+          "transfer_wait_max": 4
+        }
+      },
+      {
+        "type": "NicknamePokemon",
+        "config": {
+          "enabled": false,
+          "nickname_template": "{iv_pct}_{iv_ads}"
+        }
       },
       {
         "type": "EvolvePokemon",
         "config": {
-          "evolve_all": "NONE",
-          "evolve_cp_min": 300,
-          "evolve_speed": 20,
-          "use_lucky_egg": false
+            "evolve_all": "none",
+            "first_evolve_by": "cp",
+            "evolve_above_cp": 500,
+            "evolve_above_iv": 0.8,
+            "logic": "or",
+            "evolve_speed": 20,
+            "use_lucky_egg": false
         }
       },
       {
         "type": "RecycleItems",
         "config": {
           "min_empty_space": 15,
+          "max_balls_keep": 150,
+          "max_potions_keep": 50,
+          "max_berries_keep": 70,
+          "max_revives_keep": 70,
           "item_filter": {
             "Pokeball":       { "keep" : 100 },
             "Potion":         { "keep" : 10 },
@@ -62,7 +81,9 @@
             "Hyper Potion":   { "keep" : 30 },
             "Revive":         { "keep" : 30 },
             "Razz Berry":     { "keep" : 100 }
-          }
+          },
+          "recycle_wait_min": 1,
+          "recycle_wait_max": 4
         }
       },
 	    {
@@ -91,7 +112,7 @@
 	      }
 	    },
       {
-        "type": "SpinFort"
+        "type": "SpinFort",
         "config": {
           "spin_wait_min": 2,
           "spin_wait_max": 3
@@ -342,22 +363,28 @@
         }
       },
       {
-        "type": "MoveToFort"
+        "type": "MoveToFort",
+        "config": {
+            "lure_attraction": true,
+            "lure_max_distance": 2000
+        }
       },
       {
-        "type": "FollowSpiral"
+        "type": "FollowSpiral",
+        "config": {
+          "diameter": 4,
+          "step_size": 70
+        }
       }
     ],
     "map_object_cache_time": 5,
     "forts": {
       "avoid_circles": true,
-      "max_circle_size": 50
+      "max_circle_size": 50,
+      "cache_recent_forts": true
     },
-    "websocket_server": false,
     "walk_max": 4.16,
     "walk_min": 2.16,
-    "action_wait_min": 1,
-    "action_wait_max": 4,
     "debug": false,
     "test": false,
     "health_record": true,

--- a/configs/config.json.optimizer.example
+++ b/configs/config.json.optimizer.example
@@ -5,19 +5,41 @@
     "location": "SOME_LOCATION",
     "gmapkey": "GOOGLE_MAPS_API_KEY",
     "encrypt_location": "",
+    "websocket_server": false,
+    "heartbeat_threshold": 10,
     "tasks": [
-        {
-            "type": "HandleSoftBan"
-        },
-        {
-            "type": "CollectLevelUpReward"
-        },
-        {
-            "type": "IncubateEggs",
-            "config": {
-                "longer_eggs_first": true
-            }
-        },
+      {
+        "type": "HandleSoftBan"
+      },
+      {
+        "type": "SleepSchedule",
+        "config": {
+          "enabled": false,
+          "time": "22:54",
+          "duration":"7:46",
+          "time_random_offset": "00:24",
+          "duration_random_offset": "00:43"
+        }
+      },
+      {
+        "type": "CollectLevelUpReward"
+      },
+      {
+        "type": "IncubateEggs",
+        "config": {
+          "longer_eggs_first": true
+        }
+      },
+      {
+        "type": "UpdateLiveStats",
+        "config": {
+          "enabled": false,
+          "min_interval": 10,
+          "stats": ["username", "uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],
+          "terminal_log": true,
+          "terminal_title": true
+        }
+      },
         {
             "type": "PokemonOptimizer",
             "config": {
@@ -101,76 +123,85 @@
                     }
                 ]
             }
-        },
-        {
-            "type": "RecycleItems",
-            "config": {
-                "min_empty_space": 15,
-                "item_filter": {
-                    "Pokeball": { "keep": 100 },
-                    "Potion": { "keep": 10 },
-                    "Super Potion": { "keep": 20 },
-                    "Hyper Potion": { "keep": 30 },
-                    "Revive": { "keep": 30 },
-                    "Razz Berry": { "keep": 100 }
-                }
-            }
-        },
-				{
-					"type": "CatchPokemon",
-					"config": {
-						"catch_visible_pokemon": true,
-						"catch_lured_pokemon": true,
-						"min_ultraball_to_keep": 5,
-							"catch_throw_parameters": {
-							"excellent_rate": 0.1,
-							"great_rate": 0.5,
-							"nice_rate": 0.3,
-							"normal_rate": 0.1,
-							"spin_success_rate" : 0.6
-						},
-						"catch_simulation": {
-							"flee_count": 3,
-							"flee_duration": 2,
-							"catch_wait_min": 2,
-							"catch_wait_max": 6,
-							"berry_wait_min": 2,
-							"berry_wait_max": 3,
-							"changeball_wait_min": 2,
-							"changeball_wait_max": 3
-						},
-					}
-				},
-        {
-            "type": "SpinFort",
-            "config": {
-                "ignore_item_count": true,
-			          "spin_wait_min": 2,
-			          "spin_wait_max": 3
-            }
-        },
-        {
-            "type": "MoveToFort",
-            "config": {
-                "lure_attraction": true,
-                "lure_max_distance": 2000,
-                "ignore_item_count": true
-            }
+      },
+      {
+        "type": "RecycleItems",
+        "config": {
+          "min_empty_space": 15,
+          "max_balls_keep": 150,
+          "max_potions_keep": 50,
+          "max_berries_keep": 70,
+          "max_revives_keep": 70,
+          "item_filter": {
+            "Pokeball":       { "keep" : 100 },
+            "Potion":         { "keep" : 10 },
+            "Super Potion":   { "keep" : 20 },
+            "Hyper Potion":   { "keep" : 30 },
+            "Revive":         { "keep" : 30 },
+            "Razz Berry":     { "keep" : 100 }
+          },
+          "recycle_wait_min": 1,
+          "recycle_wait_max": 4
         }
+      },
+        {
+          "type": "CatchPokemon",
+          "config": {
+            "catch_visible_pokemon": true,
+            "catch_lured_pokemon": true,
+            "min_ultraball_to_keep": 5,
+            "catch_throw_parameters": {
+              "excellent_rate": 0.1,
+              "great_rate": 0.5,
+              "nice_rate": 0.3,
+              "normal_rate": 0.1,
+              "spin_success_rate" : 0.6
+            },
+                  "catch_simulation": {
+                    "flee_count": 3,
+                    "flee_duration": 2,
+                    "catch_wait_min": 2,
+                    "catch_wait_max": 6,
+                    "berry_wait_min": 2,
+                    "berry_wait_max": 3,
+                    "changeball_wait_min": 2,
+                    "changeball_wait_max": 3
+                  },
+          }
+        },
+      {
+        "type": "SpinFort",
+        "config": {
+          "spin_wait_min": 2,
+          "spin_wait_max": 3
+        }
+      },
+      {
+        "type": "MoveToFort",
+        "config": {
+            "lure_attraction": true,
+            "lure_max_distance": 2000
+        }
+      },
+      {
+        "type": "FollowSpiral",
+        "config": {
+          "diameter": 4,
+          "step_size": 70
+        }
+      }
     ],
     "map_object_cache_time": 5,
     "forts": {
-        "avoid_circles": true,
-        "max_circle_size": 50
+      "avoid_circles": true,
+      "max_circle_size": 50,
+      "cache_recent_forts": true
     },
-    "websocket_server": true,
     "walk_max": 4.16,
     "walk_min": 2.16,
-    "action_wait_min": 1,
-    "action_wait_max": 4,
     "debug": false,
     "test": false,
-    "health_record": false,
+    "health_record": true,
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -5,6 +5,8 @@
     "location": "SOME_LOCATION",
     "gmapkey": "GOOGLE_MAPS_API_KEY",
     "encrypt_location": "",
+    "websocket_server": false,
+    "heartbeat_threshold": 10,
     "tasks": [
       {
         "type": "HandleSoftBan"
@@ -33,13 +35,24 @@
         "config": {
           "enabled": false,
           "min_interval": 10,
-          "stats": ["uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],
+          "stats": ["username", "uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],
           "terminal_log": true,
           "terminal_title": true
         }
       },
       {
-        "type": "TransferPokemon"
+        "type": "TransferPokemon",
+        "config": {
+          "transfer_wait_min": 1,
+          "transfer_wait_max": 4
+        }
+      },
+      {
+        "type": "NicknamePokemon",
+        "config": {
+          "enabled": false,
+          "nickname_template": "{iv_pct}_{iv_ads}"
+        }
       },
       {
         "type": "EvolvePokemon",
@@ -57,6 +70,10 @@
         "type": "RecycleItems",
         "config": {
           "min_empty_space": 15,
+          "max_balls_keep": 150,
+          "max_potions_keep": 50,
+          "max_berries_keep": 70,
+          "max_revives_keep": 70,
           "item_filter": {
             "Pokeball":       { "keep" : 100 },
             "Potion":         { "keep" : 10 },
@@ -64,36 +81,38 @@
             "Hyper Potion":   { "keep" : 30 },
             "Revive":         { "keep" : 30 },
             "Razz Berry":     { "keep" : 100 }
-          }
+          },
+          "recycle_wait_min": 1,
+          "recycle_wait_max": 4
         }
       },
-	    {
-	      "type": "CatchPokemon",
-	      "config": {
-	        "catch_visible_pokemon": true,
-	        "catch_lured_pokemon": true,
-	        "min_ultraball_to_keep": 5,
-	        "catch_throw_parameters": {
-	          "excellent_rate": 0.1,
-	          "great_rate": 0.5,
-	          "nice_rate": 0.3,
-	          "normal_rate": 0.1,
-	          "spin_success_rate" : 0.6
-	        },
-				  "catch_simulation": {
-				    "flee_count": 3,
-				    "flee_duration": 2,
-				    "catch_wait_min": 2,
-				    "catch_wait_max": 6,
-				    "berry_wait_min": 2,
-				    "berry_wait_max": 3,
-				    "changeball_wait_min": 2,
-				    "changeball_wait_max": 3
-				  },
-	      }
-	    },
       {
-        "type": "SpinFort"
+        "type": "CatchPokemon",
+        "config": {
+          "catch_visible_pokemon": true,
+          "catch_lured_pokemon": true,
+          "min_ultraball_to_keep": 5,
+          "catch_throw_parameters": {
+            "excellent_rate": 0.1,
+            "great_rate": 0.5,
+            "nice_rate": 0.3,
+            "normal_rate": 0.1,
+            "spin_success_rate" : 0.6
+          },
+          "catch_simulation": {
+            "flee_count": 3,
+            "flee_duration": 2,
+            "catch_wait_min": 2,
+            "catch_wait_max": 6,
+            "berry_wait_min": 2,
+            "berry_wait_max": 3,
+            "changeball_wait_min": 2,
+            "changeball_wait_max": 3
+          },
+        }
+      },
+      {
+        "type": "SpinFort",
         "config": {
           "spin_wait_min": 2,
           "spin_wait_max": 3
@@ -113,30 +132,14 @@
       "avoid_circles": true,
       "max_circle_size": 50
     },
-    "websocket_server": false,
     "walk_max": 4.16,
     "walk_min": 2.16,
-    "action_wait_min": 1,
-    "action_wait_max": 4,
     "debug": false,
     "test": false,
     "health_record": true,
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-    "catch_randomize_reticle_factor": 1.0,
-    "catch_randomize_spin_factor": 1.0,
-	  "catch_simulation": {
-	    "flee_count": 3,
-	    "flee_duration": 2,
-	    "catch_wait_min": 2,
-	    "catch_wait_max": 6,
-	    "berry_wait_min": 2,
-	    "berry_wait_max": 3,
-	    "changeball_wait_min": 2,
-	    "changeball_wait_max": 3
-	  },
-    "min_ultraball_to_keep": 10,
     "logging_color": true,
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -5,6 +5,7 @@
     "location": "SOME_LOCATION",
     "gmapkey": "GOOGLE_MAPS_API_KEY",
     "encrypt_location": "",
+    "websocket_server": false,
     "heartbeat_threshold": 10,
     "tasks": [
       {
@@ -40,7 +41,18 @@
         }
       },
       {
-        "type": "TransferPokemon"
+        "type": "TransferPokemon",
+        "config": {
+          "transfer_wait_min": 1,
+          "transfer_wait_max": 4
+        }
+      },
+      {
+        "type": "NicknamePokemon",
+        "config": {
+          "enabled": false,
+          "nickname_template": "{iv_pct}_{iv_ads}"
+        }
       },
       {
         "type": "EvolvePokemon",
@@ -58,6 +70,10 @@
         "type": "RecycleItems",
         "config": {
           "min_empty_space": 15,
+          "max_balls_keep": 150,
+          "max_potions_keep": 50,
+          "max_berries_keep": 70,
+          "max_revives_keep": 70,
           "item_filter": {
             "Pokeball":       { "keep" : 100 },
             "Potion":         { "keep" : 10 },
@@ -65,7 +81,9 @@
             "Hyper Potion":   { "keep" : 30 },
             "Revive":         { "keep" : 30 },
             "Razz Berry":     { "keep" : 100 }
-          }
+          },
+          "recycle_wait_min": 1,
+          "recycle_wait_max": 4
         }
       },
 	    {
@@ -94,7 +112,7 @@
 	      }
 	    },
       {
-        "type": "SpinFort"
+        "type": "SpinFort",
         "config": {
           "spin_wait_min": 2,
           "spin_wait_max": 3
@@ -118,13 +136,11 @@
     "map_object_cache_time": 5,
     "forts": {
       "avoid_circles": true,
-      "max_circle_size": 50
+      "max_circle_size": 50,
+      "cache_recent_forts": true
     },
-    "websocket_server": false,
     "walk_max": 4.16,
     "walk_min": 2.16,
-    "action_wait_min": 1,
-    "action_wait_max": 4,
     "debug": false,
     "test": false,
     "health_record": true,

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -165,10 +165,7 @@ class PokemonGoBot(object):
         )
         self.event_manager.register_event(
             'bot_sleep',
-            parameters=(
-                'time_hms',
-                'wake'
-            )
+            parameters=('time_in_seconds',)
         )
 
         # fort stuff
@@ -246,9 +243,7 @@ class PokemonGoBot(object):
             'pokemon_appeared',
             parameters=(
                 'pokemon',
-                'cp',
-                'iv',
-                'iv_display',
+                'ncp', 'cp', 'iv', 'iv_display',
                 'encounter_id',
                 'latitude',
                 'longitude',
@@ -301,7 +296,7 @@ class PokemonGoBot(object):
             'pokemon_caught',
             parameters=(
                 'pokemon',
-                'cp', 'iv', 'iv_display', 'exp',
+                'ncp', 'cp', 'iv', 'iv_display', 'exp',
                 'encounter_id',
                 'latitude',
                 'longitude',
@@ -421,7 +416,7 @@ class PokemonGoBot(object):
         self.event_manager.register_event(
             'arrived_at_cluster',
             parameters=(
-                'num_points', 'forts', 'radius'
+                'forts', 'radius'
             )
         )
 

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -165,7 +165,10 @@ class PokemonGoBot(object):
         )
         self.event_manager.register_event(
             'bot_sleep',
-            parameters=('time_in_seconds',)
+            parameters=(
+                 'time_hms',
+                 'wake'
+             )
         )
 
         # fort stuff

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -166,8 +166,8 @@ class PokemonGoBot(object):
         self.event_manager.register_event(
             'bot_sleep',
             parameters=(
-                 'time_hms',
-                 'wake'
+                'time_hms',
+                'wake'
              )
         )
 

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -168,7 +168,7 @@ class PokemonGoBot(object):
             parameters=(
                 'time_hms',
                 'wake'
-             )
+            )
         )
 
         # fort stuff

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -419,7 +419,7 @@ class PokemonGoBot(object):
         self.event_manager.register_event(
             'arrived_at_cluster',
             parameters=(
-                'forts', 'radius'
+                'num_points', 'forts', 'radius'
             )
         )
 


### PR DESCRIPTION
## Short Description:
Added NCP support to pokemon_catch_worker.py.
Added logic to compare based on three variables.

Since NCP is effectively pokemon level / trainer level this seems like an improvement over absolute CP for determining catch cut offs.

I was only looking to specify anything above a certain CP% as a VIP, but this should allow you to avoid catching low CP pokemon as well.

Using a three variable comparison allows for more intricate decisions to be made by the pokemon_catch_worker. If this is a reasonable addition, it can be added to transfer_worker as well, though PokemonOptimizer largely deprecates the TransferPokemon task.