### PR TITLE
Display current candy count after evolution and transfer

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -342,7 +342,7 @@ class PokemonGoBot(Datastore):
         )
         self.event_manager.register_event(
             'pokemon_evolved',
-            parameters=('pokemon', 'iv', 'cp', 'ncp', 'dps', 'xp')
+            parameters=('pokemon', 'iv', 'cp', 'xp')
         )
         self.event_manager.register_event('skip_evolve')
         self.event_manager.register_event('threw_berry_failed', parameters=('status_code',))
@@ -435,7 +435,7 @@ class PokemonGoBot(Datastore):
         )
         self.event_manager.register_event(
             'pokemon_release',
-            parameters=('pokemon', 'iv', 'cp', 'ncp', 'dps')
+            parameters=('pokemon', 'iv', 'cp', 'candy')
         )
 
         # polyline walker

--- a/pokemongo_bot/cell_workers/evolve_pokemon.py
+++ b/pokemongo_bot/cell_workers/evolve_pokemon.py
@@ -112,8 +112,6 @@ class EvolvePokemon(Datastore, BaseTask):
                     'pokemon': pokemon.name,
                     'iv': pokemon.iv,
                     'cp': pokemon.cp,
-                    'ncp': '?',
-                    'dps': '?',
                     'xp': '?'
                 }
             )

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -171,13 +171,12 @@ class TransferPokemon(Datastore, BaseTask):
         self.bot.metrics.released_pokemon()
         self.emit_event(
             'pokemon_release',
-            formatted='Exchanged {pokemon} [CP {cp}] [IV {iv}] for candy.',
+            formatted='Exchanged {pokemon} [IV {iv}] [CP {cp}] [{candy} candies]',
             data={
                 'pokemon': pokemon.name,
-                'cp': pokemon.cp,
                 'iv': pokemon.iv,
-                'ncp': pokemon.cp_percent,
-                'dps': pokemon.moveset.dps
+                'cp': pokemon.cp,
+                'candy': candy.quantity
             }
         )
         with self.bot.database as conn:


### PR DESCRIPTION
- Display current candy count after evolution and transfer

Sorry to review my copy about transfer and evolution logging. I think candy count is one of the most relevant thing we can display when performing those actions.