### PR TITLE
not always snipe vip pokemon if using snipe_high_prio_threshold

### DIFF
--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -271,7 +271,7 @@ class MoveToMapPokemon(BaseTask):
 
         if self.config['snipe']:
             if self.snipe_high_prio_only:
-                if self.snipe_high_prio_threshold < pokemon['priority'] or pokemon['is_vip']:
+                if self.snipe_high_prio_threshold < pokemon['priority']:
                     self.snipe(pokemon)
             else:
                 return self.snipe(pokemon)


### PR DESCRIPTION
## Short Description:
- I think we don't need to always snipe vip pokemon, if that pokemon is needed for sniping, it should have higher priority than threshold. By that we can sure vip pokemon is till catch with Berry & Best Ball but no need to snipe (avoid ban)