### PR TITLE
reordered moves alphabetically

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -75,3 +75,4 @@
  * DeXtroTip
  * rawgni
  * Breeze Ro
+ * bruno-kenji

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -1611,8 +1611,7 @@
       "Body Slam",
       "Dazzling Gleam",
       "Disarming Voice",
-      "Play Rough",
-      "Dazzling Gleam"
+      "Play Rough"
     ],
     "BaseAttack": 98,
     "BaseDefense": 54,

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -3154,8 +3154,8 @@
     ],
     "Fast Attack(s)": [
       "Mud Shot",
-      "Rock Throw",
-      "Mud Slap"
+      "Mud Slap",
+      "Rock Throw"
     ],
     "Weight": "300.0 kg",
     "Height": "1.4 m",
@@ -4855,8 +4855,8 @@
     ],
     "Fast Attack(s)": [
       "Quick Attack",
-      "Water Gun",
-      "Tackle"
+      "Tackle",
+      "Water Gun"
     ],
     "Weight": "80.0 kg",
     "Height": "1.1 m",


### PR DESCRIPTION
Reordered moveset alphabetically, as @Anakin5 suggested in #4323

Not closing the issue, since people are apparently having a weird behaviour:
Missing moveset messages for Pokemon that **already has those movesets included** in pokemon.json.