### PR TITLE
Fix FollowPath bug

### DIFF
--- a/pokemongo_bot/cell_workers/follow_path.py
+++ b/pokemongo_bot/cell_workers/follow_path.py
@@ -184,8 +184,8 @@ class FollowPath(BaseTask):
                             'number_lap_max': str(self.number_lap_max)
                         }
                     )
-                if self.number_lap >= self.number_lap_max:
-                    self.endLaps()
+                    if self.number_lap >= self.number_lap_max:
+                        self.endLaps()
             else:
                 self.ptr += 1
         


### PR DESCRIPTION

## Fix follow path bug

## Fixes
- Setting number_lap to -1 is supposed to not limit the number of laps when using FollowPath, but the bot starts to rest after 1 round.

