### PR TITLE
Fix no usable ball loop

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -150,15 +150,15 @@ def main():
                     level='info',
                     formatted='Server is throttling, reconnecting in 30 seconds'
                 )
-            except PermaBannedException:
-                 bot.event_manager.emit(
-                    'api_error',
-                    sender=bot,
-                    level='info',
-                    formatted='Probably permabanned, Game Over ! Play again at https://club.pokemon.com/us/pokemon-trainer-club/sign-up/'
-                 )
                 time.sleep(30)
 
+    except PermaBannedException:
+         bot.event_manager.emit(
+            'api_error',
+            sender=bot,
+            level='info',
+            formatted='Probably permabanned, Game Over ! Play again at https://club.pokemon.com/us/pokemon-trainer-club/sign-up/'
+         )
     except GeocoderQuotaExceeded:
         raise Exception("Google Maps API key over requests limit.")
     except SIGINTRecieved:

--- a/pokecli.py
+++ b/pokecli.py
@@ -150,15 +150,15 @@ def main():
                     level='info',
                     formatted='Server is throttling, reconnecting in 30 seconds'
                 )
+            except PermaBannedException:
+                 bot.event_manager.emit(
+                    'api_error',
+                    sender=bot,
+                    level='info',
+                    formatted='Probably permabanned, Game Over ! Play again at https://club.pokemon.com/us/pokemon-trainer-club/sign-up/'
+                 )
                 time.sleep(30)
 
-    except PermaBannedException:
-         bot.event_manager.emit(
-            'api_error',
-            sender=bot,
-            level='info',
-            formatted='Probably permabanned, Game Over ! Play again at https://club.pokemon.com/us/pokemon-trainer-club/sign-up/'
-         )
     except GeocoderQuotaExceeded:
         raise Exception("Google Maps API key over requests limit.")
     except SIGINTRecieved:

--- a/pokemongo_bot/cell_workers/catch_pokemon.py
+++ b/pokemongo_bot/cell_workers/catch_pokemon.py
@@ -31,7 +31,10 @@ class CatchPokemon(BaseTask):
         num_pokemon = len(pokemon)
         if num_pokemon > 0:
             pokemon = self.sort_pokemon(pokemon)
-            self.catch_pokemon(pokemon[0])
+            
+            if self.catch_pokemon(pokemon[0]) == WorkerResult.ERROR:
+                return WorkerResult.ERROR
+            
             if num_pokemon > 1:
                 return WorkerResult.RUNNING
 

--- a/pokemongo_bot/cell_workers/catch_pokemon.py
+++ b/pokemongo_bot/cell_workers/catch_pokemon.py
@@ -34,8 +34,7 @@ class CatchPokemon(BaseTask):
             
             if self.catch_pokemon(pokemon[0]) == WorkerResult.ERROR:
                 return WorkerResult.ERROR
-            
-            if num_pokemon > 1:
+            elif num_pokemon > 1:
                 return WorkerResult.RUNNING
 
         return WorkerResult.SUCCESS

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -111,9 +111,9 @@ class PokemonCatchWorker(Datastore, BaseTask):
         if inventory.items().get(ITEM_POKEBALL).count < 1:
             if inventory.items().get(ITEM_GREATBALL).count < 1:
                 if inventory.items().get(ITEM_ULTRABALL).count < 1:
-                    return WorkerResult.SUCCESS
+                    return WorkerResult.ERROR
                 elif (not is_vip) and inventory.items().get(ITEM_ULTRABALL).count <= self.min_ultraball_to_keep:
-                    return WorkerResult.SUCCESS
+                    return WorkerResult.ERROR
 
         # log encounter
         self.emit_event(


### PR DESCRIPTION
- Kill catch task if catch worker returns error
- Return error in catch worker if not enough usable balls

Closes #4533 

We could do something more robust, but I don't want to have too much interlink between the workers. I think just returning an error to our catch task is the best decoupled approach. 