### PR TITLE
Hotfix for inventory and pokemon optimizer

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_optimizer.py
+++ b/pokemongo_bot/cell_workers/pokemon_optimizer.py
@@ -290,10 +290,7 @@ class PokemonOptimizer(BaseTask):
         return True
 
     def get_candy_gained_count(self, response_dict):
-        total_candy_gained = 0
-        for candy_gained in response_dict['responses']['CATCH_POKEMON']['capture_award']['candy']:
-            total_candy_gained += candy_gained
-        return total_candy_gained
+        return response_dict['responses']['RELEASE_POKEMON']['candy_awarded']
 
     def use_lucky_egg(self):
         lucky_egg = inventory.items().get(Item.ITEM_LUCKY_EGG.value)  # @UndefinedVariable

--- a/pokemongo_bot/inventory.py
+++ b/pokemongo_bot/inventory.py
@@ -266,7 +266,7 @@ class Pokemons(_BaseInventoryComponent):
         :return: The space used in pokemon inventory.
         :rtype: int
         """
-        return len(_inventory.pokemons.all())
+        return len(_inventory.pokemons.all_with_eggs())
 
     @classmethod
     def get_space_left(cls):
@@ -321,6 +321,10 @@ class Pokemons(_BaseInventoryComponent):
         # by default don't include eggs in all pokemon (usually just
         # makes caller's lives more difficult)
         return [p for p in super(Pokemons, self).all() if not isinstance(p, Egg)]
+
+    def all_with_eggs(self):
+        # count pokemon AND eggs, since eggs are counted as bag space
+        return [p for p in super(Pokemons, self).all()]
 
     def add(self, pokemon):
         if pokemon.unique_id <= 0:

--- a/pokemongo_bot/inventory.py
+++ b/pokemongo_bot/inventory.py
@@ -324,7 +324,7 @@ class Pokemons(_BaseInventoryComponent):
 
     def all_with_eggs(self):
         # count pokemon AND eggs, since eggs are counted as bag space
-        return [p for p in super(Pokemons, self).all()]
+        return super(Pokemons, self).all()
 
     def add(self, pokemon):
         if pokemon.unique_id <= 0:


### PR DESCRIPTION
## Short Description:

- The inventory count didn't take eggs into consideration, causing a bag to be full and the bot not realizing it
- Corrected a wrong key in the pokemon optimizer

## Fixes/Resolves/Closes:
- Bag space is now displayed correctly
- Pokemon Optimizer now transfers again when the bag is nearly full
- Fixes #4252 