### PR TITLE
Configurable altitude range 

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -160,6 +160,8 @@
     },
     "walk_max": 4.16,
     "walk_min": 2.16,
+    "alt_min": 0.75,
+    "alt_max": 2.5,
     "debug": false,
     "test": false,
     "health_record": true,

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -179,6 +179,8 @@
     },
     "walk_max": 4.16,
     "walk_min": 2.16,
+    "alt_min": 0.75,
+    "alt_max": 2.5,
     "debug": false,
     "test": false,
     "health_record": true,

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -413,6 +413,8 @@
     },
     "walk_max": 4.16,
     "walk_min": 2.16,
+    "alt_min": 0.75,
+    "alt_max": 2.5,
     "debug": false,
     "test": false,
     "health_record": true,

--- a/configs/config.json.optimizer.example
+++ b/configs/config.json.optimizer.example
@@ -226,6 +226,8 @@
     },
     "walk_max": 4.16,
     "walk_min": 2.16,
+    "alt_min": 0.75,
+    "alt_max": 2.5,
     "debug": false,
     "test": false,
     "health_record": true,

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -161,6 +161,8 @@
     },
     "walk_max": 4.16,
     "walk_min": 2.16,
+    "alt_min": 0.75,
+    "alt_max": 2.5,
     "debug": false,
     "test": false,
     "health_record": true,

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -168,6 +168,8 @@
     },
     "walk_max": 4.16,
     "walk_min": 2.16,
+    "alt_min": 0.75,
+    "alt_max": 2.5,
     "debug": false,
     "test": false,
     "health_record": true,

--- a/pokecli.py
+++ b/pokecli.py
@@ -486,7 +486,7 @@ def init_config():
         long_flag="--alt_min",
         help="Minimum random altitude",
         type=float,
-        default=85
+        default=0.75
     )
     add_config(
         parser,
@@ -494,7 +494,7 @@ def init_config():
         long_flag="--alt_max",
         help="Maximum random altitude",
         type=float,
-        default=115
+        default=2.5
     )
     # Start to parse other attrs
     config = parser.parse_args()

--- a/pokecli.py
+++ b/pokecli.py
@@ -480,6 +480,22 @@ def init_config():
         type=bool,
         default=[]
     )
+    add_config(
+        parser,
+        load,
+        long_flag="--alt_min",
+        help="Minimum random altitude",
+        type=float,
+        default=85
+    )
+    add_config(
+        parser,
+        load,
+        long_flag="--alt_max",
+        help="Maximum random altitude",
+        type=float,
+        default=115
+    )
     # Start to parse other attrs
     config = parser.parse_args()
     if not config.username and 'username' not in load:

--- a/pokemongo_bot/cell_workers/follow_cluster.py
+++ b/pokemongo_bot/cell_workers/follow_cluster.py
@@ -2,6 +2,7 @@ from pokemongo_bot.walkers.step_walker import StepWalker
 from pokemongo_bot.cell_workers.utils import distance
 from pokemongo_bot.cell_workers.utils import find_biggest_cluster
 from pokemongo_bot.base_task import BaseTask
+from random import uniform
 
 class FollowCluster(BaseTask):
     SUPPORTED_TASK_API_VERSION = 1
@@ -66,7 +67,8 @@ class FollowCluster(BaseTask):
                     if step_walker.step():
                         self.is_at_destination = True
                 else:
