### PR TITLE
Fixes: Evolving Pokemons

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -342,7 +342,7 @@ class PokemonGoBot(Datastore):
         )
         self.event_manager.register_event(
             'pokemon_evolved',
-            parameters=('pokemon', 'iv', 'cp', 'xp')
+            parameters=('pokemon', 'iv', 'cp', 'xp', 'candy')
         )
         self.event_manager.register_event('skip_evolve')
         self.event_manager.register_event('threw_berry_failed', parameters=('status_code',))
@@ -519,7 +519,7 @@ class PokemonGoBot(Datastore):
         self.event_manager.register_event('transfer_log')
         self.event_manager.register_event('pokestop_log')
         self.event_manager.register_event('softban_log')
-        
+
     def tick(self):
         self.health_record.heartbeat()
         self.cell = self.get_meta_cell()
@@ -726,7 +726,7 @@ class PokemonGoBot(Datastore):
             c = conn.cursor()
             c.execute("SELECT COUNT(name) FROM sqlite_master WHERE type='table' AND name='login'")
 
-        result = c.fetchone()        
+        result = c.fetchone()
 
         while True:
             if result[0] == 1:


### PR DESCRIPTION
## Fixes

- Add parameter `candy` to `pokemon_evolved` event.  

- Fix PokemonOptimizer evolve problem with `pokemon_evolved` event.  

- EvolvePokemon now correctly updates inventory even if evolve_log fails.  

- EvolvePokemon now emits evolved event with xp & candy.  