### PR TITLE
Berry usage threshold

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -109,6 +109,8 @@
 	        "catch_visible_pokemon": true,
 	        "catch_lured_pokemon": true,
 	        "min_ultraball_to_keep": 5,
+	        "berry_threshold": 0.35,
+	        "vip_berry_threshold": 0.9,
 	        "catch_throw_parameters": {
 	          "excellent_rate": 0.1,
 	          "great_rate": 0.5,

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -119,6 +119,8 @@
           "catch_visible_pokemon": true,
           "catch_lured_pokemon": true,
           "min_ultraball_to_keep": 5,
+          "berry_threshold": 0.35,
+          "vip_berry_threshold": 0.9,
           "catch_throw_parameters": {
             "excellent_rate": 0.1,
             "great_rate": 0.5,

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -109,6 +109,8 @@
 	        "catch_visible_pokemon": true,
 	        "catch_lured_pokemon": true,
 	        "min_ultraball_to_keep": 5,
+	        "berry_threshold": 0.35,
+	        "vip_berry_threshold": 0.9,
 	        "catch_throw_parameters": {
 	          "excellent_rate": 0.1,
 	          "great_rate": 0.5,

--- a/configs/config.json.optimizer.example
+++ b/configs/config.json.optimizer.example
@@ -167,6 +167,8 @@
             "catch_visible_pokemon": true,
             "catch_lured_pokemon": true,
             "min_ultraball_to_keep": 5,
+            "berry_threshold": 0.35,
+            "vip_berry_threshold": 0.9,
             "catch_throw_parameters": {
               "excellent_rate": 0.1,
               "great_rate": 0.5,

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -109,6 +109,8 @@
           "catch_visible_pokemon": true,
           "catch_lured_pokemon": true,
           "min_ultraball_to_keep": 5,
+          "berry_threshold": 0.35,
+          "vip_berry_threshold": 0.9,
           "catch_throw_parameters": {
             "excellent_rate": 0.1,
             "great_rate": 0.5,

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -109,6 +109,8 @@
 	        "catch_visible_pokemon": true,
 	        "catch_lured_pokemon": true,
 	        "min_ultraball_to_keep": 5,
+	        "berry_threshold": 0.35,
+	        "vip_berry_threshold": 0.9,
 	        "catch_throw_parameters": {
 	          "excellent_rate": 0.1,
 	          "great_rate": 0.5,

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -52,6 +52,8 @@ class PokemonCatchWorker(Datastore, BaseTask):
 
         #Config
         self.min_ultraball_to_keep = self.config.get('min_ultraball_to_keep', 10)
+        self.berry_threshold = self.config.get('berry_threshold', 0.35)
+        self.vip_berry_threshold = self.config.get('vip_berry_threshold', 0.9)
 
         self.catch_throw_parameters = self.config.get('catch_throw_parameters', {})
         self.catch_throw_parameters_spin_success_rate = self.catch_throw_parameters.get('spin_success_rate', 0.6)
@@ -297,7 +299,7 @@ class PokemonCatchWorker(Datastore, BaseTask):
         """
         berry_id = ITEM_RAZZBERRY
         maximum_ball = ITEM_ULTRABALL if is_vip else ITEM_GREATBALL
-        ideal_catch_rate_before_throw = 0.9 if is_vip else 0.35
+        ideal_catch_rate_before_throw = self.vip_berry_threshold if is_vip else self.berry_threshold
 
         berry_count = self.inventory.get(ITEM_RAZZBERRY).count
         ball_count = {}


### PR DESCRIPTION
## Allow users to define berry usage threshold

## Possible scenario
- If user always has excess berries when clearing inventory, adjust the berry threshold higher so that berries are used more often.
- Users who always have very limited berries can tweak the berry threshold lower and save more berries for VIP pokemon.

