### PR TITLE
Patch snipe in move_to_map_pokemon.py

### DIFF
--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -212,7 +212,7 @@ class MoveToMapPokemon(BaseTask):
         last_position = self.bot.position[0:2]
         self.bot.heartbeat()
         self._teleport_to(pokemon)
-        catch_worker = PokemonCatchWorker(pokemon, self.bot)
+        catch_worker = PokemonCatchWorker(pokemon, self.bot, self.config)
         api_encounter_response = catch_worker.create_encounter_api_call()
         time.sleep(SNIPE_SLEEP_SEC)
         self._teleport_back(last_position)


### PR DESCRIPTION
## Short Description:
Snipe does not work anymore because of wrong call to PokemonCatchWorker in Snipe method

## Fixes/Resolves/Closes (please use correct syntax):
Fixes #4142