### PR TITLE
Revert "Pokestops / Evolves / Transfers Logged to DB"

### DIFF
--- a/pokemongo_bot/cell_workers/evolve_pokemon.py
+++ b/pokemongo_bot/cell_workers/evolve_pokemon.py
@@ -3,13 +3,11 @@ from pokemongo_bot.human_behaviour import sleep
 from pokemongo_bot.inventory import Pokemon
 from pokemongo_bot.item_list import Item
 from pokemongo_bot.base_task import BaseTask
-from pokemongo_bot.datastore import Datastore
 
-class EvolvePokemon(Datastore, BaseTask):
+
+class EvolvePokemon(BaseTask):
     SUPPORTED_TASK_API_VERSION = 1
-    def __init__(self, bot, config):
-        super(EvolvePokemon, self).__init__(bot, config)
-   
+
     def initialize(self):
         self.api = self.bot.api
         self.evolve_all = self.config.get('evolve_all', [])
@@ -115,8 +113,6 @@ class EvolvePokemon(Datastore, BaseTask):
                     'xp': '?'
                 }
             )
-            with self.bot.database as conn:
-                conn.execute('''INSERT INTO evolve_log (pokemon, iv, cp) VALUES (?, ?, ?)''', (pokemon.name, pokemon.iv, pokemon.cp))
             awarded_candies = response_dict.get('responses', {}).get('EVOLVE_POKEMON', {}).get('candy_awarded', 0)
             inventory.candies().get(pokemon.pokemon_id).consume(pokemon.evolution_cost - awarded_candies)
             inventory.pokemons().remove(pokemon.unique_id)

--- a/pokemongo_bot/cell_workers/migrations/evolve_log.py
+++ b/pokemongo_bot/cell_workers/migrations/evolve_log.py
@@ -1,5 +1,0 @@
-from yoyo import step
-
-step(
-    "CREATE TABLE evolve_log (pokemon text, iv real, cp real, dated datetime DEFAULT CURRENT_TIMESTAMP)"
-)

--- a/pokemongo_bot/cell_workers/migrations/pokestop_log.py
+++ b/pokemongo_bot/cell_workers/migrations/pokestop_log.py
@@ -1,5 +1,0 @@
-from yoyo import step
-
-step(
-    "CREATE TABLE pokestop_log (pokestop text, exp real, items text, dated datetime DEFAULT CURRENT_TIMESTAMP)"
-)

--- a/pokemongo_bot/cell_workers/migrations/transfer_log.py
+++ b/pokemongo_bot/cell_workers/migrations/transfer_log.py
@@ -1,5 +1,0 @@
-from yoyo import step
-
-step(
-    "CREATE TABLE transfer_log (pokemon text, iv real, cp real, dated datetime DEFAULT CURRENT_TIMESTAMP)"
-)

--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -79,16 +79,12 @@ class SpinFort(BaseTask):
                             'items': items_awarded
                         }
                     )
-                    with self.bot.database as conn:
-                        conn.execute('''INSERT INTO pokestop_log (pokestop, exp, items) VALUES (?, ?, ?)''', (fort_name, str(experience_awarded), str(items_awarded)))                    
                 else:
                     self.emit_event(
                         'pokestop_empty',
                         formatted='Found nothing in pokestop {pokestop}.',
                         data={'pokestop': fort_name}
                     )
-                    with self.bot.database as conn:
-                        conn.execute('''INSERT INTO pokestop_log (pokestop) VALUES (?)''', (fort_name)) 
                 pokestop_cooldown = spin_details.get(
                     'cooldown_complete_timestamp_ms')
                 self.bot.fort_timeouts.update({fort["id"]: pokestop_cooldown})

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -5,13 +5,10 @@ from pokemongo_bot import inventory
 from pokemongo_bot.human_behaviour import action_delay
 from pokemongo_bot.base_task import BaseTask
 from pokemongo_bot.inventory import Pokemons, Pokemon, Attack
-from pokemongo_bot.datastore import Datastore
 
-class TransferPokemon(Datastore, BaseTask):
+class TransferPokemon(BaseTask):
     SUPPORTED_TASK_API_VERSION = 1
-    
-    def __init__(self, bot, config):
-        super(TransferPokemon, self).__init__(bot, config)
+
     def initialize(self):
         self.transfer_wait_min = self.config.get('transfer_wait_min', 1)
         self.transfer_wait_max = self.config.get('transfer_wait_max', 4)
@@ -178,8 +175,6 @@ class TransferPokemon(Datastore, BaseTask):
                 'dps': pokemon.moveset.dps
             }
         )
-        with self.bot.database as conn:
-            conn.execute('''INSERT INTO transfer_log (pokemon, iv, cp) VALUES (?, ?, ?)''', (pokemon.name, pokemon.iv, pokemon.cp))       
         action_delay(self.transfer_wait_min, self.transfer_wait_max)
 
     def _get_release_config_for(self, pokemon):


### PR DESCRIPTION
Reverts PokemonGoF/PokemonGo-Bot#4232

Caused crash reported in #dev channel, need revert.

`
Traceback (most recent call last):
  File "pokecli.py", line 596, in <module>
    main()
  File "pokecli.py", line 106, in main
    bot.tick()
  File "/Users/bstpierre/PokemonGo-Bot/pokemongo_bot/__init__.py", line 532, in tick
    if worker.work() == WorkerResult.RUNNING:
  File "/Users/bstpierre/PokemonGo-Bot/pokemongo_bot/cell_workers/spin_fort.py", line 83, in work
    conn.execute('''INSERT INTO pokestop_log (pokestop, exp, items) VALUES (?, ?, ?)''', (fort_name, str(experience_awarded), str(items_awarded)))                    
sqlite3.OperationalError: no such table: pokestop_log
`