### PR TITLE
Fix for unicode decode error #2673

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -32,6 +32,8 @@ import logging
 import os
 import ssl
 import sys
+reload(sys)
+sys.setdefaultencoding('utf8')
 import time
 import signal
 import string


### PR DESCRIPTION
Short Description:

Solution made by SSGColdSun which is the only one worked in my case (ubuntu 16.04 with python and pip up to date).

Fixes :
-UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1 #2673


