### PR TITLE
Fix for catch worker no usable ball loop

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -352,7 +352,7 @@ class PokemonCatchWorker(Datastore, BaseTask):
                     maximum_ball = ITEM_ULTRABALL
                     continue
                 else:
-                    break
+                    return WorkerResult.ERROR
 
             # check future ball count
             num_next_balls = 0


### PR DESCRIPTION
If we run out of pokeballs while in the catch worker, we were getting into an endless loop. 

Now returning an error to stop the process. 

Closes #4533