### PR TITLE
Latitude and Longitude in UpdateLiveStats

### DIFF
--- a/pokemongo_bot/cell_workers/update_live_stats.py
+++ b/pokemongo_bot/cell_workers/update_live_stats.py
@@ -245,7 +245,7 @@ class UpdateLiveStats(BaseTask):
             'stardust_earned': 'Earned {:,} Stardust'.format(stardust_earned),
             'highest_cp_pokemon': 'Highest CP pokemon : {}'.format(highest_cp_pokemon),
             'most_perfect_pokemon': 'Most perfect pokemon : {}'.format(most_perfect_pokemon),
-            'location': 'Location : ({:,}, {:,})'.format(self.bot.position[0], self.bot.position[1])
+            'location': 'Location : ({}, {})'.format(self.bot.position[0], self.bot.position[1]),
         }
 
         def get_stat(stat):

--- a/pokemongo_bot/cell_workers/update_live_stats.py
+++ b/pokemongo_bot/cell_workers/update_live_stats.py
@@ -56,6 +56,7 @@ class UpdateLiveStats(BaseTask):
     - stardust_earned : The number of earned stardust since the bot started.
     - highest_cp_pokemon : The caught pokemon with the highest CP since the bot started.
     - most_perfect_pokemon : The most perfect caught pokemon since the bot started.
+    - location : The location where the player is located.
     """
     SUPPORTED_TASK_API_VERSION = 1
 
@@ -244,6 +245,7 @@ class UpdateLiveStats(BaseTask):
             'stardust_earned': 'Earned {:,} Stardust'.format(stardust_earned),
             'highest_cp_pokemon': 'Highest CP pokemon : {}'.format(highest_cp_pokemon),
             'most_perfect_pokemon': 'Most perfect pokemon : {}'.format(most_perfect_pokemon),
+            'location': 'Location : ({:,}, {:,})'.format(self.bot.position[0], self.bot.position[1])
         }
 
         def get_stat(stat):


### PR DESCRIPTION
## Short Description:
Simply added an option to show location, as '(latitude, longitude)', to UpdateLiveStats.
Since it does an api call each time it needs to get it the location, i was thinking if using the location at `last-location-{username}.json` would be accurate enough for this function.

## Fixes/Resolves/Closes (please use correct syntax):
Closes [#4156](https://github.com/PokemonGoF/PokemonGo-Bot/issues/4156)