-                    self.bot.api.set_position(lat, lng)
+                    alt = uniform(self.bot.config.alt_min, self.bot.config.alt_max)
+                    self.bot.api.set_position(lat, lng, alt)
 
             elif not self.announced:
                 self.emit_event(

--- a/pokemongo_bot/cell_workers/follow_path.py
+++ b/pokemongo_bot/cell_workers/follow_path.py
@@ -117,7 +117,8 @@ class FollowPath(BaseTask):
                 is_at_destination = True
 
         else:
-            self.bot.api.set_position(lat, lng, 0)
+            alt = uniform(self.bot.config.alt_min, self.bot.config.alt_max)
+            self.bot.api.set_position(lat, lng, alt)
 
         dist = distance(
             last_lat,

--- a/pokemongo_bot/cell_workers/follow_path.py
+++ b/pokemongo_bot/cell_workers/follow_path.py
@@ -8,6 +8,7 @@ from pokemongo_bot.cell_workers.utils import distance, i2f, format_dist
 from pokemongo_bot.human_behaviour import sleep
 from pokemongo_bot.walkers.step_walker import StepWalker
 from pgoapi.utilities import f2i
+from random import uniform
 
 
 class FollowPath(BaseTask):

--- a/pokemongo_bot/cell_workers/follow_spiral.py
+++ b/pokemongo_bot/cell_workers/follow_spiral.py
@@ -6,6 +6,7 @@ import math
 from pokemongo_bot.cell_workers.utils import distance, format_dist
 from pokemongo_bot.walkers.step_walker import StepWalker
 from pokemongo_bot.base_task import BaseTask
+from random import uniform
 
 class FollowSpiral(BaseTask):
     SUPPORTED_TASK_API_VERSION = 1
@@ -101,7 +102,8 @@ class FollowSpiral(BaseTask):
             if step_walker.step():
                 step_walker = None
         else:
-            self.bot.api.set_position(point['lat'], point['lng'], 0)
+            alt = uniform(self.bot.config.alt_min, self.bot.config.alt_max)
+            self.bot.api.set_position(point['lat'], point['lng'], alt)
 
             self.emit_event(
                 'position_update',

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -62,6 +62,7 @@ from pokemongo_bot.walkers.walker_factory import walker_factory
 from pokemongo_bot.worker_result import WorkerResult
 from pokemongo_bot.base_task import BaseTask
 from pokemongo_bot.cell_workers.pokemon_catch_worker import PokemonCatchWorker
+from random import uniform
 
 
 # Update the map if more than N meters away from the center. (AND'd with

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -99,6 +99,7 @@ class MoveToMapPokemon(BaseTask):
             self.caught = json.load(
                 open(data_file)
             )
+        self.alt = uniform(self.bot.config.alt_min, self.bot.config.alt_max)
 
     def get_pokemon_from_map(self):
         try:
@@ -226,7 +227,7 @@ class MoveToMapPokemon(BaseTask):
         api_encounter_response = catch_worker.create_encounter_api_call()
         time.sleep(SNIPE_SLEEP_SEC)
         self._teleport_back(last_position)
-        self.bot.api.set_position(last_position[0], last_position[1], 0)
+        self.bot.api.set_position(last_position[0], last_position[1], alt)
         time.sleep(SNIPE_SLEEP_SEC)
         self.bot.heartbeat()
         catch_worker.work(api_encounter_response)
@@ -334,7 +335,7 @@ class MoveToMapPokemon(BaseTask):
             formatted='Teleporting to {poke_name}. ({poke_dist})',
             data=self._pokemon_event_data(pokemon)
         )
-        self.bot.api.set_position(pokemon['latitude'], pokemon['longitude'], 0)
+        self.bot.api.set_position(pokemon['latitude'], pokemon['longitude'], alt)
         self._encountered(pokemon)
 
     def _encountered(self, pokemon):

--- a/pokemongo_bot/walkers/polyline_walker.py
+++ b/pokemongo_bot/walkers/polyline_walker.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from random import uniform
 from pokemongo_bot.human_behaviour import sleep
 from pokemongo_bot.walkers.step_walker import StepWalker
 from polyline_generator import PolylineObjectHandler
@@ -33,7 +34,7 @@ class PolylineWalker(StepWalker):
         sleep(1)
         self.polyline_walker.pause()
         cLat, cLng = self.polyline_walker.get_pos()[0]
-        _, _, alt = self.api.get_position()
+        alt = uniform(self.bot.config.alt_min, self.bot.config.alt_max)
         self.api.set_position(cLat, cLng, alt)
         self.bot.heartbeat()
         return False

--- a/pokemongo_bot/walkers/step_walker.py
+++ b/pokemongo_bot/walkers/step_walker.py
@@ -1,6 +1,6 @@
 from math import sqrt
 
-from random import random
+from random import random, uniform
 from pokemongo_bot.cell_workers.utils import distance
 from pokemongo_bot.human_behaviour import random_lat_long_delta, sleep
 
@@ -20,6 +20,7 @@ class StepWalker(object):
             dest_lng
         )
 
+        self.alt = uniform(self.bot.config.alt_min, self.bot.config.alt_max)
         self.speed = self.bot.config.walk_max - random() * (self.bot.config.walk_max - self.bot.config.walk_min)
 
         self.destLat = dest_lat
@@ -42,7 +43,7 @@ class StepWalker(object):
 
     def step(self):
         if (self.dLat == 0 and self.dLng == 0) or self.dist < self.speed:
-            self.api.set_position(self.destLat + random_lat_long_delta(), self.destLng + random_lat_long_delta(), 0)
+            self.api.set_position(self.destLat + random_lat_long_delta(), self.destLng + random_lat_long_delta(), self.alt)
             self.bot.event_manager.emit(
                 'position_update',
                 sender=self,
@@ -69,7 +70,7 @@ class StepWalker(object):
         cLat = self.initLat + scaledDLat + random_lat_long_delta()
         cLng = self.initLng + scaledDLng + random_lat_long_delta()
 
-        self.api.set_position(cLat, cLng, 0)
+        self.api.set_position(cLat, cLng, self.alt)
         self.bot.event_manager.emit(
             'position_update',
             sender=self,

--- a/pokemongo_bot/walkers/step_walker.py
+++ b/pokemongo_bot/walkers/step_walker.py
@@ -21,7 +21,7 @@ class StepWalker(object):
         )
 
         self.alt = uniform(self.bot.config.alt_min, self.bot.config.alt_max)
-        self.speed = self.bot.config.walk_max - random() * (self.bot.config.walk_max - self.bot.config.walk_min)
+        self.speed = uniform(self.bot.config.walk_min, self.bot.config.walk_max)
 
         self.destLat = dest_lat
         self.destLng = dest_lng


### PR DESCRIPTION
- Added a min and max altitude range in config
- Added alt variance to calls to set_position in API

I did not change test files, or add a set_position wrapper as I initially intended. This does not also currently look up alt for each long/lat. It is purely random and is a very basic start. At the least, they can't query their data for alt == 0 and ban us all in one quick sweep. 

Big note, I am still not sure what unit altitude needs to be sent as. For the time being, I put a default 0.75 to 2.5.