### PR TITLE
Add items to inventory on CollectLevelUpReward

### DIFF
--- a/pokemongo_bot/cell_workers/collect_level_up_reward.py
+++ b/pokemongo_bot/cell_workers/collect_level_up_reward.py
@@ -1,4 +1,5 @@
 from pokemongo_bot.base_task import BaseTask
+from pokemongo_bot import inventory
 
 
 class CollectLevelUpReward(BaseTask):
@@ -45,6 +46,7 @@ class CollectLevelUpReward(BaseTask):
                     got_item = self.bot.item_list[str(item['item_id'])]
                     item['name'] = got_item
                     count = 'item_count' in item and item['item_count'] or 0
+                    inventory.items().get(item['item_id']).add(count)
 
             self.emit_event(
                 'level_up_reward',


### PR DESCRIPTION
Found a bug: if after levelup we have more items in inventory than its size, bot doesn't know about it, spins forts but without item reward. Inventory doesn't update and clean.