### PR TITLE
Added Daily Catch Limits & Catch Log (SQL)

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -148,6 +148,7 @@
     "distance_unit": "km",
     "reconnecting_timeout": 15,
     "logging_color": true,
+    "daily_catch_limit": 800,
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -156,6 +156,7 @@
     "distance_unit": "km",
     "reconnecting_timeout": 15,
     "logging_color": true,
+    "daily_catch_limit": 800,
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -400,6 +400,7 @@
     "distance_unit": "km",
     "reconnecting_timeout": 15,
     "logging_color": true,
+    "daily_catch_limit": 800,
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},

--- a/configs/config.json.optimizer.example
+++ b/configs/config.json.optimizer.example
@@ -214,6 +214,7 @@
     "distance_unit": "km",
     "reconnecting_timeout": 15,
     "logging_color": true,
+    "daily_catch_limit": 800,
     "catch": {
         "any": {
             "always_catch": true

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -149,6 +149,7 @@
     "distance_unit": "km",
     "reconnecting_timeout": 15,
     "logging_color": true,
+    "daily_catch_limit": 800,
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -156,6 +156,7 @@
     "distance_unit": "km",
     "reconnecting_timeout": 15,
     "logging_color": true,
+    "daily_catch_limit": 800,
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or" },
 

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -19,6 +19,7 @@
 | `location_cache`   | true    | Bot will start at last known location if you do not have location set in the config                                                                                                         |
 | `distance_unit`    | km      | Set the unit to display distance in (km for kilometers, mi for miles, ft for feet)                                                                                                          |
 | `evolve_cp_min`           | 300   |                   Min. CP for evolve_all function
+|`daily_catch_llimit`    | 800   |                   Limit the amount of pokemon caught in a 24 hour period.
 
 ## Configuring Tasks
 The behaviors of the bot are configured via the `tasks` key in the `config.json`. This enables you to list what you want the bot to do and change the priority of those tasks by reordering them in the list. This list of tasks is run repeatedly and in order. For more information on why we are moving config to this format, check out the [original proposal](https://github.com/PokemonGoF/PokemonGo-Bot/issues/142).

--- a/pokecli.py
+++ b/pokecli.py
@@ -467,7 +467,7 @@ def init_config():
     config.release = load.get('release', {})
     config.plugins = load.get('plugins', [])
     config.raw_tasks = load.get('tasks', [])
-
+    config.daily_catch_limit = load.get('daily_catch_limit', 800)
     config.vips = load.get('vips', {})
 
     if config.map_object_cache_time < 0.0:

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -323,6 +323,7 @@ class PokemonGoBot(Datastore):
         self.event_manager.register_event('threw_berry_failed', parameters=('status_code',))
         self.event_manager.register_event('vip_pokemon')
         self.event_manager.register_event('gained_candy', parameters=('quantity', 'type'))
+        self.event_manager.register_event('catch_limit')
 
         # level up stuff
         self.event_manager.register_event(

--- a/pokemongo_bot/cell_workers/migrations/catch_log.py
+++ b/pokemongo_bot/cell_workers/migrations/catch_log.py
@@ -1,0 +1,5 @@
+from yoyo import step
+
+step(
+    "CREATE TABLE catch_log (pokemon text, cp real, iv real, encounter_id text, pokemon_id real, dated datetime DEFAULT CURRENT_TIMESTAMP)"
+)

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -452,7 +452,6 @@ class PokemonCatchWorker(Datastore, BaseTask):
 
          # pokemon caught!
             elif catch_pokemon_status == CATCH_STATUS_SUCCESS:
-                self.logger = logging.getLogger(type(self).__name__)
                 pokemon.id = response_dict['responses']['CATCH_POKEMON']['captured_pokemon_id']
                 self.bot.metrics.captured_pokemon(pokemon.name, pokemon.cp, pokemon.iv_display, pokemon.iv)
                 
@@ -473,11 +472,11 @@ class PokemonCatchWorker(Datastore, BaseTask):
                     }
                
                 )
-                catches = [
-                    (pokemon.name, pokemon.cp, pokemon.iv, str(self.pokemon['encounter_id']), pokemon.pokemon_id)
-                ]
+                #catches = [
+                 #   (pokemon.name, pokemon.cp, pokemon.iv, str(self.pokemon['encounter_id']), pokemon.pokemon_id)
+                #]
                 with self.bot.database as conn:
-                    conn.executemany('''INSERT INTO catch_log (pokemon, cp, iv, encounter_id, pokemon_id) VALUES (?, ?, ?, ?, ?)''',  catches)
+                    conn.execute('''INSERT INTO catch_log (pokemon, cp, iv, encounter_id, pokemon_id) VALUES (?, ?, ?, ?, ?)''', (pokemon.name, pokemon.cp, pokemon.iv, str(encounter_id), pokemon.pokemon_id))
                 #conn.commit()
                 user_data_caught = os.path.join(_base_dir, 'data', 'caught-%s.json' % self.bot.config.username)
                 with open(user_data_caught, 'ab') as outfile:

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
+import os
+import time
+import json
+import logging
 import time
 from random import random, randrange
 from pokemongo_bot import inventory
@@ -8,6 +12,8 @@ from pokemongo_bot.human_behaviour import sleep, action_delay
 from pokemongo_bot.inventory import Pokemon
 from pokemongo_bot.worker_result import WorkerResult
 from pokemongo_bot.datastore import Datastore
+from pokemongo_bot.base_dir import _base_dir
+from datetime import datetime, timedelta
 
 CATCH_STATUS_SUCCESS = 1
 CATCH_STATUS_FAILED = 2
@@ -130,10 +136,29 @@ class PokemonCatchWorker(Datastore, BaseTask):
         if is_vip:
             self.emit_event('vip_pokemon', formatted='This is a VIP pokemon. Catch!!!')
 
-        # catch that pokemon!
-        encounter_id = self.pokemon['encounter_id']
-        catch_rate_by_ball = [0] + response['capture_probability']['capture_probability']  # offset so item ids match indces
-        self._do_catch(pokemon, encounter_id, catch_rate_by_ball, is_vip=is_vip)
+        # check for VIP pokemon
+        is_vip = self._is_vip_pokemon(pokemon)
+        if is_vip:
+            self.emit_event('vip_pokemon', formatted='This is a VIP pokemon. Catch!!!')
+
+        # check catch limits before catch
+        with self.bot.database as conn:      
+            c = conn.cursor()
+            c.execute("SELECT DISTINCT COUNT(encounter_id) FROM catch_log WHERE dated >= datetime('now','-1 day')")
+            
+        result = c.fetchone()
+        
+        while True:
+            max_catch = self.bot.config.daily_catch_limit
+            if result[0] < max_catch:
+            # catch that pokemon!
+                encounter_id = self.pokemon['encounter_id']
+                catch_rate_by_ball = [0] + response['capture_probability']['capture_probability']  # offset so item ids match indces
+                self._do_catch(pokemon, encounter_id, catch_rate_by_ball, is_vip=is_vip)
+                break
+            else:
+                self.emit_event('catch_limit', formatted='WARNING! You have reached your daily catch limit')
+                break
 
         # simulate app
         time.sleep(5)
@@ -425,11 +450,13 @@ class PokemonCatchWorker(Datastore, BaseTask):
                 if self._pct(catch_rate_by_ball[current_ball]) == 100:
                     self.bot.softban = True
 
-            # pokemon caught!
+         # pokemon caught!
             elif catch_pokemon_status == CATCH_STATUS_SUCCESS:
+                self.logger = logging.getLogger(type(self).__name__)
                 pokemon.id = response_dict['responses']['CATCH_POKEMON']['captured_pokemon_id']
                 self.bot.metrics.captured_pokemon(pokemon.name, pokemon.cp, pokemon.iv_display, pokemon.iv)
-                inventory.pokemons().add(pokemon)
+                
+            try:
                 self.emit_event(
                     'pokemon_caught',
                     formatted='Captured {pokemon}! [CP {cp}] [Potential {iv}] [{iv_display}] [+{exp} exp]',
@@ -444,7 +471,28 @@ class PokemonCatchWorker(Datastore, BaseTask):
                         'longitude': self.pokemon['longitude'],
                         'pokemon_id': pokemon.pokemon_id
                     }
+               
                 )
+                catches = [
+                    (pokemon.name, pokemon.cp, pokemon.iv, str(self.pokemon['encounter_id']), pokemon.pokemon_id)
+                ]
+                with self.bot.database as conn:
+                    conn.executemany('''INSERT INTO catch_log (pokemon, cp, iv, encounter_id, pokemon_id) VALUES (?, ?, ?, ?, ?)''',  catches)
+                #conn.commit()
+                user_data_caught = os.path.join(_base_dir, 'data', 'caught-%s.json' % self.bot.config.username)
+                with open(user_data_caught, 'ab') as outfile:
+                    outfile.write(str(datetime.now()))
+                    json.dump({
+                    'pokemon': pokemon.name,
+                    'cp': pokemon.cp,
+                    'iv': pokemon.iv,
+                    'encounter_id': self.pokemon['encounter_id'],
+                    'pokemon_id': pokemon.pokemon_id 
+                     }, outfile)
+                    outfile.write('\n')
+                   
+            except IOError as e:
+                self.logger.info('[x] Error while opening location file: %s' % e)
 
                 # We could refresh here too, but adding 3 saves a inventory request
                 candy = inventory.candies(True).get(pokemon.pokemon_id)

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -472,9 +472,6 @@ class PokemonCatchWorker(Datastore, BaseTask):
                     }
                
                 )
