### PR TITLE
Fix "Fort out of range" when gps noise (xy) is enabled

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -42,6 +42,10 @@ class PokemonGoBot(Datastore):
     def position(self):
         return self.api.actual_lat, self.api.actual_lng, self.api.actual_alt
 
+    @property
+    def noised_position(self):
+        return self.api.noised_lat, self.api.noised_lng, self.api.noised_alt
+
     #@position.setter # these should be called through api now that gps replication is there...
     #def position(self, position_tuple):
     #    self.api._position_lat, self.api._position_lng, self.api._position_alt = position_tuple

--- a/pokemongo_bot/api_wrapper.py
+++ b/pokemongo_bot/api_wrapper.py
@@ -87,7 +87,7 @@ class ApiWrapper(Datastore, PGoApi):
             self.actual_alt = alt
         else:
             alt = self.actual_alt
-        
+
         if self.config.replicate_gps_xy_noise:
             lat_noise = gps_noise_rng(self.config.gps_xy_noise_range)
             lng_noise = gps_noise_rng(self.config.gps_xy_noise_range)
@@ -96,6 +96,9 @@ class ApiWrapper(Datastore, PGoApi):
         if self.config.replicate_gps_z_noise:
             alt_noise = gps_noise_rng(self.config.gps_z_noise_range)
             alt = alt + alt_noise
+
+        self.noised_lat, self.noised_lng, self.noised_alt = lat, lng, alt
+
         PGoApi.set_position(self, lat, lng, alt)
 
     def get_position(self):

--- a/pokemongo_bot/api_wrapper.py
+++ b/pokemongo_bot/api_wrapper.py
@@ -27,6 +27,7 @@ class ApiWrapper(Datastore, PGoApi):
         PGoApi.__init__(self)
         # Set to default, just for CI...
         self.actual_lat, self.actual_lng, self.actual_alt = PGoApi.get_position(self)
+        self.noised_lat, self.noised_lng, self.noised_alt = self.actual_lat, self.actual_lng, self.actual_alt
 
         self.useVanillaRequest = False
         self.config = config

--- a/pokemongo_bot/cell_workers/move_to_fort.py
+++ b/pokemongo_bot/cell_workers/move_to_fort.py
@@ -48,22 +48,22 @@ class MoveToFort(BaseTask):
 
         unit = self.bot.config.distance_unit  # Unit to use when printing formatted distance
 
-        if self.bot.config.replicate_gps_xy_noise:
-            dist = distance(
-                self.bot.noised_position[0],
-                self.bot.noised_position[1],
-                lat,
-                lng
-            )
-        else:
-            dist = distance(
-                self.bot.position[0],
-                self.bot.position[1],
-                lat,
-                lng
-            )
+        dist = distance(
+            self.bot.position[0],
+            self.bot.position[1],
+            lat,
+            lng
+        )
+        noised_dist = distance(
+            self.bot.noised_position[0],
+            self.bot.noised_position[1],
+            lat,
+            lng
+        )
 
-        if dist > Constants.MAX_DISTANCE_FORT_IS_REACHABLE:
+        moving = noised_dist > Constants.MAX_DISTANCE_FORT_IS_REACHABLE if self.bot.config.replicate_gps_xy_noise else dist > Constants.MAX_DISTANCE_FORT_IS_REACHABLE
+
+        if moving:
             fort_event_data = {
                 'fort_name': u"{}".format(fort_name),
                 'distance': format_dist(dist, unit),

--- a/pokemongo_bot/cell_workers/move_to_fort.py
+++ b/pokemongo_bot/cell_workers/move_to_fort.py
@@ -48,12 +48,20 @@ class MoveToFort(BaseTask):
 
         unit = self.bot.config.distance_unit  # Unit to use when printing formatted distance
 
-        dist = distance(
-            self.bot.position[0],
-            self.bot.position[1],
-            lat,
-            lng
-        )
+        if self.bot.config.replicate_gps_xy_noise:
+            dist = distance(
+                self.bot.noised_position[0],
+                self.bot.noised_position[1],
+                lat,
+                lng
+            )
+        else:
+            dist = distance(
+                self.bot.position[0],
+                self.bot.position[1],
+                lat,
+                lng
+            )
 
         if dist > Constants.MAX_DISTANCE_FORT_IS_REACHABLE:
             fort_event_data = {

--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -182,12 +182,20 @@ class SpinFort(Datastore, BaseTask):
     def get_forts_in_range(self):
         forts = self.bot.get_forts(order_by_distance=True)
         forts = filter(lambda fort: fort["id"] not in self.bot.fort_timeouts, forts)
-        forts = filter(lambda fort: distance(
-            self.bot.position[0],
-            self.bot.position[1],
-            fort['latitude'],
-            fort['longitude']
-        ) <= Constants.MAX_DISTANCE_FORT_IS_REACHABLE, forts)
+        if self.bot.config.replicate_gps_xy_noise:
+            forts = filter(lambda fort: distance(
+                self.bot.noised_position[0],
+                self.bot.noised_position[1],
+                fort['latitude'],
+                fort['longitude']
+            ) <= Constants.MAX_DISTANCE_FORT_IS_REACHABLE, forts)
+        else:
+            forts = filter(lambda fort: distance(
+                self.bot.position[0],
+                self.bot.position[1],
+                fort['latitude'],
+                fort['longitude']
+            ) <= Constants.MAX_DISTANCE_FORT_IS_REACHABLE, forts)
 
         return forts
 


### PR DESCRIPTION
Distance to the fort should be calculated from noised location, not the actual one. Otherwise bot tries to spin fort, but it is out of range for first several tries.