### PR TITLE
Added a config option for "Treat as VIP missing Pokemon in Pokedex"

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -115,6 +115,7 @@
 	        "min_ultraball_to_keep": 5,
 	        "berry_threshold": 0.35,
 	        "vip_berry_threshold": 0.9,
+	        "treat_unseen_as_vip": true,
 	        "catch_throw_parameters": {
 	          "excellent_rate": 0.1,
 	          "great_rate": 0.5,

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -128,6 +128,7 @@
           "min_ultraball_to_keep": 5,
           "berry_threshold": 0.35,
           "vip_berry_threshold": 0.9,
+          "treat_unseen_as_vip": true,
           "catch_throw_parameters": {
             "excellent_rate": 0.1,
             "great_rate": 0.5,

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -115,6 +115,7 @@
 	        "min_ultraball_to_keep": 5,
 	        "berry_threshold": 0.35,
 	        "vip_berry_threshold": 0.9,
+	        "treat_unseen_as_vip": true,
 	        "catch_throw_parameters": {
 	          "excellent_rate": 0.1,
 	          "great_rate": 0.5,

--- a/configs/config.json.optimizer.example
+++ b/configs/config.json.optimizer.example
@@ -179,6 +179,7 @@
             "min_ultraball_to_keep": 5,
             "berry_threshold": 0.35,
             "vip_berry_threshold": 0.9,
+            "treat_unseen_as_vip": true,
             "catch_throw_parameters": {
               "excellent_rate": 0.1,
               "great_rate": 0.5,

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -115,6 +115,7 @@
           "min_ultraball_to_keep": 5,
           "berry_threshold": 0.35,
           "vip_berry_threshold": 0.9,
+          "treat_unseen_as_vip": true,
           "catch_throw_parameters": {
             "excellent_rate": 0.1,
             "great_rate": 0.5,

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -115,6 +115,7 @@
 	        "min_ultraball_to_keep": 5,
 	        "berry_threshold": 0.35,
 	        "vip_berry_threshold": 0.9,
+	        "treat_unseen_as_vip": true,
 	        "catch_throw_parameters": {
 	          "excellent_rate": 0.1,
 	          "great_rate": 0.5,

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -91,6 +91,7 @@ The behaviors of the bot are configured via the `tasks` key in the `config.json`
 ### Task Options:
 [[back to top](#table-of-contents)]
 * CatchPokemon
+  * `treat_unseen_as_vip`: Default `"true"` | Set to `"false"` to disable treating pokemons you don't have in your pokedex as VIPs.
 * EvolvePokemon
   * `evolve_all`: Default `NONE` | Set to `"all"` to evolve Pokémon if possible when the bot starts. Can also be set to individual Pokémon as well as multiple separated by a comma. e.g "Pidgey,Rattata,Weedle,Zubat"
   * `evolve_speed`: Default `20`

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -29,6 +29,8 @@ ITEM_GREATBALL = 2
 ITEM_ULTRABALL = 3
 ITEM_RAZZBERRY = 701
 
+DEFAULT_UNSEEN_AS_VIP = True
+
 LOGIC_TO_FUNCTION = {
     'or': lambda x, y, z: x or y or z,
     'and': lambda x, y, z: x and y and z,
@@ -57,6 +59,7 @@ class PokemonCatchWorker(Datastore, BaseTask):
         self.min_ultraball_to_keep = self.config.get('min_ultraball_to_keep', 10)
         self.berry_threshold = self.config.get('berry_threshold', 0.35)
         self.vip_berry_threshold = self.config.get('vip_berry_threshold', 0.9)
+        self.treat_unseen_as_vip = self.config.get('treat_unseen_as_vip', DEFAULT_UNSEEN_AS_VIP)
 
         self.catch_throw_parameters = self.config.get('catch_throw_parameters', {})
         self.catch_throw_parameters_spin_success_rate = self.catch_throw_parameters.get('spin_success_rate', 0.6)
@@ -243,8 +246,8 @@ class PokemonCatchWorker(Datastore, BaseTask):
 
     def _is_vip_pokemon(self, pokemon):
         # having just a name present in the list makes them vip
-        # Not seen pokemons also will become vip
-        if self.bot.config.vips.get(pokemon.name) == {} or not self.pokedex.seen(pokemon.pokemon_id):
+        # Not seen pokemons also will become vip if it's not disabled in config
+        if self.bot.config.vips.get(pokemon.name) == {} or (self.treat_unseen_as_vip and not self.pokedex.seen(pokemon.pokemon_id)):
             return True
         return self._pokemon_matches_config(self.bot.config.vips, pokemon, default_logic='or')
 


### PR DESCRIPTION
## Short Description:
Adds a config option for #4580 in the CatchPokemon task : `treat_unseen_as_vip`, defaulting to true (current behaviour).
Added info to the docs.