### PR TITLE
Add a table of content to the config file wiki

### DIFF
--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -1,9 +1,65 @@
-## Usage (up-to-date)
-  1. copy `config.json.example` to `config.json`.
-  2. Edit `config.json` and replace `auth_service`, `username`, `password`, `location` and `gmapkey` with your parameters (other keys are optional, check `Advance Configuration` below)
-  3. Simply launch the script with : `./run.sh` or `./pokecli.py` or `python pokecli.py -cf ./configs/config.json` if you want to specify a config file
+<a class="mk-toclify" id="table-of-contents"></a>
 
+# Table of Contents
+- [Usage](#usage)
+- [Advanced Configuration](#advanced-configuration)
+- [Configuring Tasks](#configuring-tasks)
+    - [Task Options:](#task-options)
+    - [Example configuration:](#example-configuration)
+    - [Specifying configuration for tasks](#specifying-configuration-for-tasks)
+    - [An example task configuration if you only wanted to collect items from forts:](#an-example-task-configuration-if-you-only-wanted-to-collect-items-from-forts)
+- [Catch Configuration](#catch-configuration)
+- [Release Configuration](#release-configuration)
+    - [Common configuration](#common-configuration)
+    - [Keep the strongest pokemon configuration (dev branch)](#keep-the-strongest-pokemon-configuration-dev-branch)
+    - [Keep the best custom pokemon configuration (dev branch)](#keep-the-best-custom-pokemon-configuration-dev-branch)
+- [Evolve All Configuration](#evolve-all-configuration)
+- [Path Navigator Configuration](#path-navigator-configuration)
+        - [Number of Laps](#number-of-laps)
+- [Pokemon Nicknaming](#pokemon-nicknaming)
+    - [Config options](#config-options)
+    - [Valid names in templates](#valid-names-in-templates)
+        - [Sample usages](#sample-usages)
+    - [Sample configuration](#sample-configuration)
+- [CatchPokemon `catch_simulation` Settings](#catchpokemon-catch_simulation-settings)
+    - [Default Settings](#default-settings)
+    - [Settings Description](#settings-description)
+    - [`flee_count` and `flee_duration`](#flee_count-and-flee_duration)
+    - [Previous Behaviour](#previous-behaviour)
+- [Sniping _(MoveToLocation)_](#sniping-_-movetolocation-_)
+    - [Description](#description)
+    - [Options](#options)
+        - [Example](#example)
+- [FollowPath Settings](#followpath-settings)
+    - [Description](#description)
+    - [Options](#options)
+    - [Sample Configuration](#sample-configuration)
+- [UpdateLiveStats Settings](#updatelivestats-settings)
+    - [Options](#options)
+    - [Sample Configuration](#sample-configuration)
+- [UpdateLiveInventory Settings](#updateliveinventory-settings)
+    - [Description](#description)
+    - [Options](#options)
+    - [Sample configuration](#sample-configuration)
+    - [Example console output](#example-console-output)
+- [Sleep Schedule Task](#sleep-schedule-task)
+- [Random Pause](#random-pause)
+
+#Configuration files
+
+Document the configuration options of PokemonGo-Bot.
+
+<a class="mk-toclify" id="usage"></a>
+## Usage 
+[[back to top](#table-of-contents)]
+
+1. copy `config.json.example` to `config.json`.
+2. Edit `config.json` and replace `auth_service`, `username`, `password`, `location` and `gmapkey` with your parameters (other keys are optional, check `Advance Configuration` below)
+3. Simply launch the script with : `./run.sh` or `./pokecli.py` or `python pokecli.py -cf ./configs/config.json` if you want to specify a config file
+
+<a class="mk-toclify" id="advanced-configuration"></a>
 ## Advanced Configuration
+[[back to top](#table-of-contents)]
 |      Parameter     | Default |                                                                                         Description                                                                                         |
 |------------------|-------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `tasks`            | []     | The behaviors you want the bot to do. Read [how to configure tasks](#configuring-tasks).
@@ -24,111 +80,123 @@
 |`pokemon_bag.show_count`    | false   |                   Show amount of each pokemon.
 |`pokemon_bag.pokemon_info`    | []   |                   Check any config example file to see available settings.
 
+<a class="mk-toclify" id="configuring-tasks"></a>
 ## Configuring Tasks
+[[back to top](#table-of-contents)]
 The behaviors of the bot are configured via the `tasks` key in the `config.json`. This enables you to list what you want the bot to do and change the priority of those tasks by reordering them in the list. This list of tasks is run repeatedly and in order. For more information on why we are moving config to this format, check out the [original proposal](https://github.com/PokemonGoF/PokemonGo-Bot/issues/142).
 
+<a class="mk-toclify" id="task-options"></a>
 ### Task Options:
+[[back to top](#table-of-contents)]
 * CatchPokemon
 * EvolvePokemon
-  * `evolve_all`: Default `NONE` | Set to `"all"` to evolve Pokémon if possible when the bot starts. Can also be set to individual Pokémon as well as multiple separated by a comma. e.g "Pidgey,Rattata,Weedle,Zubat"
-  * `evolve_speed`: Default `20`
-  * `use_lucky_egg`: Default: `False`
+* `evolve_all`: Default `NONE` | Set to `"all"` to evolve Pokémon if possible when the bot starts. Can also be set to individual Pokémon as well as multiple separated by a comma. e.g "Pidgey,Rattata,Weedle,Zubat"
+* `evolve_speed`: Default `20`
+* `use_lucky_egg`: Default: `False`
 * FollowPath
-  * `path_mode`: Default `loop` | Set the mode for the path navigator (loop or linear).
-  * `path_file`: Default `NONE` | Set the file containing the waypoints for the path navigator.
+* `path_mode`: Default `loop` | Set the mode for the path navigator (loop or linear).
+* `path_file`: Default `NONE` | Set the file containing the waypoints for the path navigator.
 * FollowSpiral
 * HandleSoftBan
 * IncubateEggs
-  * `longer_eggs_first`: Default `True`
+* `longer_eggs_first`: Default `True`
 * MoveToFort
 * [MoveToMapPokemon](#sniping-movetolocation)
 * NicknamePokemon
-  * `nickname_template`: Default `""` | See the [Pokemon Nicknaming](#pokemon-nicknaming) section for more details
-  * `dont_nickname_favorite`: Default `false` | Prevents renaming of favorited pokemons
-  * `good_attack_threshold`: Default `0.7` | Threshold for perfection of the attack in it's type *(0.0-1.0)* after which attack will be treated as good.<br>Used for `{fast_attack_char}`, `{charged_attack_char}`, `{attack_code}`  templates
+* `nickname_template`: Default `""` | See the [Pokemon Nicknaming](#pokemon-nicknaming) section for more details
+* `dont_nickname_favorite`: Default `false` | Prevents renaming of favorited pokemons
+* `good_attack_threshold`: Default `0.7` | Threshold for perfection of the attack in it's type *(0.0-1.0)* after which attack will be treated as good.<br>Used for `{fast_attack_char}`, `{charged_attack_char}`, `{attack_code}`  templates
 * RecycleItems
 
-  > **NOTE:** It's highly recommended to put this task before MoveToFort and SpinFort tasks. This way you'll most likely be able to loot.
-  * `min_empty_space`: Default `6` | Minimum empty space to keep in inventory. Once the inventory has less empty space than that amount, the recycling process is triggered. Set it to the inventory size to trigger it at every tick.
-  * `item_filter`: Pass a list of unwanted [items (using their JSON codes or names)](https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Item-ID's) to recycle.
-  * `max_balls_keep`: Default `None` | Maximum amount of balls to keep in inventory
-  * `max_potions_keep`: Default `None` | Maximum amount of potions to keep in inventory
-  * `max_berries_keep`: Default `None` | Maximum amount of berries to keep in inventory
-  * `max_revives_keep`: Default `None` | Maximum amount of revives to keep in inventory
+> **NOTE:** It's highly recommended to put this task before MoveToFort and SpinFort tasks. This way you'll most likely be able to loot.
+* `min_empty_space`: Default `6` | Minimum empty space to keep in inventory. Once the inventory has less empty space than that amount, the recycling process is triggered. Set it to the inventory size to trigger it at every tick.
+* `item_filter`: Pass a list of unwanted [items (using their JSON codes or names)](https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Item-ID's) to recycle.
+* `max_balls_keep`: Default `None` | Maximum amount of balls to keep in inventory
+* `max_potions_keep`: Default `None` | Maximum amount of potions to keep in inventory
+* `max_berries_keep`: Default `None` | Maximum amount of berries to keep in inventory
+* `max_revives_keep`: Default `None` | Maximum amount of revives to keep in inventory
 * SpinFort
 * TransferPokemon
-  * `min_free_slot`: Default `5` | Once the pokebag has less empty slots than this amount, the transfer process is triggered. | Big values (i.e 9999) will trigger the transfer process after each catch.
+* `min_free_slot`: Default `5` | Once the pokebag has less empty slots than this amount, the transfer process is triggered. | Big values (i.e 9999) will trigger the transfer process after each catch.
 * UpdateLiveStats
 * [UpdateLiveInventory](#updateliveinventory-settings)
 
+<a class="mk-toclify" id="example-configuration"></a>
 ### Example configuration:
+[[back to top](#table-of-contents)]
 The following configuration tells the bot to transfer all the Pokemon that match the transfer configuration rules, then recycle the items that match its configuration, then catch the pokemon that it can, so on, so forth. Note the last two tasks, MoveToFort and FollowSpiral. When a task is still in progress, it won't run the next things in the list. So it will move towards the fort, on each step running through the list of tasks again. Only when it arrives at the fort and there are no other stops available for it to move towards will it continue to the next step and follow the spiral.
 
 ```
 {
-  // ...
-  "tasks": [
-    {
-      "type": "TransferPokemon"
-    },
-    {
-      "type": "RecycleItems"
-    },
-    {
-      "type": "CatchPokemon"
-    },
-    {
-      "type": "SpinFort"
-    },
-    {
-      "type": "MoveToFort"
-    },
-    {
-      "type": "FollowSpiral"
-    }
-  ]
-  // ...
+// ...
+"tasks": [
+{
+"type": "TransferPokemon"
+},
+{
+"type": "RecycleItems"
+},
+{
+"type": "CatchPokemon"
+},
+{
+"type": "SpinFort"
+},
+{
+"type": "MoveToFort"
+},
+{
+"type": "FollowSpiral"
+}
+]
+// ...
 }
 ```
 
+<a class="mk-toclify" id="specifying-configuration-for-tasks"></a>
 ### Specifying configuration for tasks
+[[back to top](#table-of-contents)]
 If you want to configure a given task, you can pass values like this:
 
 ```
 {
-  // ...
-  "tasks": [
-    {
-      "type": "IncubateEggs",
-      "config": {
-        "longer_eggs_first": true
-      }
-    }
-  ]
-  // ...
+// ...
+"tasks": [
+{
+"type": "IncubateEggs",
+"config": {
+"longer_eggs_first": true
+}
+}
+]
+// ...
 }
 ```
 
+<a class="mk-toclify" id="an-example-task-configuration-if-you-only-wanted-to-collect-items-from-forts"></a>
 ### An example task configuration if you only wanted to collect items from forts:
+[[back to top](#table-of-contents)]
 ```
 {
-  // ...
-  "tasks": [
-    {
-      "type": "RecycleItems"
-    },
-    {
-      "type": "SpinFortWorker"
-    },
-    {
-      "type": "MoveToFortWorker"
-    }
-  ],
-  // ...
+// ...
+"tasks": [
+{
+"type": "RecycleItems"
+},
+{
+"type": "SpinFortWorker"
+},
+{
+"type": "MoveToFortWorker"
+}
+],
+// ...
 }
 ```
 
+<a class="mk-toclify" id="catch-configuration"></a>
 ## Catch Configuration
+[[back to top](#table-of-contents)]
 Default configuration will capture all Pokémon.
 
 ```"any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"}```
@@ -141,9 +209,13 @@ Additionally, you can specify always_capture and never_capture flags.
 
 For example: ```"Pidgey": {"never_capture": true}``` will stop catching Pidgey entirely.
 
+<a class="mk-toclify" id="release-configuration"></a>
 ## Release Configuration
+[[back to top](#table-of-contents)]
 
+<a class="mk-toclify" id="common-configuration"></a>
 ### Common configuration
+[[back to top](#table-of-contents)]
 
 Default configuration will not release any Pokémon.
 
@@ -157,7 +229,9 @@ Additionally, you can specify always_release and never_release flags. For exampl
 
 ```"release": {"Pidgey": {"always_release": true}}``` will release all Pidgey caught.
 
+<a class="mk-toclify" id="keep-the-strongest-pokemon-configuration-dev-branch"></a>
 ### Keep the strongest pokemon configuration (dev branch)
+[[back to top](#table-of-contents)]
 
 You can set ```"release": {"Pidgey": {"keep_best_cp": 1}}``` or ```"release": {"any": {"keep_best_iv": 1}}```.
 
@@ -169,7 +243,9 @@ If you already have it, it will keep a stronger version and will transfer the a 
 
 ```"release": {"any": {"keep_best_cp": 2}}```, ```"release": {"any": {"keep_best_cp": 10}}``` - can be any number.
 
+<a class="mk-toclify" id="keep-the-best-custom-pokemon-configuration-dev-branch"></a>
 ### Keep the best custom pokemon configuration (dev branch)
+[[back to top](#table-of-contents)]
 
 Define a list of criteria to keep the best Pokemons according to those criteria.
 
@@ -184,7 +260,9 @@ The list of criteria is the following:```'cp','iv', 'iv_attack', 'iv_defense', '
 
 ```"release": {"Zubat": {"keep_best_custom": "hp_max,hp", "amount":10}}````
 
+<a class="mk-toclify" id="evolve-all-configuration"></a>
 ## Evolve All Configuration
+[[back to top](#table-of-contents)]
 
 By setting the `evolve_all` attribute in config.json, you can instruct the bot to automatically
 evolve specified Pokémon on startup. This is especially useful for batch-evolving after popping up
@@ -198,10 +276,10 @@ It will also automatically transfer the evolved Pokémon based on the release co
 Examples on how to use (set in config.json):
 
 1. "evolve_all": "all"
-  Will evolve ALL Pokémon.
+Will evolve ALL Pokémon.
 
 2. "evolve_all": "Pidgey,Weedle"
-  Will only evolve Pidgey and Weedle.
+Will only evolve Pidgey and Weedle.
 
 3. Not setting evolve_all or having any other string would not evolve any Pokémon on startup.
 
@@ -211,13 +289,17 @@ If you wish to change the default threshold of 300 CP, simply add the following 
 "evolve_cp_min":  <number>
 ```
 
+<a class="mk-toclify" id="path-navigator-configuration"></a>
 ## Path Navigator Configuration
+[[back to top](#table-of-contents)]
 
 Setting the `navigator.type` setting to `path` allows you to specify waypoints which the bot will follow. The waypoints can be loaded from a GPX or JSON file. By default the bot will walk along all specified waypoints and then move directly to the first waypoint again. When setting `navigator.path_mode` to `linear`, the bot will turn around at the last waypoint and along the given waypoints in reverse order.
 
 An example for a JSON file can be found in `configs/path.example.json`. GPX files can be exported from many online tools, such as gpsies.com.The bot loads the first segment of the first track.
 
+<a class="mk-toclify" id="number-of-laps"></a>
 #### Number of Laps
+[[back to top](#table-of-contents)]
 
 In the path navigator configuration task, add a maximum of passage above which the bot stop for a time before starting again. *Note that others tasks (such as SleepSchedule or RandomPause) can stop the bot before.*
 
@@ -231,7 +313,10 @@ In the path navigator configuration task, add a maximum of passage above which t
 
 `"timer_restart_max": "00:20:00"` (will stop for a maximum of 10 minutes)
 
+
+<a class="mk-toclify" id="pokemon-nicknaming"></a>
 ## Pokemon Nicknaming
+[[back to top](#table-of-contents)]
 
 A `nickname_template` can be specified for the `NicknamePokemon` task to allow a nickname template to be applied to all pokemon in the user's inventory. For example, a user wanting all their pokemon to have their IV values as their nickname could use a template `{iv_ads}`, which will cause their pokemon to be named something like `13/7/12` (depending on the pokemon's actual IVs).
 
@@ -243,7 +328,9 @@ Niantic imposes a 12-character limit on all pokemon nicknames, so any new nickna
 
 Because some pokemon have very long names, you can use the [Format String syntax](https://docs.python.org/2.7/library/string.html#formatstrings) to ensure that your names do not cause your templates to truncate. For example, using `{name:.8s}` causes the Pokemon name to never take up more than 8 characters in the nickname. This would help guarantee that a template like `{name:.8s}_{iv_pct}` never goes over the 12-character limit.
 
+<a class="mk-toclify" id="config-options"></a>
 ### Config options
+[[back to top](#table-of-contents)]
 
 * `enable` (default: `true`): To enable or disable this task.
 * `nickname_template` (default: `{name}`): The template to rename the pokemon.
@@ -251,55 +338,59 @@ Because some pokemon have very long names, you can use the [Format String syntax
 * `good_attack_threshold` (default: `0.7`): Threshold for perfection of the attack in it's type (0.0-1.0) after which attack will be treated as good. Used for {fast_attack_char}, {charged_attack_char}, {attack_code} templates.
 * `locale` (default: `en`): The locale to use for the pokemon name.
 
+<a class="mk-toclify" id="valid-names-in-templates"></a>
 ### Valid names in templates
+[[back to top](#table-of-contents)]
 
 Key | Info
 ---- | ----
 **{name}** |  Pokemon name     *(e.g. Articuno)*
 **{id}**  |  Pokemon ID/Number *(1-151, e.g. 1 for Bulbasaurs)*
 **{cp}**  |  Pokemon's Combat Points (CP)    *(10-4145)*
- | **Individial Values (IV)**
+| **Individial Values (IV)**
 **{iv_attack}**  |  Individial Attack *(0-15)* of the current specific pokemon
 **{iv_defense}** |  Individial Defense *(0-15)* of the current specific pokemon
 **{iv_stamina}** |  Individial Stamina *(0-15)* of the current specific pokemon
 **{iv_ads}**     |  Joined IV values in `(attack)/(defense)/(stamina)` format (*e.g. 4/12/9*, matches web UI format -- A/D/S)
 **{iv_ads_hex}** |  Joined IV values of `(attack)(defense)(stamina)` in HEX (*e.g. 4C9* for A/D/S = 4/12/9)
 **{iv_sum}**     |  Sum of the Individial Values *(0-45, e.g. 45 when 3 perfect 15 IVs)*
- |  **Basic Values of the pokemon (identical for all of one kind)**
+|  **Basic Values of the pokemon (identical for all of one kind)**
 **{base_attack}**   |  Basic Attack *(40-284)* of the current pokemon kind
 **{base_defense}**  |  Basic Defense *(54-242)* of the current pokemon kind
 **{base_stamina}**  |  Basic Stamina *(20-500)* of the current pokemon kind
 **{base_ads}**      |  Joined Basic Values *(e.g. 125/93/314)*
- |  **Final Values of the pokemon (Base Values + Individial Values)**
+|  **Final Values of the pokemon (Base Values + Individial Values)**
 **{attack}**        |  Basic Attack + Individial Attack
 **{defense}**       |  Basic Defense + Individial Defense
 **{stamina}**       |  Basic Stamina + Individial Stamina
 **{sum_ads}**       |  Joined Final Values *(e.g. 129/97/321)*
- |  **Individial Values perfection percent**
+|  **Individial Values perfection percent**
 **{iv_pct}**     |  IV perfection *(in 000-100 format - 3 chars)*
 **{iv_pct2}**    |  IV perfection *(in 00-99 format - 2 chars).* So 99 is best (it's a 100% perfection)
 **{iv_pct1}**    |  IV perfection *(in 0-9 format - 1 char)*
- |  **IV CP perfection - kind of IV perfection percent but calculated using weight of each IV in its contribution to CP of the best evolution of current pokemon.**<br> It tends to be more accurate than simple IV perfection.
+|  **IV CP perfection - kind of IV perfection percent but calculated using weight of each IV in its contribution to CP of the best evolution of current pokemon.**<br> It tends to be more accurate than simple IV perfection.
 **{ivcp_pct}**      |  IV CP perfection *(in 000-100 format - 3 chars)*
 **{ivcp_pct2}**     |  IV CP perfection *(in 00-99 format - 2 chars).* So 99 is best (it's a 100% perfection)
 **{ivcp_pct1}**     |  IV CP perfection *(in 0-9 format - 1 char)*
- |  **Moveset perfection percents for attack and for defense.**<br> Calculated for current pokemon only, not between all pokemons. So perfect moveset can be weak if pokemon is weak (e.g. Caterpie)
+|  **Moveset perfection percents for attack and for defense.**<br> Calculated for current pokemon only, not between all pokemons. So perfect moveset can be weak if pokemon is weak (e.g. Caterpie)
 **{attack_pct}**   |  Moveset perfection for attack *(in 000-100 format - 3 chars)*
 **{attack_pct2}**  |  Moveset perfection for attack *(in 00-99 format - 2 chars)*
 **{attack_pct1}**  |  Moveset perfection for attack *(in 0-9 format - 1 char)*
 **{defense_pct}**  |  Moveset perfection for defense *(in 000-100 format - 3 chars)*
 **{defense_pct2}** |  Moveset perfection for defense *(in 00-99 format - 2 chars)*
 **{defense_pct1}** |  Moveset perfection for defense *(in 0-9 format - 1 char)*
- |  **Character codes for fast/charged attack types.**<br> If attack is good character is uppecased, otherwise lowercased.<br>Use `'good_attack_threshold'` option for customization.<br><br> It's an effective way to represent type with one character.<br> If first char of the type name is unique - it's used, in other case suitable substitute used.<br><br> Type codes:<br> &nbsp;&nbsp;`Bug: 'B'`<br> &nbsp;&nbsp;`Dark: 'K'`<br> &nbsp;&nbsp;`Dragon: 'D'`<br> &nbsp;&nbsp;`Electric: 'E'`<br> &nbsp;&nbsp;`Fairy: 'Y'`<br> &nbsp;&nbsp;`Fighting: 'T'`<br> &nbsp;&nbsp;`Fire: 'F'`<br> &nbsp;&nbsp;`Flying: 'L'`<br> &nbsp;&nbsp;`Ghost: 'H'`<br> &nbsp;&nbsp;`Grass: 'A'`<br> &nbsp;&nbsp;`Ground: 'G'`<br> &nbsp;&nbsp;`Ice: 'I'`<br> &nbsp;&nbsp;`Normal: 'N'`<br> &nbsp;&nbsp;`Poison: 'P'`<br> &nbsp;&nbsp;`Psychic: 'C'`<br> &nbsp;&nbsp;`Rock: 'R'`<br> &nbsp;&nbsp;`Steel: 'S'`<br> &nbsp;&nbsp;`Water: 'W'`
+|  **Character codes for fast/charged attack types.**<br> If attack is good character is uppecased, otherwise lowercased.<br>Use `'good_attack_threshold'` option for customization.<br><br> It's an effective way to represent type with one character.<br> If first char of the type name is unique - it's used, in other case suitable substitute used.<br><br> Type codes:<br> &nbsp;&nbsp;`Bug: 'B'`<br> &nbsp;&nbsp;`Dark: 'K'`<br> &nbsp;&nbsp;`Dragon: 'D'`<br> &nbsp;&nbsp;`Electric: 'E'`<br> &nbsp;&nbsp;`Fairy: 'Y'`<br> &nbsp;&nbsp;`Fighting: 'T'`<br> &nbsp;&nbsp;`Fire: 'F'`<br> &nbsp;&nbsp;`Flying: 'L'`<br> &nbsp;&nbsp;`Ghost: 'H'`<br> &nbsp;&nbsp;`Grass: 'A'`<br> &nbsp;&nbsp;`Ground: 'G'`<br> &nbsp;&nbsp;`Ice: 'I'`<br> &nbsp;&nbsp;`Normal: 'N'`<br> &nbsp;&nbsp;`Poison: 'P'`<br> &nbsp;&nbsp;`Psychic: 'C'`<br> &nbsp;&nbsp;`Rock: 'R'`<br> &nbsp;&nbsp;`Steel: 'S'`<br> &nbsp;&nbsp;`Water: 'W'`
 **{fast_attack_char}**   |  One character code for fast attack type (e.g. 'F' for good Fire or 's' for bad Steel attack)
 **{charged_attack_char}**   |  One character code for charged attack type (e.g. 'n' for bad Normal or 'I' for good Ice attack)
 **{attack_code}**           |  Joined 2 character code for both attacks (e.g. 'Lh' for pokemon with strong Flying and weak Ghost attacks)
- |  **Special case: pokemon object**<br> You can access any available pokemon info via it.<br>Examples:<br> &nbsp;&nbsp;`'{pokemon.ivcp:.2%}'             ->  '47.00%'`<br> &nbsp;&nbsp;`'{pokemon.fast_attack}'          ->  'Wing Attack'`<br> &nbsp;&nbsp;`'{pokemon.fast_attack.type}'     ->  'Flying'`<br> &nbsp;&nbsp;`'{pokemon.fast_attack.dps:.2f}'  ->  '10.91'`<br> &nbsp;&nbsp;`'{pokemon.fast_attack.dps:.0f}'  ->  '11'`<br> &nbsp;&nbsp;`'{pokemon.charged_attack}'       ->  'Ominous Wind'`
+|  **Special case: pokemon object**<br> You can access any available pokemon info via it.<br>Examples:<br> &nbsp;&nbsp;`'{pokemon.ivcp:.2%}'             ->  '47.00%'`<br> &nbsp;&nbsp;`'{pokemon.fast_attack}'          ->  'Wing Attack'`<br> &nbsp;&nbsp;`'{pokemon.fast_attack.type}'     ->  'Flying'`<br> &nbsp;&nbsp;`'{pokemon.fast_attack.dps:.2f}'  ->  '10.91'`<br> &nbsp;&nbsp;`'{pokemon.fast_attack.dps:.0f}'  ->  '11'`<br> &nbsp;&nbsp;`'{pokemon.charged_attack}'       ->  'Ominous Wind'`
 **{pokemon}**   |  Pokemon instance (see inventory.py for class sources)
 
 > **NOTE:** Use a blank template (`""`) to revert all pokemon to their original names (as if they had no nickname).
 
+<a class="mk-toclify" id="sample-usages"></a>
 #### Sample usages
+[[back to top](#table-of-contents)]
 
 - `"{name}_{iv_pct}"` => `Mankey_069`
 - `"{iv_pct}_{iv_ads}"` => `091_15/11/15`
@@ -307,42 +398,50 @@ Key | Info
 - `"{attack_code}{attack_pct1}{defense_pct1}{ivcp_pct1}{name}"` => `Lh474Golbat`
 ![sample](https://cloud.githubusercontent.com/assets/8896778/17285954/0fa44a88-577b-11e6-8204-b1302f4294bd.png)
 
+<a class="mk-toclify" id="sample-configuration"></a>
 ### Sample configuration
+[[back to top](#table-of-contents)]
 
 ```json
 {
-  "type": "NicknamePokemon",
-  "config": {
-    "enabled": true,
-    "dont_nickname_favorite": false,
-    "good_attack_threshold": 0.7,
-    "nickname_template": "{iv_pct}_{iv_ads}"
-    "locale": "en"
-  }
+"type": "NicknamePokemon",
+"config": {
+"enabled": true,
+"dont_nickname_favorite": false,
+"good_attack_threshold": 0.7,
+"nickname_template": "{iv_pct}_{iv_ads}"
+"locale": "en"
+}
 }
 ```
 
+<a class="mk-toclify" id="catchpokemon-catch_simulation-settings"></a>
 ## CatchPokemon `catch_simulation` Settings
+[[back to top](#table-of-contents)]
 
 These settings determine how the bot will simulate the app by adding pauses to throw the ball and navigate menus.  All times are in seconds.  To configure these settings add them to the config in the CatchPokemon task.
 
+<a class="mk-toclify" id="default-settings"></a>
 ### Default Settings
+[[back to top](#table-of-contents)]
 The default settings are 'safe' settings intended to simulate human and app behaviour.
 
 ```
 "catch_simulation": {
-    "flee_count": 3,
-    "flee_duration": 2,
-    "catch_wait_min": 2,
-    "catch_wait_max": 6,
-    "berry_wait_min": 2,
-    "berry_wait_max": 3,
-    "changeball_wait_min": 2,
-    "changeball_wait_max": 3
+"flee_count": 3,
+"flee_duration": 2,
+"catch_wait_min": 2,
+"catch_wait_max": 6,
+"berry_wait_min": 2,
+"berry_wait_max": 3,
+"changeball_wait_min": 2,
+"changeball_wait_max": 3
 }
 ```
 
+<a class="mk-toclify" id="settings-description"></a>
 ### Settings Description
+[[back to top](#table-of-contents)]
 
 Setting | Description
 ---- | ----
@@ -355,41 +454,51 @@ Setting | Description
 `changeball_wait_min`| The minimum amount of time to change ball
 `changeball_wait_max`| The maximum amount of time to change ball
 
+<a class="mk-toclify" id="flee_count-and-flee_duration"></a>
 ### `flee_count` and `flee_duration`
+[[back to top](#table-of-contents)]
 This part is app simulation and the default settings are advised.  When we hit a pokemon in the app the animation will play randomly 1, 2 or 3 times for roughly 2 seconds each time.  So we pause for a random number of animations up to `flee_count` of duration `flee_duration`
 
+<a class="mk-toclify" id="previous-behaviour"></a>
 ### Previous Behaviour
+[[back to top](#table-of-contents)]
 If you want to make your bot behave as it did prior to this update please use the following settings.
 
 ```
 "catch_simulation": {
-    "flee_count": 1,
-    "flee_duration": 2,
-    "catch_wait_min": 0,
-    "catch_wait_max": 0,
-    "berry_wait_min": 0,
-    "berry_wait_max": 0,
-    "changeball_wait_min": 0,
-    "changeball_wait_max": 0
+"flee_count": 1,
+"flee_duration": 2,
+"catch_wait_min": 0,
+"catch_wait_max": 0,
+"berry_wait_min": 0,
+"berry_wait_max": 0,
+"changeball_wait_min": 0,
+"changeball_wait_max": 0
 }
 ```
 
+<a class="mk-toclify" id="sniping-_-movetolocation-_"></a>
 ## Sniping _(MoveToLocation)_
+[[back to top](#table-of-contents)]
 
+<a class="mk-toclify" id="description"></a>
 ### Description
+[[back to top](#table-of-contents)]
 This task will fetch current pokemon spawns from /raw_data of an PokemonGo-Map instance. For information on how to properly setup PokemonGo-Map have a look at the Github page of the project [here](https://github.com/AHAAAAAAA/PokemonGo-Map/). There is an example config in `config/config.json.map.example`
 
+<a class="mk-toclify" id="options"></a>
 ### Options
+[[back to top](#table-of-contents)]
 * `Address` - Address of the webserver of PokemonGo-Map. ex: `http://localhost:5000`
 * `Mode` - Which mode to run snipin on
-    - `distance` - Will move to the nearest pokemon
-    - `priority` - Will move to the pokemon with the highest priority assigned (tie breaking by distance)
+- `distance` - Will move to the nearest pokemon
+- `priority` - Will move to the pokemon with the highest priority assigned (tie breaking by distance)
 * `prioritize_vips` - Will prioritize vips in distance and priority mode above all normal pokemon if set to true
 * `min_time` - Minimum time the pokemon has to be available before despawn
 * `max_distance` - Maximum distance the pokemon is allowed to be when walking, ignored when sniping
 * `snipe`:
-    - `True` - Will teleport to target pokemon, encounter it, teleport back then catch it
-    - `False` - Will walk normally to the pokemon
+- `True` - Will teleport to target pokemon, encounter it, teleport back then catch it
+- `False` - Will walk normally to the pokemon
 * `update_map` - disable/enable if the map location should be automatically updated to the bots current location
 * `catch` - A dictionary of pokemon to catch with an assigned priority (higher => better)
 * `snipe_high_prio_only` - Whether to snipe pokemon above a certain threshold.
@@ -397,57 +506,67 @@ This task will fetch current pokemon spawns from /raw_data of an PokemonGo-Map i
 *   - Any pokemon above this threshold value will be caught by teleporting to its location, and getting back to original location if `snipe` is `True`.
 *   - Any pokemon under this threshold value will make the bot walk to the Pokemon target wether `snipe` is `True` or `False`.
 
+<a class="mk-toclify" id="example"></a>
 #### Example
+[[back to top](#table-of-contents)]
 ```
 {
-  \\ ...
-  {
-    "type": "MoveToMapPokemon",
-    "config": {
-      "address": "http://localhost:5000",
-      "max_distance": 500,
-      "min_time": 60,
-      "min_ball": 50,
-      "prioritize_vips": true,
-      "snipe": true,
-      "snipe_high_prio_only": true,
-      "snipe_high_prio_threshold": 400,
-      "update_map": true,
-      "mode": "priority",
-      "catch": {
-        "Aerodactyl": 1000,
-        "Ditto": 900,
-        "Omastar": 500,
-        "Omanyte": 150,
-        "Caterpie": 10,
-      }
-    }
-  }
-  \\ ...
+\\ ...
+{
+"type": "MoveToMapPokemon",
+"config": {
+"address": "http://localhost:5000",
+"max_distance": 500,
+"min_time": 60,
+"min_ball": 50,
+"prioritize_vips": true,
+"snipe": true,
+"snipe_high_prio_only": true,
+"snipe_high_prio_threshold": 400,
+"update_map": true,
+"mode": "priority",
+"catch": {
+"Aerodactyl": 1000,
+"Ditto": 900,
+"Omastar": 500,
+"Omanyte": 150,
+"Caterpie": 10,
+}
+}
+}
+\\ ...
 }
 ```
 
+<a class="mk-toclify" id="followpath-settings"></a>
 ## FollowPath Settings
+[[back to top](#table-of-contents)]
+<a class="mk-toclify" id="description"></a>
 ### Description
+[[back to top](#table-of-contents)]
 Walk to the specified locations loaded from .gpx or .json file. It is highly recommended to use website such as [GPSies](http://www.gpsies.com) which allow you to export your created track in JSON file. Note that you'll have to first convert its JSON file into the format that the bot can understand. See [Example of pier39.json] below for the content. I had created a simple python script to do the conversion. 
 
+<a class="mk-toclify" id="options"></a>
 ### Options
+[[back to top](#table-of-contents)]
 * `path_mode` - linear, loop
-  - `loop` - The bot will walk along all specified waypoints and then move directly to the first waypoint again. 
-  - `linear` - The bot will turn around at the last waypoint and along the given waypoints in reverse order.
+- `loop` - The bot will walk along all specified waypoints and then move directly to the first waypoint again. 
+- `linear` - The bot will turn around at the last waypoint and along the given waypoints in reverse order.
 * `path_start_mode` - first
 * `path_file` - "/path/to/your/path.json"
 
 
+<a class="mk-toclify" id="sample-configuration"></a>
 ### Sample Configuration
+[[back to top](#table-of-contents)]
 ```
 {
-	"type": "FollowPath",
-    "config": {
-    	"path_mode": "linear",
-	  	"path_start_mode": "first",
-      "path_file": "/home/gary/bot/PokemonGo-Bot/configs/path/pier39.json"
-    }
+"type": "FollowPath",
+"config": {
+"path_mode": "linear",
+"path_start_mode": "first",
+"path_file": "/home/gary/bot/PokemonGo-Bot/configs/path/pier39.json"
+}
 }
 ```
 
@@ -471,18 +590,22 @@ You would then see the [FollowPath] [INFO] console log as the bot walks to each 
 2016-08-21 00:09:45,766 [FollowPath] [INFO] [position_update] Walk to (37.8093976, -122.4103554, 0) now at (37.80935021728436, -122.40999180104075, 0), distance left: (32.3738347114 m) ..
 ```
 
+<a class="mk-toclify" id="updatelivestats-settings"></a>
 ## UpdateLiveStats Settings
+[[back to top](#table-of-contents)]
 Periodically displays stats about the bot in the terminal and/or in its title.
 
 Fetching some stats requires making API calls. If you're concerned about the amount of calls your bot is making, don't enable this worker.
 
+<a class="mk-toclify" id="options"></a>
 ### Options
+[[back to top](#table-of-contents)]
 ```
 min_interval : The minimum interval at which the stats are displayed,
-               in seconds (defaults to 120 seconds).
-               The update interval cannot be accurate as workers run synchronously.
+in seconds (defaults to 120 seconds).
+The update interval cannot be accurate as workers run synchronously.
 stats : An array of stats to display and their display order (implicitly),
-        see available stats below (defaults to []).
+see available stats below (defaults to []).
 terminal_log : Logs the stats into the terminal (defaults to false).
 terminal_title : Displays the stats into the terminal title (defaults to true).
 ```
@@ -495,7 +618,7 @@ Available `stats` parameters:
 - km_walked : The kilometers walked since the bot started.
 - level : The current character's level.
 - level_completion : The current level experience, the next level experience and the completion
-                     percentage.
+percentage.
 - level_stats : Puts together the current character's level and its completion.
 - xp_per_hour : The estimated gain of experience per hour.
 - xp_earned : The experience earned since the bot started.
@@ -513,18 +636,20 @@ Available `stats` parameters:
 - most_perfect_pokemon : The most perfect caught pokemon since the bot started.
 ```
 
+<a class="mk-toclify" id="sample-configuration"></a>
 ### Sample Configuration
+[[back to top](#table-of-contents)]
 Following task will shows the information on the console every 10 seconds.
 ```
 {
-  "type": "UpdateLiveStats",
-  "config": {
-    "enabled": true,
-    "min_interval": 10,
-    "stats": ["username", "uptime", "level_completion", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited", "km_walked", "pokemon_encountered", "pokemon_caught", "pokemon_released", "pokemon_unseen", "pokeballs_thrown", "highest_cp_pokemon", "most_perfect_pokemon"],
-    "terminal_log": true,
-    "terminal_title": true
-  }
+"type": "UpdateLiveStats",
+"config": {
+"enabled": true,
+"min_interval": 10,
+"stats": ["username", "uptime", "level_completion", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited", "km_walked", "pokemon_encountered", "pokemon_caught", "pokemon_released", "pokemon_unseen", "pokeballs_thrown", "highest_cp_pokemon", "most_perfect_pokemon"],
+"terminal_log": true,
+"terminal_title": true
+}
 }
 ```
 
@@ -533,14 +658,20 @@ Example console output
 2016-08-20 23:55:48,513 [UpdateLiveStats] [INFO] [log_stats] USERNAME | Uptime : 0:17:17 | Level 26 (192,995 / 390,000, 49%) | Earned 900 Stardust | +2,810 XP | 9,753 XP/h | Visited 23 stops | 0.80km walked | Caught 9 pokemon
 ```
 
+<a class="mk-toclify" id="updateliveinventory-settings"></a>
 ## UpdateLiveInventory Settings
+[[back to top](#table-of-contents)]
+<a class="mk-toclify" id="description"></a>
 ### Description
+[[back to top](#table-of-contents)]
 Periodically displays the user inventory in the terminal.
 
+<a class="mk-toclify" id="options"></a>
 ### Options
- * `min_interval` : The minimum interval at which the stats are displayed, in seconds (defaults to 120 seconds). The update interval cannot be accurate as workers run synchronously.
- * `show_all_multiple_lines` : Logs all items on inventory using multiple lines. Ignores configuration of 'items' 
- * `items` : An array of items to display and their display order (implicitly), see available items below (defaults to []).
+[[back to top](#table-of-contents)]
+* `min_interval` : The minimum interval at which the stats are displayed, in seconds (defaults to 120 seconds). The update interval cannot be accurate as workers run synchronously.
+* `show_all_multiple_lines` : Logs all items on inventory using multiple lines. Ignores configuration of 'items' 
+* `items` : An array of items to display and their display order (implicitly), see available items below (defaults to []).
 
 Available `items` :
 ```
@@ -567,22 +698,28 @@ Available `items` :
 - 'maxrevive'
 ```
 
+<a class="mk-toclify" id="sample-configuration"></a>
 ### Sample configuration
+[[back to top](#table-of-contents)]
 ```json
 {
-    "type": "UpdateLiveInventory",
-    "config": {
-      "enabled": true,
-      "min_interval": 120,
-      "show_all_multiple_lines": false,
-      "items": ["space_info", "pokeballs", "greatballs", "ultraballs", "razzberries", "luckyegg"]
+"type": "UpdateLiveInventory",
+"config": {
+"enabled": true,
+"min_interval": 120,
+"show_all_multiple_lines": false,
+"items": ["space_info", "pokeballs", "greatballs", "ultraballs", "razzberries", "luckyegg"]
 ```
 
+<a class="mk-toclify" id="example-console-output"></a>
 ### Example console output
+[[back to top](#table-of-contents)]
 ```
 2016-08-20 18:56:22,754 [UpdateLiveInventory] [INFO] [show_inventory] Items: 335/350 | Pokeballs: 8 | GreatBalls: 186 | UltraBalls: 0 | RazzBerries: 51 | LuckyEggs: 3
 ```
+<a class="mk-toclify" id="sleep-schedule-task"></a>
 ## Sleep Schedule Task
+[[back to top](#table-of-contents)]
 
 Pauses the execution of the bot every day for some time
 
@@ -593,21 +730,23 @@ Simulates the user going to sleep every day for some time, the sleep time and th
 - `time_random_offset`: (HH:MM) random offset of time that the sleep will start for this example the possible start time is 11:30-12:30
 - `duration_random_offset`: (HH:MM) random offset of duration of sleep for this example the possible duration is 5:00-6:00
 - `wake_up_at_location`: (lat, long | lat, long, alt | "") the location at which the bot wake up *Note that an empty string ("") will not change the location*.
- 
+
 ###Example Config
 ```
 {
-    "type": "SleepSchedule",
-    "config": {
-      "time": "12:00",
-      "duration":"5:30",
-      "time_random_offset": "00:30",
-      "duration_random_offset": "00:30"
-      "wake_up_at_location": "39.408692,149.595838,590.8"
-    }
+"type": "SleepSchedule",
+"config": {
+"time": "12:00",
+"duration":"5:30",
+"time_random_offset": "00:30",
+"duration_random_offset": "00:30"
+"wake_up_at_location": "39.408692,149.595838,590.8"
+}
 }
 ```
+<a class="mk-toclify" id="random-pause"></a>
 ## Random Pause
+[[back to top](#table-of-contents)]
 
 Pause the execution of the bot at a random time for a random time.
 
@@ -621,12 +760,12 @@ Simulates the random pause of the day (speaking to someone, getting into a store
 ###Example Config
 ```
 {
-	"type": "RandomPause",
-    "config": {
-	  "min_duration": "00:00:10",
-	  "max_duration": "00:10:00",
-	  "min_interval": "00:10:00",
-	  "max_interval": "02:00:00"
-    }
+"type": "RandomPause",
+"config": {
+"min_duration": "00:00:10",
+"max_duration": "00:10:00",
+"min_interval": "00:10:00",
+"max_interval": "02:00:00"
+}
 }
 ```

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -49,7 +49,6 @@
 
 Document the configuration options of PokemonGo-Bot.
 
-<a class="mk-toclify" id="usage"></a>
 ## Usage 
 [[back to top](#table-of-contents)]
 
@@ -57,7 +56,7 @@ Document the configuration options of PokemonGo-Bot.
 2. Edit `config.json` and replace `auth_service`, `username`, `password`, `location` and `gmapkey` with your parameters (other keys are optional, check `Advance Configuration` below)
 3. Simply launch the script with : `./run.sh` or `./pokecli.py` or `python pokecli.py -cf ./configs/config.json` if you want to specify a config file
 
-<a class="mk-toclify" id="advanced-configuration"></a>
+
 ## Advanced Configuration
 [[back to top](#table-of-contents)]
 |      Parameter     | Default |                                                                                         Description                                                                                         |
@@ -80,12 +79,12 @@ Document the configuration options of PokemonGo-Bot.
 |`pokemon_bag.show_count`    | false   |                   Show amount of each pokemon.
 |`pokemon_bag.pokemon_info`    | []   |                   Check any config example file to see available settings.
 
-<a class="mk-toclify" id="configuring-tasks"></a>
+
 ## Configuring Tasks
 [[back to top](#table-of-contents)]
 The behaviors of the bot are configured via the `tasks` key in the `config.json`. This enables you to list what you want the bot to do and change the priority of those tasks by reordering them in the list. This list of tasks is run repeatedly and in order. For more information on why we are moving config to this format, check out the [original proposal](https://github.com/PokemonGoF/PokemonGo-Bot/issues/142).
 
-<a class="mk-toclify" id="task-options"></a>
+
 ### Task Options:
 [[back to top](#table-of-contents)]
 * CatchPokemon
@@ -153,7 +152,6 @@ The following configuration tells the bot to transfer all the Pokemon that match
 }
 ```
 
-<a class="mk-toclify" id="specifying-configuration-for-tasks"></a>
 ### Specifying configuration for tasks
 [[back to top](#table-of-contents)]
 If you want to configure a given task, you can pass values like this:
@@ -173,7 +171,6 @@ If you want to configure a given task, you can pass values like this:
 }
 ```
 
-<a class="mk-toclify" id="an-example-task-configuration-if-you-only-wanted-to-collect-items-from-forts"></a>
 ### An example task configuration if you only wanted to collect items from forts:
 [[back to top](#table-of-contents)]
 ```
@@ -194,7 +191,6 @@ If you want to configure a given task, you can pass values like this:
 }
 ```
 
-<a class="mk-toclify" id="catch-configuration"></a>
 ## Catch Configuration
 [[back to top](#table-of-contents)]
 Default configuration will capture all Pokémon.
@@ -209,11 +205,9 @@ Additionally, you can specify always_capture and never_capture flags.
 
 For example: ```"Pidgey": {"never_capture": true}``` will stop catching Pidgey entirely.
 
-<a class="mk-toclify" id="release-configuration"></a>
 ## Release Configuration
 [[back to top](#table-of-contents)]
 
-<a class="mk-toclify" id="common-configuration"></a>
 ### Common configuration
 [[back to top](#table-of-contents)]
 
@@ -229,7 +223,6 @@ Additionally, you can specify always_release and never_release flags. For exampl
 
 ```"release": {"Pidgey": {"always_release": true}}``` will release all Pidgey caught.
 
-<a class="mk-toclify" id="keep-the-strongest-pokemon-configuration-dev-branch"></a>
 ### Keep the strongest pokemon configuration (dev branch)
 [[back to top](#table-of-contents)]
 
@@ -243,7 +236,6 @@ If you already have it, it will keep a stronger version and will transfer the a 
 
 ```"release": {"any": {"keep_best_cp": 2}}```, ```"release": {"any": {"keep_best_cp": 10}}``` - can be any number.
 
-<a class="mk-toclify" id="keep-the-best-custom-pokemon-configuration-dev-branch"></a>
 ### Keep the best custom pokemon configuration (dev branch)
 [[back to top](#table-of-contents)]
 
@@ -260,7 +252,6 @@ The list of criteria is the following:```'cp','iv', 'iv_attack', 'iv_defense', '
 
 ```"release": {"Zubat": {"keep_best_custom": "hp_max,hp", "amount":10}}````
 
-<a class="mk-toclify" id="evolve-all-configuration"></a>
 ## Evolve All Configuration
 [[back to top](#table-of-contents)]
 
@@ -289,7 +280,6 @@ If you wish to change the default threshold of 300 CP, simply add the following 
 "evolve_cp_min":  <number>
 ```
 
-<a class="mk-toclify" id="path-navigator-configuration"></a>
 ## Path Navigator Configuration
 [[back to top](#table-of-contents)]
 
@@ -314,7 +304,6 @@ In the path navigator configuration task, add a maximum of passage above which t
 `"timer_restart_max": "00:20:00"` (will stop for a maximum of 10 minutes)
 
 
-<a class="mk-toclify" id="pokemon-nicknaming"></a>
 ## Pokemon Nicknaming
 [[back to top](#table-of-contents)]
 
@@ -328,7 +317,6 @@ Niantic imposes a 12-character limit on all pokemon nicknames, so any new nickna
 
 Because some pokemon have very long names, you can use the [Format String syntax](https://docs.python.org/2.7/library/string.html#formatstrings) to ensure that your names do not cause your templates to truncate. For example, using `{name:.8s}` causes the Pokemon name to never take up more than 8 characters in the nickname. This would help guarantee that a template like `{name:.8s}_{iv_pct}` never goes over the 12-character limit.
 
-<a class="mk-toclify" id="config-options"></a>
 ### Config options
 [[back to top](#table-of-contents)]
 
@@ -338,7 +326,6 @@ Because some pokemon have very long names, you can use the [Format String syntax
 * `good_attack_threshold` (default: `0.7`): Threshold for perfection of the attack in it's type (0.0-1.0) after which attack will be treated as good. Used for {fast_attack_char}, {charged_attack_char}, {attack_code} templates.
 * `locale` (default: `en`): The locale to use for the pokemon name.
 
-<a class="mk-toclify" id="valid-names-in-templates"></a>
 ### Valid names in templates
 [[back to top](#table-of-contents)]
 
@@ -398,7 +385,6 @@ Key | Info
 - `"{attack_code}{attack_pct1}{defense_pct1}{ivcp_pct1}{name}"` => `Lh474Golbat`
 ![sample](https://cloud.githubusercontent.com/assets/8896778/17285954/0fa44a88-577b-11e6-8204-b1302f4294bd.png)
 
-<a class="mk-toclify" id="sample-configuration"></a>
 ### Sample configuration
 [[back to top](#table-of-contents)]
 
@@ -415,7 +401,6 @@ Key | Info
 }
 ```
 
-<a class="mk-toclify" id="catchpokemon-catch_simulation-settings"></a>
 ## CatchPokemon `catch_simulation` Settings
 [[back to top](#table-of-contents)]
 
@@ -439,7 +424,6 @@ The default settings are 'safe' settings intended to simulate human and app beha
 }
 ```
 
-<a class="mk-toclify" id="settings-description"></a>
 ### Settings Description
 [[back to top](#table-of-contents)]
 
@@ -454,12 +438,10 @@ Setting | Description
 `changeball_wait_min`| The minimum amount of time to change ball
 `changeball_wait_max`| The maximum amount of time to change ball
 
-<a class="mk-toclify" id="flee_count-and-flee_duration"></a>
 ### `flee_count` and `flee_duration`
 [[back to top](#table-of-contents)]
 This part is app simulation and the default settings are advised.  When we hit a pokemon in the app the animation will play randomly 1, 2 or 3 times for roughly 2 seconds each time.  So we pause for a random number of animations up to `flee_count` of duration `flee_duration`
 
-<a class="mk-toclify" id="previous-behaviour"></a>
 ### Previous Behaviour
 [[back to top](#table-of-contents)]
 If you want to make your bot behave as it did prior to this update please use the following settings.
@@ -477,16 +459,13 @@ If you want to make your bot behave as it did prior to this update please use th
 }
 ```
 
-<a class="mk-toclify" id="sniping-_-movetolocation-_"></a>
 ## Sniping _(MoveToLocation)_
 [[back to top](#table-of-contents)]
 
-<a class="mk-toclify" id="description"></a>
 ### Description
 [[back to top](#table-of-contents)]
 This task will fetch current pokemon spawns from /raw_data of an PokemonGo-Map instance. For information on how to properly setup PokemonGo-Map have a look at the Github page of the project [here](https://github.com/AHAAAAAAA/PokemonGo-Map/). There is an example config in `config/config.json.map.example`
 
-<a class="mk-toclify" id="options"></a>
 ### Options
 [[back to top](#table-of-contents)]
 * `Address` - Address of the webserver of PokemonGo-Map. ex: `http://localhost:5000`
@@ -506,7 +485,6 @@ This task will fetch current pokemon spawns from /raw_data of an PokemonGo-Map i
 *   - Any pokemon above this threshold value will be caught by teleporting to its location, and getting back to original location if `snipe` is `True`.
 *   - Any pokemon under this threshold value will make the bot walk to the Pokemon target wether `snipe` is `True` or `False`.
 
-<a class="mk-toclify" id="example"></a>
 #### Example
 [[back to top](#table-of-contents)]
 ```
@@ -538,15 +516,13 @@ This task will fetch current pokemon spawns from /raw_data of an PokemonGo-Map i
 }
 ```
 
-<a class="mk-toclify" id="followpath-settings"></a>
 ## FollowPath Settings
 [[back to top](#table-of-contents)]
-<a class="mk-toclify" id="description"></a>
+
 ### Description
 [[back to top](#table-of-contents)]
 Walk to the specified locations loaded from .gpx or .json file. It is highly recommended to use website such as [GPSies](http://www.gpsies.com) which allow you to export your created track in JSON file. Note that you'll have to first convert its JSON file into the format that the bot can understand. See [Example of pier39.json] below for the content. I had created a simple python script to do the conversion. 
 
-<a class="mk-toclify" id="options"></a>
 ### Options
 [[back to top](#table-of-contents)]
 * `path_mode` - linear, loop
@@ -556,7 +532,6 @@ Walk to the specified locations loaded from .gpx or .json file. It is highly rec
 * `path_file` - "/path/to/your/path.json"
 
 
-<a class="mk-toclify" id="sample-configuration"></a>
 ### Sample Configuration
 [[back to top](#table-of-contents)]
 ```
@@ -590,14 +565,12 @@ You would then see the [FollowPath] [INFO] console log as the bot walks to each 
 2016-08-21 00:09:45,766 [FollowPath] [INFO] [position_update] Walk to (37.8093976, -122.4103554, 0) now at (37.80935021728436, -122.40999180104075, 0), distance left: (32.3738347114 m) ..
 ```
 
-<a class="mk-toclify" id="updatelivestats-settings"></a>
 ## UpdateLiveStats Settings
 [[back to top](#table-of-contents)]
 Periodically displays stats about the bot in the terminal and/or in its title.
 
 Fetching some stats requires making API calls. If you're concerned about the amount of calls your bot is making, don't enable this worker.
 
-<a class="mk-toclify" id="options"></a>
 ### Options
 [[back to top](#table-of-contents)]
 ```
@@ -636,7 +609,6 @@ percentage.
 - most_perfect_pokemon : The most perfect caught pokemon since the bot started.
 ```
 
-<a class="mk-toclify" id="sample-configuration"></a>
 ### Sample Configuration
 [[back to top](#table-of-contents)]
 Following task will shows the information on the console every 10 seconds.
@@ -658,15 +630,13 @@ Example console output
 2016-08-20 23:55:48,513 [UpdateLiveStats] [INFO] [log_stats] USERNAME | Uptime : 0:17:17 | Level 26 (192,995 / 390,000, 49%) | Earned 900 Stardust | +2,810 XP | 9,753 XP/h | Visited 23 stops | 0.80km walked | Caught 9 pokemon
 ```
 
-<a class="mk-toclify" id="updateliveinventory-settings"></a>
 ## UpdateLiveInventory Settings
 [[back to top](#table-of-contents)]
-<a class="mk-toclify" id="description"></a>
+
 ### Description
 [[back to top](#table-of-contents)]
 Periodically displays the user inventory in the terminal.
 
-<a class="mk-toclify" id="options"></a>
 ### Options
 [[back to top](#table-of-contents)]
 * `min_interval` : The minimum interval at which the stats are displayed, in seconds (defaults to 120 seconds). The update interval cannot be accurate as workers run synchronously.
@@ -698,7 +668,6 @@ Available `items` :
 - 'maxrevive'
 ```
 
-<a class="mk-toclify" id="sample-configuration"></a>
 ### Sample configuration
 [[back to top](#table-of-contents)]
 ```json
@@ -711,13 +680,12 @@ Available `items` :
 "items": ["space_info", "pokeballs", "greatballs", "ultraballs", "razzberries", "luckyegg"]
 ```
 
-<a class="mk-toclify" id="example-console-output"></a>
 ### Example console output
 [[back to top](#table-of-contents)]
 ```
 2016-08-20 18:56:22,754 [UpdateLiveInventory] [INFO] [show_inventory] Items: 335/350 | Pokeballs: 8 | GreatBalls: 186 | UltraBalls: 0 | RazzBerries: 51 | LuckyEggs: 3
 ```
-<a class="mk-toclify" id="sleep-schedule-task"></a>
+
 ## Sleep Schedule Task
 [[back to top](#table-of-contents)]
 
@@ -744,7 +712,7 @@ Simulates the user going to sleep every day for some time, the sleep time and th
 }
 }
 ```
-<a class="mk-toclify" id="random-pause"></a>
+
 ## Random Pause
 [[back to top](#table-of-contents)]
 

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -49,7 +49,7 @@
 
 Document the configuration options of PokemonGo-Bot.
 
-## Usage 
+## Usage
 [[back to top](#table-of-contents)]
 
 1. copy `config.json.example` to `config.json`.
@@ -59,6 +59,7 @@ Document the configuration options of PokemonGo-Bot.
 
 ## Advanced Configuration
 [[back to top](#table-of-contents)]
+
 |      Parameter     | Default |                                                                                         Description                                                                                         |
 |------------------|-------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `tasks`            | []     | The behaviors you want the bot to do. Read [how to configure tasks](#configuring-tasks).
@@ -82,6 +83,7 @@ Document the configuration options of PokemonGo-Bot.
 
 ## Configuring Tasks
 [[back to top](#table-of-contents)]
+
 The behaviors of the bot are configured via the `tasks` key in the `config.json`. This enables you to list what you want the bot to do and change the priority of those tasks by reordering them in the list. This list of tasks is run repeatedly and in order. For more information on why we are moving config to this format, check out the [original proposal](https://github.com/PokemonGoF/PokemonGo-Bot/issues/142).
 
 
@@ -89,110 +91,114 @@ The behaviors of the bot are configured via the `tasks` key in the `config.json`
 [[back to top](#table-of-contents)]
 * CatchPokemon
 * EvolvePokemon
-* `evolve_all`: Default `NONE` | Set to `"all"` to evolve Pokémon if possible when the bot starts. Can also be set to individual Pokémon as well as multiple separated by a comma. e.g "Pidgey,Rattata,Weedle,Zubat"
-* `evolve_speed`: Default `20`
-* `use_lucky_egg`: Default: `False`
+  * `evolve_all`: Default `NONE` | Set to `"all"` to evolve Pokémon if possible when the bot starts. Can also be set to individual Pokémon as well as multiple separated by a comma. e.g "Pidgey,Rattata,Weedle,Zubat"
+  * `evolve_speed`: Default `20`
+  * `use_lucky_egg`: Default: `False`
 * FollowPath
-* `path_mode`: Default `loop` | Set the mode for the path navigator (loop or linear).
-* `path_file`: Default `NONE` | Set the file containing the waypoints for the path navigator.
+  * `path_mode`: Default `loop` | Set the mode for the path navigator (loop or linear).
+  * `path_file`: Default `NONE` | Set the file containing the waypoints for the path navigator.
 * FollowSpiral
 * HandleSoftBan
 * IncubateEggs
-* `longer_eggs_first`: Default `True`
+  * `longer_eggs_first`: Default `True`
 * MoveToFort
 * [MoveToMapPokemon](#sniping-movetolocation)
 * NicknamePokemon
-* `nickname_template`: Default `""` | See the [Pokemon Nicknaming](#pokemon-nicknaming) section for more details
-* `dont_nickname_favorite`: Default `false` | Prevents renaming of favorited pokemons
-* `good_attack_threshold`: Default `0.7` | Threshold for perfection of the attack in it's type *(0.0-1.0)* after which attack will be treated as good.<br>Used for `{fast_attack_char}`, `{charged_attack_char}`, `{attack_code}`  templates
+  * `nickname_template`: Default `""` | See the [Pokemon Nicknaming](#pokemon-nicknaming) section for more details
+  * `dont_nickname_favorite`: Default `false` | Prevents renaming of favorited pokemons
+  * `good_attack_threshold`: Default `0.7` | Threshold for perfection of the attack in it's type *(0.0-1.0)* after which attack will be treated as good.<br>Used for `{fast_attack_char}`, `{charged_attack_char}`, `{attack_code}`  templates
 * RecycleItems
 
-> **NOTE:** It's highly recommended to put this task before MoveToFort and SpinFort tasks. This way you'll most likely be able to loot.
-* `min_empty_space`: Default `6` | Minimum empty space to keep in inventory. Once the inventory has less empty space than that amount, the recycling process is triggered. Set it to the inventory size to trigger it at every tick.
-* `item_filter`: Pass a list of unwanted [items (using their JSON codes or names)](https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Item-ID's) to recycle.
-* `max_balls_keep`: Default `None` | Maximum amount of balls to keep in inventory
-* `max_potions_keep`: Default `None` | Maximum amount of potions to keep in inventory
-* `max_berries_keep`: Default `None` | Maximum amount of berries to keep in inventory
-* `max_revives_keep`: Default `None` | Maximum amount of revives to keep in inventory
+  > **NOTE:** It's highly recommended to put this task before MoveToFort and SpinFort tasks. This way you'll most likely be able to loot.
+  * `min_empty_space`: Default `6` | Minimum empty space to keep in inventory. Once the inventory has less empty space than that amount, the recycling process is triggered. Set it to the inventory size to trigger it at every tick.
+  * `item_filter`: Pass a list of unwanted [items (using their JSON codes or names)](https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Item-ID's) to recycle.
+  * `max_balls_keep`: Default `None` | Maximum amount of balls to keep in inventory
+  * `max_potions_keep`: Default `None` | Maximum amount of potions to keep in inventory
+  * `max_berries_keep`: Default `None` | Maximum amount of berries to keep in inventory
+  * `max_revives_keep`: Default `None` | Maximum amount of revives to keep in inventory
 * SpinFort
 * TransferPokemon
-* `min_free_slot`: Default `5` | Once the pokebag has less empty slots than this amount, the transfer process is triggered. | Big values (i.e 9999) will trigger the transfer process after each catch.
+  * `min_free_slot`: Default `5` | Once the pokebag has less empty slots than this amount, the transfer process is triggered. | Big values (i.e 9999) will trigger the transfer process after each catch.
 * UpdateLiveStats
 * [UpdateLiveInventory](#updateliveinventory-settings)
 
-<a class="mk-toclify" id="example-configuration"></a>
+
 ### Example configuration:
 [[back to top](#table-of-contents)]
+
 The following configuration tells the bot to transfer all the Pokemon that match the transfer configuration rules, then recycle the items that match its configuration, then catch the pokemon that it can, so on, so forth. Note the last two tasks, MoveToFort and FollowSpiral. When a task is still in progress, it won't run the next things in the list. So it will move towards the fort, on each step running through the list of tasks again. Only when it arrives at the fort and there are no other stops available for it to move towards will it continue to the next step and follow the spiral.
 
 ```
 {
-// ...
-"tasks": [
-{
-"type": "TransferPokemon"
-},
-{
-"type": "RecycleItems"
-},
-{
-"type": "CatchPokemon"
-},
-{
-"type": "SpinFort"
-},
-{
-"type": "MoveToFort"
-},
-{
-"type": "FollowSpiral"
-}
-]
-// ...
+  // ...
+  "tasks": [
+    {
+      "type": "TransferPokemon"
+    },
+    {
+      "type": "RecycleItems"
+    },
+    {
+      "type": "CatchPokemon"
+    },
+    {
+      "type": "SpinFort"
+    },
+    {
+      "type": "MoveToFort"
+    },
+    {
+      "type": "FollowSpiral"
+    }
+  ]
+  // ...
 }
 ```
 
 ### Specifying configuration for tasks
 [[back to top](#table-of-contents)]
+
 If you want to configure a given task, you can pass values like this:
 
 ```
 {
-// ...
-"tasks": [
-{
-"type": "IncubateEggs",
-"config": {
-"longer_eggs_first": true
-}
-}
-]
-// ...
+  // ...
+  "tasks": [
+    {
+      "type": "IncubateEggs",
+      "config": {
+        "longer_eggs_first": true
+      }
+    }
+  ]
+  // ...
 }
 ```
 
 ### An example task configuration if you only wanted to collect items from forts:
 [[back to top](#table-of-contents)]
+
 ```
 {
-// ...
-"tasks": [
-{
-"type": "RecycleItems"
-},
-{
-"type": "SpinFortWorker"
-},
-{
-"type": "MoveToFortWorker"
-}
-],
-// ...
+  // ...
+  "tasks": [
+    {
+      "type": "RecycleItems"
+    },
+    {
+      "type": "SpinFortWorker"
+    },
+    {
+      "type": "MoveToFortWorker"
+    }
+  ],
+  // ...
 }
 ```
 
 ## Catch Configuration
 [[back to top](#table-of-contents)]
+
 Default configuration will capture all Pokémon.
 
 ```"any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"}```
@@ -334,48 +340,47 @@ Key | Info
 **{name}** |  Pokemon name     *(e.g. Articuno)*
 **{id}**  |  Pokemon ID/Number *(1-151, e.g. 1 for Bulbasaurs)*
 **{cp}**  |  Pokemon's Combat Points (CP)    *(10-4145)*
-| **Individial Values (IV)**
+ | **Individial Values (IV)**
 **{iv_attack}**  |  Individial Attack *(0-15)* of the current specific pokemon
 **{iv_defense}** |  Individial Defense *(0-15)* of the current specific pokemon
 **{iv_stamina}** |  Individial Stamina *(0-15)* of the current specific pokemon
 **{iv_ads}**     |  Joined IV values in `(attack)/(defense)/(stamina)` format (*e.g. 4/12/9*, matches web UI format -- A/D/S)
 **{iv_ads_hex}** |  Joined IV values of `(attack)(defense)(stamina)` in HEX (*e.g. 4C9* for A/D/S = 4/12/9)
 **{iv_sum}**     |  Sum of the Individial Values *(0-45, e.g. 45 when 3 perfect 15 IVs)*
-|  **Basic Values of the pokemon (identical for all of one kind)**
+ |  **Basic Values of the pokemon (identical for all of one kind)**
 **{base_attack}**   |  Basic Attack *(40-284)* of the current pokemon kind
 **{base_defense}**  |  Basic Defense *(54-242)* of the current pokemon kind
 **{base_stamina}**  |  Basic Stamina *(20-500)* of the current pokemon kind
 **{base_ads}**      |  Joined Basic Values *(e.g. 125/93/314)*
-|  **Final Values of the pokemon (Base Values + Individial Values)**
+ |  **Final Values of the pokemon (Base Values + Individial Values)**
 **{attack}**        |  Basic Attack + Individial Attack
 **{defense}**       |  Basic Defense + Individial Defense
 **{stamina}**       |  Basic Stamina + Individial Stamina
 **{sum_ads}**       |  Joined Final Values *(e.g. 129/97/321)*
-|  **Individial Values perfection percent**
+ |  **Individial Values perfection percent**
 **{iv_pct}**     |  IV perfection *(in 000-100 format - 3 chars)*
 **{iv_pct2}**    |  IV perfection *(in 00-99 format - 2 chars).* So 99 is best (it's a 100% perfection)
 **{iv_pct1}**    |  IV perfection *(in 0-9 format - 1 char)*
-|  **IV CP perfection - kind of IV perfection percent but calculated using weight of each IV in its contribution to CP of the best evolution of current pokemon.**<br> It tends to be more accurate than simple IV perfection.
+ |  **IV CP perfection - kind of IV perfection percent but calculated using weight of each IV in its contribution to CP of the best evolution of current pokemon.**<br> It tends to be more accurate than simple IV perfection.
 **{ivcp_pct}**      |  IV CP perfection *(in 000-100 format - 3 chars)*
 **{ivcp_pct2}**     |  IV CP perfection *(in 00-99 format - 2 chars).* So 99 is best (it's a 100% perfection)
 **{ivcp_pct1}**     |  IV CP perfection *(in 0-9 format - 1 char)*
-|  **Moveset perfection percents for attack and for defense.**<br> Calculated for current pokemon only, not between all pokemons. So perfect moveset can be weak if pokemon is weak (e.g. Caterpie)
+ |  **Moveset perfection percents for attack and for defense.**<br> Calculated for current pokemon only, not between all pokemons. So perfect moveset can be weak if pokemon is weak (e.g. Caterpie)
 **{attack_pct}**   |  Moveset perfection for attack *(in 000-100 format - 3 chars)*
 **{attack_pct2}**  |  Moveset perfection for attack *(in 00-99 format - 2 chars)*
 **{attack_pct1}**  |  Moveset perfection for attack *(in 0-9 format - 1 char)*
 **{defense_pct}**  |  Moveset perfection for defense *(in 000-100 format - 3 chars)*
 **{defense_pct2}** |  Moveset perfection for defense *(in 00-99 format - 2 chars)*
 **{defense_pct1}** |  Moveset perfection for defense *(in 0-9 format - 1 char)*
-|  **Character codes for fast/charged attack types.**<br> If attack is good character is uppecased, otherwise lowercased.<br>Use `'good_attack_threshold'` option for customization.<br><br> It's an effective way to represent type with one character.<br> If first char of the type name is unique - it's used, in other case suitable substitute used.<br><br> Type codes:<br> &nbsp;&nbsp;`Bug: 'B'`<br> &nbsp;&nbsp;`Dark: 'K'`<br> &nbsp;&nbsp;`Dragon: 'D'`<br> &nbsp;&nbsp;`Electric: 'E'`<br> &nbsp;&nbsp;`Fairy: 'Y'`<br> &nbsp;&nbsp;`Fighting: 'T'`<br> &nbsp;&nbsp;`Fire: 'F'`<br> &nbsp;&nbsp;`Flying: 'L'`<br> &nbsp;&nbsp;`Ghost: 'H'`<br> &nbsp;&nbsp;`Grass: 'A'`<br> &nbsp;&nbsp;`Ground: 'G'`<br> &nbsp;&nbsp;`Ice: 'I'`<br> &nbsp;&nbsp;`Normal: 'N'`<br> &nbsp;&nbsp;`Poison: 'P'`<br> &nbsp;&nbsp;`Psychic: 'C'`<br> &nbsp;&nbsp;`Rock: 'R'`<br> &nbsp;&nbsp;`Steel: 'S'`<br> &nbsp;&nbsp;`Water: 'W'`
+ |  **Character codes for fast/charged attack types.**<br> If attack is good character is uppecased, otherwise lowercased.<br>Use `'good_attack_threshold'` option for customization.<br><br> It's an effective way to represent type with one character.<br> If first char of the type name is unique - it's used, in other case suitable substitute used.<br><br> Type codes:<br> &nbsp;&nbsp;`Bug: 'B'`<br> &nbsp;&nbsp;`Dark: 'K'`<br> &nbsp;&nbsp;`Dragon: 'D'`<br> &nbsp;&nbsp;`Electric: 'E'`<br> &nbsp;&nbsp;`Fairy: 'Y'`<br> &nbsp;&nbsp;`Fighting: 'T'`<br> &nbsp;&nbsp;`Fire: 'F'`<br> &nbsp;&nbsp;`Flying: 'L'`<br> &nbsp;&nbsp;`Ghost: 'H'`<br> &nbsp;&nbsp;`Grass: 'A'`<br> &nbsp;&nbsp;`Ground: 'G'`<br> &nbsp;&nbsp;`Ice: 'I'`<br> &nbsp;&nbsp;`Normal: 'N'`<br> &nbsp;&nbsp;`Poison: 'P'`<br> &nbsp;&nbsp;`Psychic: 'C'`<br> &nbsp;&nbsp;`Rock: 'R'`<br> &nbsp;&nbsp;`Steel: 'S'`<br> &nbsp;&nbsp;`Water: 'W'`
 **{fast_attack_char}**   |  One character code for fast attack type (e.g. 'F' for good Fire or 's' for bad Steel attack)
 **{charged_attack_char}**   |  One character code for charged attack type (e.g. 'n' for bad Normal or 'I' for good Ice attack)
 **{attack_code}**           |  Joined 2 character code for both attacks (e.g. 'Lh' for pokemon with strong Flying and weak Ghost attacks)
-|  **Special case: pokemon object**<br> You can access any available pokemon info via it.<br>Examples:<br> &nbsp;&nbsp;`'{pokemon.ivcp:.2%}'             ->  '47.00%'`<br> &nbsp;&nbsp;`'{pokemon.fast_attack}'          ->  'Wing Attack'`<br> &nbsp;&nbsp;`'{pokemon.fast_attack.type}'     ->  'Flying'`<br> &nbsp;&nbsp;`'{pokemon.fast_attack.dps:.2f}'  ->  '10.91'`<br> &nbsp;&nbsp;`'{pokemon.fast_attack.dps:.0f}'  ->  '11'`<br> &nbsp;&nbsp;`'{pokemon.charged_attack}'       ->  'Ominous Wind'`
+ |  **Special case: pokemon object**<br> You can access any available pokemon info via it.<br>Examples:<br> &nbsp;&nbsp;`'{pokemon.ivcp:.2%}'             ->  '47.00%'`<br> &nbsp;&nbsp;`'{pokemon.fast_attack}'          ->  'Wing Attack'`<br> &nbsp;&nbsp;`'{pokemon.fast_attack.type}'     ->  'Flying'`<br> &nbsp;&nbsp;`'{pokemon.fast_attack.dps:.2f}'  ->  '10.91'`<br> &nbsp;&nbsp;`'{pokemon.fast_attack.dps:.0f}'  ->  '11'`<br> &nbsp;&nbsp;`'{pokemon.charged_attack}'       ->  'Ominous Wind'`
 **{pokemon}**   |  Pokemon instance (see inventory.py for class sources)
 
 > **NOTE:** Use a blank template (`""`) to revert all pokemon to their original names (as if they had no nickname).
 
-<a class="mk-toclify" id="sample-usages"></a>
 #### Sample usages
 [[back to top](#table-of-contents)]
 
@@ -390,14 +395,14 @@ Key | Info
 
 ```json
 {
-"type": "NicknamePokemon",
-"config": {
-"enabled": true,
-"dont_nickname_favorite": false,
-"good_attack_threshold": 0.7,
-"nickname_template": "{iv_pct}_{iv_ads}"
-"locale": "en"
-}
+  "type": "NicknamePokemon",
+  "config": {
+    "enabled": true,
+    "dont_nickname_favorite": false,
+    "good_attack_threshold": 0.7,
+    "nickname_template": "{iv_pct}_{iv_ads}"
+    "locale": "en"
+  }
 }
 ```
 
@@ -406,21 +411,21 @@ Key | Info
 
 These settings determine how the bot will simulate the app by adding pauses to throw the ball and navigate menus.  All times are in seconds.  To configure these settings add them to the config in the CatchPokemon task.
 
-<a class="mk-toclify" id="default-settings"></a>
 ### Default Settings
 [[back to top](#table-of-contents)]
+
 The default settings are 'safe' settings intended to simulate human and app behaviour.
 
 ```
 "catch_simulation": {
-"flee_count": 3,
-"flee_duration": 2,
-"catch_wait_min": 2,
-"catch_wait_max": 6,
-"berry_wait_min": 2,
-"berry_wait_max": 3,
-"changeball_wait_min": 2,
-"changeball_wait_max": 3
+    "flee_count": 3,
+    "flee_duration": 2,
+    "catch_wait_min": 2,
+    "catch_wait_max": 6,
+    "berry_wait_min": 2,
+    "berry_wait_max": 3,
+    "changeball_wait_min": 2,
+    "changeball_wait_max": 3
 }
 ```
 
@@ -440,22 +445,24 @@ Setting | Description
 
 ### `flee_count` and `flee_duration`
 [[back to top](#table-of-contents)]
+
 This part is app simulation and the default settings are advised.  When we hit a pokemon in the app the animation will play randomly 1, 2 or 3 times for roughly 2 seconds each time.  So we pause for a random number of animations up to `flee_count` of duration `flee_duration`
 
 ### Previous Behaviour
 [[back to top](#table-of-contents)]
+
 If you want to make your bot behave as it did prior to this update please use the following settings.
 
 ```
 "catch_simulation": {
-"flee_count": 1,
-"flee_duration": 2,
-"catch_wait_min": 0,
-"catch_wait_max": 0,
-"berry_wait_min": 0,
-"berry_wait_max": 0,
-"changeball_wait_min": 0,
-"changeball_wait_max": 0
+    "flee_count": 1,
+    "flee_duration": 2,
+    "catch_wait_min": 0,
+    "catch_wait_max": 0,
+    "berry_wait_min": 0,
+    "berry_wait_max": 0,
+    "changeball_wait_min": 0,
+    "changeball_wait_max": 0
 }
 ```
 
@@ -464,20 +471,22 @@ If you want to make your bot behave as it did prior to this update please use th
 
 ### Description
 [[back to top](#table-of-contents)]
+
 This task will fetch current pokemon spawns from /raw_data of an PokemonGo-Map instance. For information on how to properly setup PokemonGo-Map have a look at the Github page of the project [here](https://github.com/AHAAAAAAA/PokemonGo-Map/). There is an example config in `config/config.json.map.example`
 
 ### Options
 [[back to top](#table-of-contents)]
+
 * `Address` - Address of the webserver of PokemonGo-Map. ex: `http://localhost:5000`
 * `Mode` - Which mode to run snipin on
-- `distance` - Will move to the nearest pokemon
-- `priority` - Will move to the pokemon with the highest priority assigned (tie breaking by distance)
+   - `distance` - Will move to the nearest pokemon
+   - `priority` - Will move to the pokemon with the highest priority assigned (tie breaking by distance)
 * `prioritize_vips` - Will prioritize vips in distance and priority mode above all normal pokemon if set to true
 * `min_time` - Minimum time the pokemon has to be available before despawn
 * `max_distance` - Maximum distance the pokemon is allowed to be when walking, ignored when sniping
 * `snipe`:
-- `True` - Will teleport to target pokemon, encounter it, teleport back then catch it
-- `False` - Will walk normally to the pokemon
+   - `True` - Will teleport to target pokemon, encounter it, teleport back then catch it
+   - `False` - Will walk normally to the pokemon
 * `update_map` - disable/enable if the map location should be automatically updated to the bots current location
 * `catch` - A dictionary of pokemon to catch with an assigned priority (higher => better)
 * `snipe_high_prio_only` - Whether to snipe pokemon above a certain threshold.
@@ -487,32 +496,33 @@ This task will fetch current pokemon spawns from /raw_data of an PokemonGo-Map i
 
 #### Example
 [[back to top](#table-of-contents)]
+
 ```
 {
-\\ ...
-{
-"type": "MoveToMapPokemon",
-"config": {
-"address": "http://localhost:5000",
-"max_distance": 500,
-"min_time": 60,
-"min_ball": 50,
-"prioritize_vips": true,
-"snipe": true,
-"snipe_high_prio_only": true,
-"snipe_high_prio_threshold": 400,
-"update_map": true,
-"mode": "priority",
-"catch": {
-"Aerodactyl": 1000,
-"Ditto": 900,
-"Omastar": 500,
-"Omanyte": 150,
-"Caterpie": 10,
-}
-}
-}
-\\ ...
+  \\ ...
+  {
+    "type": "MoveToMapPokemon",
+    "config": {
+      "address": "http://localhost:5000",
+      "max_distance": 500,
+      "min_time": 60,
+      "min_ball": 50,
+      "prioritize_vips": true,
+      "snipe": true,
+      "snipe_high_prio_only": true,
+      "snipe_high_prio_threshold": 400,
+      "update_map": true,
+      "mode": "priority",
+      "catch": {
+        "Aerodactyl": 1000,
+        "Ditto": 900,
+        "Omastar": 500,
+        "Omanyte": 150,
+        "Caterpie": 10,
+      }
+    }
+  }
+  \\ ...
 }
 ```
 
@@ -521,27 +531,29 @@ This task will fetch current pokemon spawns from /raw_data of an PokemonGo-Map i
 
 ### Description
 [[back to top](#table-of-contents)]
+
 Walk to the specified locations loaded from .gpx or .json file. It is highly recommended to use website such as [GPSies](http://www.gpsies.com) which allow you to export your created track in JSON file. Note that you'll have to first convert its JSON file into the format that the bot can understand. See [Example of pier39.json] below for the content. I had created a simple python script to do the conversion. 
 
 ### Options
 [[back to top](#table-of-contents)]
 * `path_mode` - linear, loop
-- `loop` - The bot will walk along all specified waypoints and then move directly to the first waypoint again. 
-- `linear` - The bot will turn around at the last waypoint and along the given waypoints in reverse order.
+   - `loop` - The bot will walk along all specified waypoints and then move directly to the first waypoint again. 
+   - `linear` - The bot will turn around at the last waypoint and along the given waypoints in reverse order.
 * `path_start_mode` - first
 * `path_file` - "/path/to/your/path.json"
 
 
 ### Sample Configuration
 [[back to top](#table-of-contents)]
+
 ```
 {
-"type": "FollowPath",
-"config": {
-"path_mode": "linear",
-"path_start_mode": "first",
-"path_file": "/home/gary/bot/PokemonGo-Bot/configs/path/pier39.json"
-}
+	"type": "FollowPath",
+    "config": {
+    	"path_mode": "linear",
+	  	"path_start_mode": "first",
+      "path_file": "/home/gary/bot/PokemonGo-Bot/configs/path/pier39.json"
+    }
 }
 ```
 
@@ -567,6 +579,7 @@ You would then see the [FollowPath] [INFO] console log as the bot walks to each 
 
 ## UpdateLiveStats Settings
 [[back to top](#table-of-contents)]
+
 Periodically displays stats about the bot in the terminal and/or in its title.
 
 Fetching some stats requires making API calls. If you're concerned about the amount of calls your bot is making, don't enable this worker.
@@ -575,10 +588,10 @@ Fetching some stats requires making API calls. If you're concerned about the amo
 [[back to top](#table-of-contents)]
 ```
 min_interval : The minimum interval at which the stats are displayed,
-in seconds (defaults to 120 seconds).
-The update interval cannot be accurate as workers run synchronously.
+               in seconds (defaults to 120 seconds).
+               The update interval cannot be accurate as workers run synchronously.
 stats : An array of stats to display and their display order (implicitly),
-see available stats below (defaults to []).
+        see available stats below (defaults to []).
 terminal_log : Logs the stats into the terminal (defaults to false).
 terminal_title : Displays the stats into the terminal title (defaults to true).
 ```
@@ -591,7 +604,7 @@ Available `stats` parameters:
 - km_walked : The kilometers walked since the bot started.
 - level : The current character's level.
 - level_completion : The current level experience, the next level experience and the completion
-percentage.
+                     percentage.
 - level_stats : Puts together the current character's level and its completion.
 - xp_per_hour : The estimated gain of experience per hour.
 - xp_earned : The experience earned since the bot started.
@@ -611,17 +624,18 @@ percentage.
 
 ### Sample Configuration
 [[back to top](#table-of-contents)]
+
 Following task will shows the information on the console every 10 seconds.
 ```
 {
-"type": "UpdateLiveStats",
-"config": {
-"enabled": true,
-"min_interval": 10,
-"stats": ["username", "uptime", "level_completion", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited", "km_walked", "pokemon_encountered", "pokemon_caught", "pokemon_released", "pokemon_unseen", "pokeballs_thrown", "highest_cp_pokemon", "most_perfect_pokemon"],
-"terminal_log": true,
-"terminal_title": true
-}
+  "type": "UpdateLiveStats",
+  "config": {
+    "enabled": true,
+    "min_interval": 10,
+    "stats": ["username", "uptime", "level_completion", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited", "km_walked", "pokemon_encountered", "pokemon_caught", "pokemon_released", "pokemon_unseen", "pokeballs_thrown", "highest_cp_pokemon", "most_perfect_pokemon"],
+    "terminal_log": true,
+    "terminal_title": true
+  }
 }
 ```
 
@@ -635,6 +649,7 @@ Example console output
 
 ### Description
 [[back to top](#table-of-contents)]
+
 Periodically displays the user inventory in the terminal.
 
 ### Options
@@ -672,12 +687,12 @@ Available `items` :
 [[back to top](#table-of-contents)]
 ```json
 {
-"type": "UpdateLiveInventory",
-"config": {
-"enabled": true,
-"min_interval": 120,
-"show_all_multiple_lines": false,
-"items": ["space_info", "pokeballs", "greatballs", "ultraballs", "razzberries", "luckyegg"]
+    "type": "UpdateLiveInventory",
+    "config": {
+      "enabled": true,
+      "min_interval": 120,
+      "show_all_multiple_lines": false,
+      "items": ["space_info", "pokeballs", "greatballs", "ultraballs", "razzberries", "luckyegg"]
 ```
 
 ### Example console output
@@ -702,14 +717,14 @@ Simulates the user going to sleep every day for some time, the sleep time and th
 ###Example Config
 ```
 {
-"type": "SleepSchedule",
-"config": {
-"time": "12:00",
-"duration":"5:30",
-"time_random_offset": "00:30",
-"duration_random_offset": "00:30"
-"wake_up_at_location": "39.408692,149.595838,590.8"
-}
+	"type": "SleepSchedule",
+	"config": {
+		"time": "12:00",
+		"duration":"5:30",
+		"time_random_offset": "00:30",
+		"duration_random_offset": "00:30"
+		"wake_up_at_location": "39.408692,149.595838,590.8"
+	}
 }
 ```
 
@@ -728,12 +743,12 @@ Simulates the random pause of the day (speaking to someone, getting into a store
 ###Example Config
 ```
 {
-"type": "RandomPause",
-"config": {
-"min_duration": "00:00:10",
-"max_duration": "00:10:00",
-"min_interval": "00:10:00",
-"max_interval": "02:00:00"
-}
+	"type": "RandomPause",
+	"config": {
+		"min_duration": "00:00:10",
+		"max_duration": "00:10:00",
+		"min_interval": "00:10:00",
+		"max_interval": "02:00:00"
+	}
 }
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ raven==5.23.0
 demjson==2.2.4
 greenlet==0.4.9
 yoyo-migrations==5.0.3
+markdown_toclify==0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,3 @@ raven==5.23.0
 demjson==2.2.4
 greenlet==0.4.9
 yoyo-migrations==5.0.3
-markdown_toclify==0.1.7


### PR DESCRIPTION
## Short Description:

Add a table of content to the configuration file task. 

It is not beautiful, it is not working entirely (because of md, when an header has the same name than another header, the anchor links always go to the first one), but it is something. 

The table was generated with markdown-toclify, which I added to the pip config (https://github.com/rasbt/markdown-toclify). I don't know if you feel like keeping it or no...

## Fixes/Resolves/Closes (please use correct syntax):
- Closes #4451 (partially)
