### PR TITLE
Fix altitude and walker_factory usage

### DIFF
--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -276,6 +276,9 @@ class MoveToMapPokemon(BaseTask):
             else:
                 return self.snipe(pokemon)
 
+        if pokeballs_quantity + superballs_quantity + ultraballs_quantity < self.min_ball:
+            return WorkerResult.SUCCESS
+
         step_walker = self._move_to(pokemon)
         if not step_walker.step():
             return WorkerResult.RUNNING

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -228,7 +228,7 @@ class MoveToMapPokemon(BaseTask):
         api_encounter_response = catch_worker.create_encounter_api_call()
         time.sleep(SNIPE_SLEEP_SEC)
         self._teleport_back(last_position)
-        self.bot.api.set_position(last_position[0], last_position[1], alt)
+        self.bot.api.set_position(last_position[0], last_position[1], self.alt)
         time.sleep(SNIPE_SLEEP_SEC)
         self.bot.heartbeat()
         catch_worker.work(api_encounter_response)
@@ -336,7 +336,7 @@ class MoveToMapPokemon(BaseTask):
             formatted='Teleporting to {poke_name}. ({poke_dist})',
             data=self._pokemon_event_data(pokemon)
         )
-        self.bot.api.set_position(pokemon['latitude'], pokemon['longitude'], alt)
+        self.bot.api.set_position(pokemon['latitude'], pokemon['longitude'], self.alt)
         self._encountered(pokemon)
 
     def _encountered(self, pokemon):

--- a/pokemongo_bot/walkers/polyline_walker.py
+++ b/pokemongo_bot/walkers/polyline_walker.py
@@ -12,10 +12,11 @@ class PolylineWalker(StepWalker):
     Heavy multi-botting can cause issue, since the directions API has limits.
     '''
 
-    def __init__(self, bot, speed, dest_lat, dest_lng, parent):
-        super(PolylineWalker, self).__init__(bot, speed, dest_lat, dest_lng)
+    def __init__(self, bot, dest_lat, dest_lng, parent):
+        super(PolylineWalker, self).__init__(bot, dest_lat, dest_lng)
         self.polyline_walker = PolylineObjectHandler.cached_polyline(bot, (self.api._position_lat, self.api._position_lng),
                                         (self.destLat, self.destLng), self.speed, parent)
+
         self.dist = distance(
             self.bot.position[0],
             self.bot.position[1],

--- a/pokemongo_bot/walkers/walker_factory.py
+++ b/pokemongo_bot/walkers/walker_factory.py
@@ -1,15 +1,15 @@
 from pokemongo_bot.walkers.polyline_walker import PolylineWalker
 from pokemongo_bot.walkers.step_walker import StepWalker
 
-def walker_factory(name, bot, speed, dest_lat, dest_lng, *args, **kwargs):
+def walker_factory(name, bot, dest_lat, dest_lng, *args, **kwargs):
     '''
     Charlie and the Walker Factory
     '''
     if 'StepWalker' == name:
-        ret = StepWalker(bot, speed, dest_lat, dest_lng)
+        ret = StepWalker(bot, dest_lat, dest_lng)
     elif 'PolylineWalker' == name:
         try:
-            ret = PolylineWalker(bot, speed, dest_lat, dest_lng, *args, **kwargs)
+            ret = PolylineWalker(bot, dest_lat, dest_lng, *args, **kwargs)
         except:
-            ret = StepWalker(bot, speed, dest_lat, dest_lng)
+            ret = StepWalker(bot, dest_lat, dest_lng)
     return ret


### PR DESCRIPTION
## Fixes
- `alt` isn't specified in `move_to_map_pokemon`. Using `self.alt` instead. (Introduced in https://github.com/PokemonGoF/PokemonGo-Bot/pull/4250)  
- `walker_factory` receives `speed` but isn't get passed. Remove `speed` in the parameter and let the walkers calculate it using the bot config instead. (Introduced in https://github.com/PokemonGoF/PokemonGo-Bot/pull/3854)
- Make uses of `min_ball` config in `move_to_map_pokemon`. Now only move towards the Pokemon when the total balls >= `min_ball`. Sniping still works regularly.  

Closes #4253
Closes #4260 
---

## Mentions

* Another bug with #4238 is now the `web/` can't fetch the newest Pokemon data realtime. It can only update when the bot is stopped with SIGINT @BriceSD .