### PR TITLE
Evolve / Transfer / Pokestop logs (DB)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -74,3 +74,4 @@
  * umbreon222
  * DeXtroTip
  * rawgni
+ * Breeze Ro

--- a/pokemongo_bot/cell_workers/migrations/evolve_log.py
+++ b/pokemongo_bot/cell_workers/migrations/evolve_log.py
@@ -1,0 +1,5 @@
+from yoyo import step
+
+step(
+    "CREATE TABLE IF NOT EXISTS evolve_log (pokemon text, iv real, cp real, dated datetime DEFAULT CURRENT_TIMESTAMP)"
+)

--- a/pokemongo_bot/cell_workers/migrations/pokestop_log.py
+++ b/pokemongo_bot/cell_workers/migrations/pokestop_log.py
@@ -1,0 +1,5 @@
+from yoyo import step
+
+step(
+    "CREATE TABLE IF NOT EXISTS  pokestop_log (pokestop text, exp real, items text, dated datetime DEFAULT CURRENT_TIMESTAMP)"
+)

--- a/pokemongo_bot/cell_workers/migrations/transfer_log.py
+++ b/pokemongo_bot/cell_workers/migrations/transfer_log.py
@@ -1,0 +1,5 @@
+from yoyo import step
+
+step(
+    "CREATE TABLE IF NOT EXISTS transfer_log (pokemon text, iv real, cp real, dated datetime DEFAULT CURRENT_TIMESTAMP)"
+)

--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -14,6 +14,7 @@ from pokemongo_bot.worker_result import WorkerResult
 from pokemongo_bot.base_task import BaseTask
 from pokemongo_bot.base_dir import _base_dir
 from utils import distance, format_time, fort_details
+from pokemongo_bot.datastore import Datastore
 
 SPIN_REQUEST_RESULT_SUCCESS = 1
 SPIN_REQUEST_RESULT_OUT_OF_RANGE = 2
@@ -21,9 +22,11 @@ SPIN_REQUEST_RESULT_IN_COOLDOWN_PERIOD = 3
 SPIN_REQUEST_RESULT_INVENTORY_FULL = 4
 
 
-class SpinFort(BaseTask):
+class SpinFort(Datastore, BaseTask):
     SUPPORTED_TASK_API_VERSION = 1
 
+    def __init__(self, bot, config):
+        super(SpinFort, self).__init__(bot, config)
     def initialize(self):
         self.ignore_item_count = self.config.get("ignore_item_count", False)
         self.spin_wait_min = self.config.get("spin_wait_min", 2)
@@ -85,6 +88,22 @@ class SpinFort(BaseTask):
                         formatted='Found nothing in pokestop {pokestop}.',
                         data={'pokestop': fort_name}
                     )
+                with self.bot.database as conn:
+                    c = conn.cursor()
+                    c.execute("SELECT COUNT(name) FROM sqlite_master WHERE type='table' AND name='pokestop_log'")
+                result = c.fetchone()        
+                while True:
+                    if result[0] == 1:
+                        conn.execute('''INSERT INTO pokestop_log (pokestop, exp, items) VALUES (?, ?, ?)''', (fort_name, str(experience_awarded), str(items_awarded)))
+                        break
+                    else:
+                        self.emit_event(
+                        'pokestop_log',
+                        sender=self,
+                        level='info',
+                        formatted="pokestop_log table not found, skipping log"
+                        )
+                        break
                 pokestop_cooldown = spin_details.get(
                     'cooldown_complete_timestamp_ms')
                 self.bot.fort_timeouts.update({fort["id"]: pokestop_cooldown})


### PR DESCRIPTION
Addresses issues in reversed pr https://github.com/PokemonGoF/PokemonGo-Bot/pull/4239 

Added checks to ensure tables exist before attempting to insert a record, and checks to ensure a table doesn't already exist before creating it. If the log tables cannot be found in the database, the bot will proceed without logging.

Also addresses issue in pr mentioned above with the number of arguments passed logging pokestops that did not award anything.

![image](https://cloud.githubusercontent.com/assets/2157599/17823787/64680c20-662c-11e6-9734-d909d50fc982.png)

This will be useful in limiting pokestops and effortlessly analyzing data on banned accounts
