### PR TITLE
[Move_to_map_pokemon] Add an option to move towards near forts before Pokemon

### DIFF
--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -137,8 +137,6 @@
           "spin_wait_min": 2,
           "spin_wait_max": 3
         }
-      },
-      {
         "type": "MoveToMapPokemon",
         "config": {
           "address": "http://localhost:5000",
@@ -152,6 +150,7 @@
           "mode": "priority",
           "map_path": "raw_data",
           "walker": "StepWalker",
+          "max_extra_dist_fort": 10,
           "catch": {
             "==========Legendaries==========": 0,
             "Aerodactyl": 1000,

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -137,6 +137,8 @@
           "spin_wait_min": 2,
           "spin_wait_max": 3
         }
+      },
+      {
         "type": "MoveToMapPokemon",
         "config": {
           "address": "http://localhost:5000",

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -396,6 +396,7 @@ This task will fetch current pokemon spawns from /raw_data of an PokemonGo-Map i
 * `snipe_high_prio_threshold` - The threshold number corresponding with the `catch` dictionary.
 *   - Any pokemon above this threshold value will be caught by teleporting to its location, and getting back to original location if `snipe` is `True`.
 *   - Any pokemon under this threshold value will make the bot walk to the Pokemon target wether `snipe` is `True` or `False`.
+*   `max_extra_dist_fort` : Percentage of extra distance allowed to move to a fort on the way to the targeted Pokemon
 
 #### Example
 ```
@@ -414,6 +415,7 @@ This task will fetch current pokemon spawns from /raw_data of an PokemonGo-Map i
       "snipe_high_prio_threshold": 400,
       "update_map": true,
       "mode": "priority",
+      "max_extra_dist_fort": 10,   
       "catch": {
         "Aerodactyl": 1000,
         "Ditto": 900,

--- a/pokecli.py
+++ b/pokecli.py
@@ -32,6 +32,8 @@ import logging
 import os
 import ssl
 import sys
+reload(sys)
+sys.setdefaultencoding('utf8')
 import time
 import signal
 import string

--- a/pokecli.py
+++ b/pokecli.py
@@ -32,8 +32,6 @@ import logging
 import os
 import ssl
 import sys
-reload(sys)
-sys.setdefaultencoding('utf8')
 import time
 import signal
 import string

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -516,6 +516,10 @@ class PokemonGoBot(Datastore):
             'move_to_map_pokemon_teleport_back',
             parameters=('last_lat', 'last_lon')
         )
+        self.event_manager.register_event(
+            'moving_to_pokemon_throught_fort',
+            parameters=('fort_name', 'distance','poke_name','poke_dist')
+        )
 
         # cached recent_forts
         self.event_manager.register_event('loaded_cached_forts')

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -57,13 +57,13 @@ import requests
 
 from pokemongo_bot import inventory
 from pokemongo_bot.base_dir import _base_dir
-from pokemongo_bot.cell_workers.utils import distance, format_dist, format_time
+from pokemongo_bot.cell_workers.utils import distance, format_dist, format_time, fort_details
 from pokemongo_bot.walkers.walker_factory import walker_factory
 from pokemongo_bot.worker_result import WorkerResult
 from pokemongo_bot.base_task import BaseTask
 from pokemongo_bot.cell_workers.pokemon_catch_worker import PokemonCatchWorker
 from random import uniform
-
+from pokemongo_bot.constants import Constants
 
 # Update the map if more than N meters away from the center. (AND'd with
 # UPDATE_MAP_MIN_TIME_MINUTES)
@@ -279,12 +279,23 @@ class MoveToMapPokemon(BaseTask):
         if pokeballs_quantity + superballs_quantity + ultraballs_quantity < self.min_ball:
             return WorkerResult.SUCCESS
 
-        step_walker = self._move_to(pokemon)
-        if not step_walker.step():
-            return WorkerResult.RUNNING
-        self._encountered(pokemon)
-        self.add_caught(pokemon)
-        return WorkerResult.SUCCESS
+        nearest_fort = self.get_nearest_fort_on_the_way(pokemon)
+        
+        if nearest_fort is None :
+            step_walker = self._move_to(pokemon)
+            if not step_walker.step():
+                
+                if pokemon['dist'] < Constants.MAX_DISTANCE_POKEMON_IS_REACHABLE:
+                    self._encountered(pokemon)
+                    self.add_caught(pokemon)
+                    return WorkerResult.SUCCESS
+                else :
+                    return WorkerResult.RUNNING
+
+        else :
+            step_walker = self._move_to_pokemon_througt_fort(nearest_fort, pokemon)
+            if not step_walker.step():
+                return WorkerResult.RUNNING
 
     def _emit_failure(self, msg):
         """Emits failure to event log.
@@ -384,3 +395,81 @@ class MoveToMapPokemon(BaseTask):
             pokemon['latitude'],
             pokemon['longitude']
         )
+    def _move_to_pokemon_througt_fort(self, fort, pokemon):
+        """Moves trainer towards a fort before a Pokemon.
+
+        Args:
+            fort
+
+        Returns:
+            StepWalker
+        """
+        
+        nearest_fort = fort
+
+        lat = nearest_fort['latitude']
+        lng = nearest_fort['longitude']
+        fortID = nearest_fort['id']
+        details = fort_details(self.bot, fortID, lat, lng)
+        fort_name = details.get('name', 'Unknown')
+
+        unit = self.bot.config.distance_unit  # Unit to use when printing formatted distance
+
+        dist = distance(
+            self.bot.position[0],
+            self.bot.position[1],
+            lat,
+            lng
+        )
+
+        if dist > Constants.MAX_DISTANCE_FORT_IS_REACHABLE:
+            pokemon_throught_fort_event_data = {
+                'fort_name': u"{}".format(fort_name),
+                'distance': format_dist(dist, unit),
+                'poke_name': pokemon['name'],
+                'poke_dist': (format_dist(pokemon['dist'], self.unit))
+            }
+
+
+            self.emit_event(
+                'moving_to_pokemon_throught_fort',
+                formatted="Moving towards {poke_name} - {poke_dist}  through pokestop  {fort_name} - {distance}",
+                data= pokemon_throught_fort_event_data
+            )
+
+            return walker_factory(self.walker,
+                self.bot,
+                lat,
+                lng
+                )
+
+
+        self.emit_event(
+            'arrived_at_fort',
+            formatted='Arrived at fort.'
+        )
+      
+    
+    
+    def get_nearest_fort_on_the_way(self, pokemon):
+        forts = self.bot.get_forts(order_by_distance=True)
+        
+        # Remove stops that are still on timeout
+        forts = filter(lambda x: x["id"] not in self.bot.fort_timeouts, forts)
+        i=0
+        while i < len(forts) :
+            ratio = float(self.config.get('max_extra_dist_fort'))
+            dist_self_to_fort = distance (self.bot.position[0], self.bot.position[1], forts[i]['latitude'], forts [i]['longitude'])
+            dist_fort_to_pokemon = distance (pokemon['latitude'], pokemon['longitude'], forts[i]['latitude'], forts [i]['longitude'])
+            total_dist = dist_self_to_fort + dist_fort_to_pokemon
+            dist_self_to_pokemon = distance (self.bot.position[0], self.bot.position[1], pokemon['latitude'], pokemon['longitude'])
+            if total_dist < (1 + (ratio / 100))* dist_self_to_pokemon:
+                i = i + 1
+            else :
+                del forts[i]
+		#Return nearest fort if there are remaining
+        if len(forts)> 0 :
+            return forts[0]
+        else :
+            return None
+        

--- a/pokemongo_bot/constants.py
+++ b/pokemongo_bot/constants.py
@@ -1,2 +1,3 @@
 class Constants(object):
   MAX_DISTANCE_FORT_IS_REACHABLE = 40 # meters
+  MAX_DISTANCE_POKEMON_IS_REACHABLE = 60


### PR DESCRIPTION
Short Description:

Add some improvements to move_to_map_pokemon mode :

- option to go towards a pokemon through a fort
- the percentage of extra distance is a parameter in the config file
- add a constant to mark a pokemon a "encountered" before reaching the it's exact position

PS : sorry for my english and if the code is not "clean", i'm kind a beginner in program writing