### PR TITLE
Fix: Check inventory for egg incubating

### DIFF
--- a/pokemongo_bot/cell_workers/incubate_eggs.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs.py
@@ -101,7 +101,7 @@ class IncubateEggs(BaseTask):
 
     def _check_inventory(self, lookup_ids=[]):
         inv = {}
-        response_dict = self.bot.get_inventory()
+        response_dict = self.bot.api.get_inventory()
         matched_pokemon = []
         temp_eggs = []
         temp_used_incubators = []


### PR DESCRIPTION
## Fixes

Eggs are now correctly incubated, egg status messages are also shown.  

## Resolves

https://github.com/PokemonGoF/PokemonGo-Bot/issues/4304