-                #catches = [
-                 #   (pokemon.name, pokemon.cp, pokemon.iv, str(self.pokemon['encounter_id']), pokemon.pokemon_id)
-                #]
                 with self.bot.database as conn:
                     conn.execute('''INSERT INTO catch_log (pokemon, cp, iv, encounter_id, pokemon_id) VALUES (?, ?, ?, ?, ?)''', (pokemon.name, pokemon.cp, pokemon.iv, str(encounter_id), pokemon.pokemon_id))
                 #conn.commit()

--- a/pokemongo_bot/event_handlers/colored_logging_handler.py
+++ b/pokemongo_bot/event_handlers/colored_logging_handler.py
@@ -11,6 +11,7 @@ class ColoredLoggingHandler(EventHandler):
         'api_error':                         'red',
         'bot_exit':                          'red',
         'bot_start':                         'green',
+        'catch_limit':                       'red',
         'config_error':                      'red',
         'egg_already_incubating':            'yellow',
         'egg_hatched':                       'green',

--- a/pokemongo_bot/migrations/catch_log.py
+++ b/pokemongo_bot/migrations/catch_log.py
@@ -1,0 +1,5 @@
+from yoyo import step
+
+step(
+    "CREATE TABLE catch_log (pokemon text, cp real, iv real, encounter_id text, pokemon_id real, dated datetime DEFAULT CURRENT_TIMESTAMP)"
+)

