### PR TITLE
Fix for lure pokemon loop

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -150,15 +150,15 @@ def main():
                     level='info',
                     formatted='Server is throttling, reconnecting in 30 seconds'
                 )
-            except PermaBannedException:
-                 bot.event_manager.emit(
-                    'api_error',
-                    sender=bot,
-                    level='info',
-                    formatted='Probably permabanned, Game Over ! Play again at https://club.pokemon.com/us/pokemon-trainer-club/sign-up/'
-                 )
                 time.sleep(30)
 
+    except PermaBannedException:
+         bot.event_manager.emit(
+            'api_error',
+            sender=bot,
+            level='info',
+            formatted='Probably permabanned, Game Over ! Play again at https://club.pokemon.com/us/pokemon-trainer-club/sign-up/'
+         )
     except GeocoderQuotaExceeded:
         raise Exception("Google Maps API key over requests limit.")
     except SIGINTRecieved:

--- a/pokecli.py
+++ b/pokecli.py
@@ -150,15 +150,15 @@ def main():
                     level='info',
                     formatted='Server is throttling, reconnecting in 30 seconds'
                 )
+            except PermaBannedException:
+                 bot.event_manager.emit(
+                    'api_error',
+                    sender=bot,
+                    level='info',
+                    formatted='Probably permabanned, Game Over ! Play again at https://club.pokemon.com/us/pokemon-trainer-club/sign-up/'
+                 )
                 time.sleep(30)
 
-    except PermaBannedException:
-         bot.event_manager.emit(
-            'api_error',
-            sender=bot,
-            level='info',
-            formatted='Probably permabanned, Game Over ! Play again at https://club.pokemon.com/us/pokemon-trainer-club/sign-up/'
-         )
     except GeocoderQuotaExceeded:
         raise Exception("Google Maps API key over requests limit.")
     except SIGINTRecieved:

--- a/pokemongo_bot/cell_workers/catch_pokemon.py
+++ b/pokemongo_bot/cell_workers/catch_pokemon.py
@@ -25,12 +25,12 @@ class CatchPokemon(BaseTask):
         pokemon = []
         if self.config.get('catch_visible_pokemon', True):
             pokemon = self.get_visible_pokemon()
+            pokemon = self.sort_pokemon(pokemon)
         if self.config.get('catch_lured_pokemon', True):
             pokemon += self.get_lured_pokemon()
 
         num_pokemon = len(pokemon)
         if num_pokemon > 0:
-            pokemon = self.sort_pokemon(pokemon)
             self.catch_pokemon(pokemon[0])
             if num_pokemon > 1:
                 return WorkerResult.RUNNING


### PR DESCRIPTION
There is a glitch with the catch task that is resulting in continually targeting a different lured location on each call. I moved the sorting function so we're leaving catch lured pokemon closer to it's original code. 

Trying to fix #4541 

If anyone has any input on the issue, that'd be great. The original placement of the sort was hoping we'd have all pokemon in our area sorted by their distance to us. But somewhere along the line, we're moving around a little bit and not getting anywhere. Apart from the pokemon/stops being close enough, why would distance even matter here? We aren't setting position or calling our walkers. I'm tired...