### PR TITLE
alt_min to lowest land altitude

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -632,8 +632,8 @@ def init_config():
         parser.error("--walk_min is out of range! (should be >= 1.0)")
         return None
 
-    if config.alt_min < 0:
-        parser.error("--alt_min is out of range! (should be >= 0.0)")
+    if config.alt_min < -413.0:
+        parser.error("--alt_min is out of range! (should be >= -413.0)")
         return None
 
     if not (config.location or config.location_cache):


### PR DESCRIPTION
Previously required alt_min be at least 0.
Set it to the lowest land altitude on Earth (-413.0m).