--- a/pokemongo_bot/migrations/catch_log.py
+++ b/pokemongo_bot/migrations/catch_log.py
@@ -1,5 +1,0 @@
-from yoyo import step
-
-step(
-    "CREATE TABLE catch_log (pokemon text, cp real, iv real, encounter_id text, pokemon_id real, dated datetime DEFAULT CURRENT_TIMESTAMP)"
-)


### PR DESCRIPTION
Added daily pokemon catch limits (per 24 hours) using config variable "daily_catch_limit". The catches are now stored to the "catch_log" table in the database (and in data/caught-username.json file) which is queried using "SELECT" to find all catches that took place in the past 24 hours. If the limit is reached, the pokemon will not be attempted to be caught.

Default is 800 (since majority of community reports bans at at 1,000 / 24 hours)

```
# check catch limits before catch
        with self.bot.database.backend.connection as conn:       
            c = conn.cursor()
            c.execute("SELECT DISTINCT COUNT(encounter_id) FROM catch_log WHERE dated >= datetime('now','-1 day')")
            
        result = c.fetchone()
        
        while True:
            max_catch = self.bot.config.daily_catch_limit
            if result[0] < max_catch:
            # catch that pokemon!
```

I use distinct on the ecounter_id just in case there is a duplicated record for what ever reason.

![image](https://cloud.githubusercontent.com/assets/2157599/17755817/4496edae-64aa-11e6-8339-6a6a54c7ebfe.png)

Many thanks to @cwild for the database/migrations implementation and a lot of help and discussion on slack (starting at https://github.com/PokemonGoF/PokemonGo-Bot/pull/4129) 