### PR TITLE
Fix pokemon_evolved event parameters conflict

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_optimizer.py
+++ b/pokemongo_bot/cell_workers/pokemon_optimizer.py
@@ -392,7 +392,6 @@ class PokemonOptimizer(Datastore, BaseTask):
                         data={"pokemon": pokemon.name,
                               "iv": pokemon.iv,
                               "cp": pokemon.cp,
-                              "candy": candy.quantity,
                               "xp": xp})
 
         if self.config_evolve and (not self.bot.config.test):


### PR DESCRIPTION
Hotfix for error:
```
Traceback (most recent call last):
  File "pokecli.py", line 674, in <module>
    main()
  File "pokecli.py", line 118, in main
    bot.tick()
  File "/home/cmezh/pogocmezh/pokemongo_bot/__init__.py", line 541, in tick
    if worker.work() == WorkerResult.RUNNING:
  File "/home/cmezh/pogocmezh/pokemongo_bot/cell_workers/pokemon_optimizer.py", line 78, in work
    self.apply_optimization(transfer_all, evo_all)
  File "/home/cmezh/pogocmezh/pokemongo_bot/cell_workers/pokemon_optimizer.py", line 294, in apply_optimization
    self.evolve_pokemon(pokemon)
  File "/home/cmezh/pogocmezh/pokemongo_bot/cell_workers/pokemon_optimizer.py", line 396, in evolve_pokemon
    "xp": xp})
  File "/home/cmezh/pogocmezh/pokemongo_bot/base_task.py", line 35, in emit_event
    data=data
  File "/home/cmezh/pogocmezh/pokemongo_bot/event_manager.py", line 59, in emit
    raise EventMalformedException("Event %s does not require parameter %s" % (event, k))
pokemongo_bot.event_manager.EventMalformedException: Event pokemon_evolved does not require parameter candy
```