### PR TITLE
Allow to use berry again only if capture failed

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -340,6 +340,7 @@ class PokemonCatchWorker(Datastore, BaseTask):
             if self.min_ultraball_to_keep >= 0 and self.min_ultraball_to_keep < min_ultraball_to_keep:
                 min_ultraball_to_keep = self.min_ultraball_to_keep
 
+        used_berry = False
         while True:
 
             # find lowest available ball
@@ -367,7 +368,6 @@ class PokemonCatchWorker(Datastore, BaseTask):
             berries_to_spare = berry_count > 0 if is_vip else berry_count > num_next_balls + 30
 
             # use a berry if we are under our ideal rate and have berries to spare
-            used_berry = False
             changed_ball = False
             if catch_rate_by_ball[current_ball] < ideal_catch_rate_before_throw and berries_to_spare:
                 new_catch_rate_by_ball = self._use_berry(berry_id, berry_count, encounter_id, catch_rate_by_ball, current_ball)
@@ -451,6 +451,7 @@ class PokemonCatchWorker(Datastore, BaseTask):
                     formatted='{pokemon} capture failed.. trying again!',
                     data={'pokemon': pokemon.name}
                 )
+                used_berry = False
 
                 # sleep according to flee_count and flee_duration config settings
                 # randomly chooses a number of times to 'show' wobble animation between 1 and flee_count

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -369,7 +369,7 @@ class PokemonCatchWorker(Datastore, BaseTask):
 
             # use a berry if we are under our ideal rate and have berries to spare
             changed_ball = False
-            if catch_rate_by_ball[current_ball] < ideal_catch_rate_before_throw and berries_to_spare:
+            if catch_rate_by_ball[current_ball] < ideal_catch_rate_before_throw and berries_to_spare and not used_berry:
                 new_catch_rate_by_ball = self._use_berry(berry_id, berry_count, encounter_id, catch_rate_by_ball, current_ball)
                 if new_catch_rate_by_ball != catch_rate_by_ball:
                     catch_rate_by_ball = new_catch_rate_by_ball


### PR DESCRIPTION
## Short Description:
I'm seeing the bot was throwing berry again after the ball had completely missed the pokemon:

> [pokemon_appeared] A wild Aerodactyl appeared! [CP 793] [NCP 0.37] [Potential 0.49] [A/D/S 6/1/15]
> [threw_berry] **Threw a Razz Berry!** Catch rate with Pokeball is now: 24.01
> [threw_pokeball] Nice Curveball throw! Used Greatball, with chance 34.53 (40 left)
> [pokemon_capture_failed] Pokeball thrown to Aerodactyl **missed**.. trying again!
> [threw_berry] **Threw a Razz Berry!** Catch rate with Pokeball is now: 36.01

However, that is not allowed in the game. One can only use berries again after capture had failed.