### PR TITLE
Ban Dump (to #banreports slack)

### DIFF
--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -20,6 +20,7 @@
 | `distance_unit`    | km      | Set the unit to display distance in (km for kilometers, mi for miles, ft for feet)                                                                                                          |
 | `evolve_cp_min`           | 300   |                   Min. CP for evolve_all function
 |`daily_catch_llimit`    | 800   |                   Limit the amount of pokemon caught in a 24 hour period.
+|`slackname`    | ""   |                   If set (with slack username), you will receive slack notifcations on bot activity
 
 ## Configuring Tasks
 The behaviors of the bot are configured via the `tasks` key in the `config.json`. This enables you to list what you want the bot to do and change the priority of those tasks by reordering them in the list. This list of tasks is run repeatedly and in order. For more information on why we are moving config to this format, check out the [original proposal](https://github.com/PokemonGoF/PokemonGo-Bot/issues/142).

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ raven==5.23.0
 demjson==2.2.4
 greenlet==0.4.9
 yoyo-migrations==5.0.3
-slackclient=1.0.1
+slackclient==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ raven==5.23.0
 demjson==2.2.4
 greenlet==0.4.9
 yoyo-migrations==5.0.3
+slackclient=1.0.1


### PR DESCRIPTION
Dumps various statics when permanent ban is detected to the #banreports slack channel with @slackname for analytical puproses.

Stats are a bit incomplete, will update here shortly. Should help us track down ban triggers a little bit.

![image](https://cloud.githubusercontent.com/assets/2157599/17833350/c1a4c790-66e8-11e6-8ddd-b4583762f20f.png)
