### PR TITLE
Revert "Change log color for UpdateLiveStats and UpdateLiveInventory"

### DIFF
--- a/pokemongo_bot/event_handlers/colored_logging_handler.py
+++ b/pokemongo_bot/event_handlers/colored_logging_handler.py
@@ -60,8 +60,6 @@ class ColoredLoggingHandler(EventHandler):
         'unknown_spin_result':               'red',
         'unset_pokemon_nickname':            'red',
         'vip_pokemon':                       'red',
-        'log_stats':                         'magenta',
-        'show_inventory':                    'magenta',
 
         # event names for 'white' still here to remember that these events are already determined its color.
         'arrived_at_cluster':                'white',


### PR DESCRIPTION
Reverts PokemonGoF/PokemonGo-Bot#4230

it was too bright and too spammy in magenta color, perhaps the default live stat update timer should be set higher (like 1 minute), or using a different color