### PR TITLE
Update the typo in Sample Config

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -4,7 +4,7 @@
     "password": "YOUR_PASSWORD",
     "location": "SOME_LOCATION",
     "gmapkey": "GOOGLE_MAPS_API_KEY",
-    "libencrypt_location": "",
+    "encrypt_location": "",
     "tasks": [
       {
         "type": "HandleSoftBan"


### PR DESCRIPTION
The key for encrypt_location is inconsistent with the code, in pokemongo_bot/__init__.py, it is looking at key "encrypt_location" instead of "libencrypt_location"