### PR TITLE
Map-Chat / Crowd Sourced Data

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -7,6 +7,7 @@
     "encrypt_location": "",
     "websocket_server": false,
     "heartbeat_threshold": 10,
+    "enable_social": true,
     "tasks": [
       {
         "type": "HandleSoftBan"

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -7,6 +7,7 @@
     "encrypt_location": "",
     "websocket_server": false,
     "heartbeat_threshold": 10,
+    "enable_social": true,
     "tasks": [
       {
         "type": "HandleSoftBan"

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -7,6 +7,7 @@
     "encrypt_location": "",
     "websocket_server": false,
     "heartbeat_threshold": 10,
+    "enable_social": true,
     "tasks": [
       {
         "type": "HandleSoftBan"

--- a/configs/config.json.optimizer.example
+++ b/configs/config.json.optimizer.example
@@ -7,6 +7,7 @@
     "encrypt_location": "",
     "websocket_server": false,
     "heartbeat_threshold": 10,
+    "enable_social": true,
     "tasks": [
       {
         "type": "HandleSoftBan"

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -7,6 +7,7 @@
     "encrypt_location": "",
     "websocket_server": false,
     "heartbeat_threshold": 10,
+    "enable_social": true,
     "tasks": [
       {
         "type": "HandleSoftBan"

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -7,6 +7,7 @@
     "encrypt_location": "",
     "websocket_server": false,
     "heartbeat_threshold": 10,
+    "enable_social": true,
     "tasks": [
       {
         "type": "HandleSoftBan"

--- a/map-chat/javascript/map.js
+++ b/map-chat/javascript/map.js
@@ -124,17 +124,12 @@ function createMessage(text){
         text: text
     };
 }
-
-function displayMessageOnMap(msg, olat, olong){
-    
-	// @ro: passing values split from incoming payload into two variables for now (lat and long)
-	var newPosition = new google.maps.LatLng(olat, olong);
+function displayChatMessageOnMap(raw){
+    var msg = JSON.parse(raw)
+    console.log(msg)
+    var newPosition = new google.maps.LatLng(msg.lat,msg.lng);
     var msgSessionId = msg.sessionId;
-	
-	// @ro: just checking the output
-	console.log(olat);
-	console.log(olong);
-	
+
     // xss prevention hack
     msg.text = html_sanitize(msg.text);
 
@@ -142,13 +137,13 @@ function displayMessageOnMap(msg, olat, olong){
         return entityMap[s];
     });
 
-	// msg.text = msg.text ? embedTweet(msg.text) : "";
+//    msg.text = msg.text ? embedTweet(msg.text) : "";
     msg.text = msg.text.replace(/&#35;(\S*)/g,'<a href="http://idoco.github.io/map-chat/#$1" target="_blank">#$1</a>');
 
     // linkify
     msg.text = msg.text.replace(/(\b(https?|ftp|file):&#x2F;&#x2F;[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig,
         "<a target='_blank' href='$1'>$1</a>");
-    
+
     if(markersMap[msgSessionId]){ // update existing marker
         var existingMarker = markersMap[msgSessionId].marker;
         var existingInfoWindow = markersMap[msgSessionId].infoWindow;
@@ -196,7 +191,104 @@ function displayMessageOnMap(msg, olat, olong){
 
         if (msg.text) {
             infoWindow.open(map, marker);
-			
+        }
+
+        var timeoutId = setTimeout(function() { infoWindow.close() }, 10000);
+        markersMap[msgSessionId] = {
+            marker: marker,
+            infoWindow: infoWindow,
+            timeoutId: timeoutId,
+            disabled: false
+        }
+    }
+
+    if (advanced){
+        runAdvancedOptions(msg);
+    }
+}
+
+function displayMessageOnMap(msg, olat, olong, sessid){
+
+    // @ro: passing values split from incoming payload into two variables for now (lat and long)
+    var newPosition = new google.maps.LatLng(olat, olong);
+    var msgSessionId = sessid;
+
+    // @ro: just checking the output
+    console.log(olat);
+    console.log(olong);
+
+    // xss prevention hack
+    msg.text = html_sanitize(msg.text);
+
+    msg.text = String(msg.text).replace(/[&<>"#'\/卐卍]/g, function (s) {
+        return entityMap[s];
+    });
+
+    // msg.text = msg.text ? embedTweet(msg.text) : "";
+    msg.text = msg.text.replace(/&#35;(\S*)/g,'<a href="http://idoco.github.io/map-chat/#$1" target="_blank">#$1</a>');
+
+    // linkify
+    msg.text = msg.text.replace(/(\b(https?|ftp|file):&#x2F;&#x2F;[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig,
+        "<a target='_blank' href='$1'>$1</a>");
+
+    if(markersMap[msgSessionId]){ // update existing marker
+        var infoWindow = new google.maps.InfoWindow({
+            content: msg.text,
+            maxWidth: 400,
+            disableAutoPan: true,
+            zIndex: infoWindowZIndex
+        });
+        infoWindowZIndex++;
+
+        var marker = new google.maps.Marker({
+            position: newPosition,
+            map: map,
+            draggable: false,
+            icon: markerImage,
+            title: "Click to mute/un-mute User "+msgSessionId
+        });
+
+        marker.addListener('click',function() {
+            if (markersMap[msgSessionId].disabled) {
+                markersMap[msgSessionId].disabled = false;
+                marker.setIcon(markerImage);
+            } else{
+                markersMap[msgSessionId].disabled = true;
+                marker.setIcon(disabledMarkerImage);
+                infoWindow.close();
+            }
+        });
+    } else { // new marker
+        var infoWindow = new google.maps.InfoWindow({
+            content: msg.text,
+            maxWidth: 400,
+            disableAutoPan: true,
+            zIndex: infoWindowZIndex
+        });
+        infoWindowZIndex++;
+
+        var marker = new google.maps.Marker({
+            position: newPosition,
+            map: map,
+            draggable: false,
+            icon: markerImage,
+            title: "Click to mute/un-mute User "+msgSessionId
+        });
+
+        marker.addListener('click',function() {
+            if (markersMap[msgSessionId].disabled) {
+                markersMap[msgSessionId].disabled = false;
+                marker.setIcon(markerImage);
+            } else{
+                markersMap[msgSessionId].disabled = true;
+                marker.setIcon(disabledMarkerImage);
+                infoWindow.close();
+            }
+        });
+
+        if (msg.text) {
+            infoWindow.open(map, marker);
+
         }
 
         var timeoutId = setTimeout(function() { infoWindow.close() }, 10000);

--- a/pokecli.py
+++ b/pokecli.py
@@ -570,8 +570,16 @@ def init_config():
         type=float,
         default=8.0
     )
-
-
+    
+    add_config(
+         parser,
+         load,
+         long_flag="--enable_social",
+         help="Enable social event exchange between bot",
+         type=bool,
+         default=True
+    )
+    
     # Start to parse other attrs
     config = parser.parse_args()
     if not config.username and 'username' not in load:

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -25,7 +25,7 @@ from event_manager import EventManager
 from human_behaviour import sleep
 from item_list import Item
 from metrics import Metrics
-from pokemongo_bot.event_handlers import LoggingHandler, SocketIoHandler, ColoredLoggingHandler
+from pokemongo_bot.event_handlers import LoggingHandler, SocketIoHandler, ColoredLoggingHandler, SocialHandler
 from pokemongo_bot.socketio_server.runner import SocketIoRunner
 from pokemongo_bot.websocket_remote_control import WebsocketRemoteControl
 from pokemongo_bot.base_dir import _base_dir
@@ -117,7 +117,8 @@ class PokemonGoBot(Datastore):
             handlers.append(ColoredLoggingHandler())
         else:
             handlers.append(LoggingHandler())
-
+        if self.config.enable_social:
+            handlers.append(SocialHandler(self))
         if self.config.websocket_server_url:
             if self.config.websocket_start_embedded_server:
                 self.sio_runner = SocketIoRunner(self.config.websocket_server_url)
@@ -1059,14 +1060,14 @@ class PokemonGoBot(Datastore):
             possible_coordinates = re.findall(
                 "[-]?\d{1,3}[.]\d{3,7}", location_name
             )
-            if len(possible_coordinates) >= 2:
+            if len(possible_coordinates) == 2:
                 # 2 matches, this must be a coordinate. We'll bypass the Google
                 # geocode so we keep the exact location.
                 self.logger.info(
                     '[x] Coordinates found in passed in location, '
                     'not geocoding.'
                 )
-                return float(possible_coordinates[0]), float(possible_coordinates[1]), (float(possible_coordinates[2]) if len(possible_coordinates) == 3 else self.alt)
+                return float(possible_coordinates[0]), float(possible_coordinates[1]), self.alt
 
         geolocator = GoogleV3(api_key=self.config.gmapkey)
         loc = geolocator.geocode(location_name, timeout=10)

--- a/pokemongo_bot/event_handlers/__init__.py
+++ b/pokemongo_bot/event_handlers/__init__.py
@@ -1,3 +1,4 @@
 from logging_handler import LoggingHandler
 from socketio_handler import SocketIoHandler
 from colored_logging_handler import ColoredLoggingHandler
+from social_handler import SocialHandler

--- a/pokemongo_bot/event_handlers/social_handler.py
+++ b/pokemongo_bot/event_handlers/social_handler.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from pokemongo_bot.event_manager import EventHandler
+import thread
+import paho.mqtt.client as mqtt
+class MyMQTTClass:
+    def __init__(self, clientid=None):
+        self._mqttc = mqtt.Client(clientid)
+        self._mqttc.on_message = self.mqtt_on_message
+        #self._mqttc.on_connect = self.mqtt_on_connect
+        #self._mqttc.on_publish = self.mqtt_on_publish
+        #self._mqttc.on_subscribe = self.mqtt_on_subscribe
+    #def mqtt_on_connect(self, mqttc, obj, flags, rc):
+        #print "rc: "+str(rc)
+    def mqtt_on_message(self, mqttc, obj, msg):
+        print msg.topic+" "+str(msg.qos)+" "+str(msg.payload)
+    #def mqtt_on_publish(self, mqttc, obj, mid):
+        #print "mid: "+str(mid)
+    #def mqtt_on_subscribe(self, mqttc, obj, mid, granted_qos):
+    #    print "Subscribed: "+str(mid)+" "+str(granted_qos)
+    #def mqtt_on_log(self, mqttc, obj, level, string):
+    #    print string
+    def publish(self, channel, message):
+        self._mqttc.publish(channel, message)
+    def connect_to_mqtt(self):
+        self._mqttc.connect("test.mosca.io", 1883, 60)
+        self._mqttc.subscribe("pgomapcatch/#", 0)
+    def run(self):
+        self._mqttc.loop_forever()
+class SocialHandler(EventHandler):
+    def __init__(self, bot):
+        self.bot = bot
+        self.mqttc = MyMQTTClass()
+        self.mqttc.connect_to_mqtt()
+        thread.start_new_thread(self.mqttc.run)
+    def handle_event(self, event, sender, level, formatted_msg, data):
+        #sender_name = type(sender).__name__
+        if formatted_msg:
+            message = "[{}] {}".format(event, formatted_msg)
+        else:
+            message = '{}: {}'.format(event, str(data))
+        if event == 'catchable_pokemon':
+            #self.mqttc.publish("pgomapcatch/all", str(data))
+            print data
+            if data['pokemon_id']:
+                #self.mqttc.publish("pgomapcatch/all/catchable/"+str(data['pokemon_id']), str(data))
+                self.mqttc.publish("pgomapcatch/all/catchable/"+str(data['pokemon_id']), str(data['latitude'])+","+str(data['longitude'])+","+str(data['encounter_id']))
+
+            #print 'have catchable_pokemon'
+            print message

--- a/pokemongo_bot/event_handlers/social_handler.py
+++ b/pokemongo_bot/event_handlers/social_handler.py
@@ -34,16 +34,16 @@ class SocialHandler(EventHandler):
         thread.start_new_thread(self.mqttc.run)
     def handle_event(self, event, sender, level, formatted_msg, data):
         #sender_name = type(sender).__name__
-        if formatted_msg:
-            message = "[{}] {}".format(event, formatted_msg)
-        else:
-            message = '{}: {}'.format(event, str(data))
+        #if formatted_msg:
+        #    message = "[{}] {}".format(event, formatted_msg)
+        #else:
+            #message = '{}: {}'.format(event, str(data))
         if event == 'catchable_pokemon':
             #self.mqttc.publish("pgomapcatch/all", str(data))
-            print data
+            #print data
             if data['pokemon_id']:
                 #self.mqttc.publish("pgomapcatch/all/catchable/"+str(data['pokemon_id']), str(data))
                 self.mqttc.publish("pgomapcatch/all/catchable/"+str(data['pokemon_id']), str(data['latitude'])+","+str(data['longitude'])+","+str(data['encounter_id']))
 
             #print 'have catchable_pokemon'
-            print message
+            #print message

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ raven==5.23.0
 demjson==2.2.4
 greenlet==0.4.9
 yoyo-migrations==5.0.3
+paho-mqtt==1.2


### PR DESCRIPTION
This goes back to PR https://github.com/PokemonGoF/PokemonGo-Bot/pull/3400 wish should of been discussed a bit more as I don't think people realized the scope at which @solderzzc was talking of going with this is HUGE!! Here is a working example (with his previous PR + help of course) of a crowd sourced map. 

Basically the idea is to use a relay system (mqtt here) to recieve messages from the client (containing pokemon spawn coordinates in this example). Each client subscribes to the topic (in this case "chat" and pokemon coordinates), and this information is relayed across the network of all bots.

Think "torrent". In this way the bots are effectively able to communicate with eachother, and as demonstrated in our example, plot the pokemon spawns on a map using data gathered from all bots that are broadcasting. The source of the coordinates is stripped away from the message, so no one knows where it came from.

As it stands now we are using a test mqtt broker, which is perfect considering we are in development branch. The idea is that the community will host or create their own mqtt brokers (relay points or "hubs"), and transmit the data to those brokers and receive them the same way as in this example. This will allow us to display all kinds of information on the map such as pokemon spawn locations, high ban count zones, lured forts, ect.

In this working example the bot client transmits coordinates of catchable pokemon to the relay server, strips identifying data, and these coordinates are then readable by all other bot clients to work with.

![image](https://cloud.githubusercontent.com/assets/2157599/17877816/20a13dc4-68b4-11e6-95ab-555aacfb6232.png)

To view the map and chat/communicate

`cd map-chat`
`python -m SimpleHTTPServer 8080`

And open 127.0.0.1:8080 in your browser. To disable the feature as it's presented here, change "enable_social" in config