### PR TITLE
Fix for catch worker no usable ball loop

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -150,15 +150,15 @@ def main():
                     level='info',
                     formatted='Server is throttling, reconnecting in 30 seconds'
                 )
+            except PermaBannedException:
+                 bot.event_manager.emit(
+                    'api_error',
+                    sender=bot,
+                    level='info',
+                    formatted='Probably permabanned, Game Over ! Play again at https://club.pokemon.com/us/pokemon-trainer-club/sign-up/'
+                 )
                 time.sleep(30)
 
-    except PermaBannedException:
-         bot.event_manager.emit(
-            'api_error',
-            sender=bot,
-            level='info',
-            formatted='Probably permabanned, Game Over ! Play again at https://club.pokemon.com/us/pokemon-trainer-club/sign-up/'
-         )
     except GeocoderQuotaExceeded:
         raise Exception("Google Maps API key over requests limit.")
     except SIGINTRecieved:

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -355,7 +355,7 @@ class PokemonCatchWorker(Datastore, BaseTask):
                     maximum_ball = ITEM_ULTRABALL
                     continue
                 else:
-                    break
+                    return WorkerResult.ERROR
 
             # check future ball count
             num_next_balls = 0


### PR DESCRIPTION
If we run out of pokeballs while in the catch worker, we were getting into an endless loop.

Now returning an error to stop the process.

Closes #4533