### PR TITLE
'all' in 'release' config discards all pokemon except N best (Closes #4552)

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -107,33 +107,33 @@
           "recycle_wait_max": 4
         }
       },
-	    {
-	      "type": "CatchPokemon",
-	      "config": {
-	        "catch_visible_pokemon": true,
-	        "catch_lured_pokemon": true,
-	        "min_ultraball_to_keep": 5,
-	        "berry_threshold": 0.35,
-	        "vip_berry_threshold": 0.9,
-	        "catch_throw_parameters": {
-	          "excellent_rate": 0.1,
-	          "great_rate": 0.5,
-	          "nice_rate": 0.3,
-	          "normal_rate": 0.1,
-	          "spin_success_rate" : 0.6
-	        },
-				  "catch_simulation": {
-				    "flee_count": 3,
-				    "flee_duration": 2,
-				    "catch_wait_min": 2,
-				    "catch_wait_max": 6,
-				    "berry_wait_min": 2,
-				    "berry_wait_max": 3,
-				    "changeball_wait_min": 2,
-				    "changeball_wait_max": 3
-				  }
-	      }
-	    },
+      {
+        "type": "CatchPokemon",
+        "config": {
+          "catch_visible_pokemon": true,
+          "catch_lured_pokemon": true,
+          "min_ultraball_to_keep": 5,
+          "berry_threshold": 0.35,
+          "vip_berry_threshold": 0.9,
+          "catch_throw_parameters": {
+            "excellent_rate": 0.1,
+            "great_rate": 0.5,
+            "nice_rate": 0.3,
+            "normal_rate": 0.1,
+            "spin_success_rate" : 0.6
+          },
+          "catch_simulation": {
+            "flee_count": 3,
+            "flee_duration": 2,
+            "catch_wait_min": 2,
+            "catch_wait_max": 6,
+            "berry_wait_min": 2,
+            "berry_wait_max": 3,
+            "changeball_wait_min": 2,
+            "changeball_wait_max": 3
+          }
+        }
+      },
       {
         "type": "SpinFort",
         "config": {
@@ -191,8 +191,10 @@
       "// Pidgey": {"keep_best_cp": 3},
       "// Example of keeping 2 stronger (based on IV) Zubat:": {},
       "// Zubat": {"keep_best_iv": 2},
-      "// Also, it is working with any": {},
+      "// Keep no more than 3 best IV pokemon for every pokemon type": {},
       "// any": {"keep_best_iv": 3},
+      "// Discard all pokemon in bag except 100 pokemon with best CP": {},
+      "// all": {"keep_best_cp": 100},
       "// Example of keeping the 2 strongest (based on CP) and 3 best (based on IV) Zubat:": {},
       "// Zubat": {"keep_best_cp": 2, "keep_best_iv": 3}
     },

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -49,8 +49,8 @@
         "config": {
           "longer_eggs_first": true,
           "min_interval": 120,
-		  "infinite": [2,5,10],
-		  "breakable": [2,5,10]
+         "infinite": [2,5,10],
+         "breakable": [2,5,10]
         }
       },
       {
@@ -219,12 +219,14 @@
       "// Pidgey": {"keep_best_cp": 3},
       "// Example of keeping 2 best (based on IV) Zubat:": {},
       "// Zubat": {"keep_best_iv": 2},
-      "// Also, it is working with any": {},
+      "// Keep no more than 3 best IV pokemon for every pokemon type": {},
       "// any": {"keep_best_iv": 3},
+      "// Discard all pokemon in bag except 100 pokemon with best CP": {},
+      "// all": {"keep_best_cp": 100},
       "// Example of keeping the 2 strongest (based on CP) and 3 best (based on IV) Zubat:": {},
       "// Zubat": {"keep_best_cp": 2, "keep_best_iv": 3},
-	  "// Example of custom order of static criterion": {},
-	  "// Zubat": {"keep_best_custom": "iv, cp, hp_max", "amount":2}
+      "// Example of custom order of static criterion": {},
+      "// Zubat": {"keep_best_custom": "iv, cp, hp_max", "amount":2}
     },
     "vips" : {
         "Any pokemon put here directly force to use Berry & Best Ball to capture, to secure the capture rate!": {},

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -107,33 +107,33 @@
           "recycle_wait_max": 4
         }
       },
-	    {
-	      "type": "CatchPokemon",
-	      "config": {
-	        "catch_visible_pokemon": true,
-	        "catch_lured_pokemon": true,
-	        "min_ultraball_to_keep": 5,
-	        "berry_threshold": 0.35,
-	        "vip_berry_threshold": 0.9,
-	        "catch_throw_parameters": {
-	          "excellent_rate": 0.1,
-	          "great_rate": 0.5,
-	          "nice_rate": 0.3,
-	          "normal_rate": 0.1,
-	          "spin_success_rate" : 0.6
-	        },
-				  "catch_simulation": {
-				    "flee_count": 3,
-				    "flee_duration": 2,
-				    "catch_wait_min": 2,
-				    "catch_wait_max": 6,
-				    "berry_wait_min": 2,
-				    "berry_wait_max": 3,
-				    "changeball_wait_min": 2,
-				    "changeball_wait_max": 3
-				  }
-	      }
-	    },
+      {
+        "type": "CatchPokemon",
+        "config": {
+          "catch_visible_pokemon": true,
+          "catch_lured_pokemon": true,
+          "min_ultraball_to_keep": 5,
+          "berry_threshold": 0.35,
+          "vip_berry_threshold": 0.9,
+          "catch_throw_parameters": {
+            "excellent_rate": 0.1,
+            "great_rate": 0.5,
+            "nice_rate": 0.3,
+            "normal_rate": 0.1,
+            "spin_success_rate" : 0.6
+          },
+          "catch_simulation": {
+            "flee_count": 3,
+            "flee_duration": 2,
+            "catch_wait_min": 2,
+            "catch_wait_max": 6,
+            "berry_wait_min": 2,
+            "berry_wait_max": 3,
+            "changeball_wait_min": 2,
+            "changeball_wait_max": 3
+          }
+        }
+      },
       {
         "type": "SpinFort",
         "config": {
@@ -445,8 +445,10 @@
       "// Pidgey": {"keep_best_cp": 3},
       "// Example of keeping 2 stronger (based on IV) Zubat:": {},
       "// Zubat": {"keep_best_iv": 2},
-      "// Also, it is working with any": {},
+      "// Keep no more than 3 best IV pokemon for every pokemon type": {},
       "// any": {"keep_best_iv": 3},
+      "// Discard all pokemon in bag except 100 pokemon with best CP": {},
+      "// all": {"keep_best_cp": 100},
       "// Example of keeping the 2 strongest (based on CP) and 3 best (based on IV) Zubat:": {},
       "// Zubat": {"keep_best_cp": 2, "keep_best_iv": 3}
     },

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -195,8 +195,10 @@
       "// Pidgey": {"keep_best_cp": 3},
       "// Example of keeping 2 stronger (based on IV) Zubat:": {},
       "// Zubat": {"keep_best_iv": 2},
-      "// Also, it is working with any": {},
+      "// Keep no more than 3 best IV pokemon for every pokemon type": {},
       "// any": {"keep_best_iv": 3},
+      "// Discard all pokemon in bag except 100 pokemon with best CP": {},
+      "// all": {"keep_best_cp": 100},
       "// Example of keeping the 2 strongest (based on CP) and 3 best (based on IV) Zubat:": {},
       "// Zubat": {"keep_best_cp": 2, "keep_best_iv": 3}
     }

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -242,7 +242,10 @@ If you don't have it, it will keep it (no matter was it strong or weak Pokémon)
 
 If you already have it, it will keep a stronger version and will transfer the a weaker one.
 
-```"release": {"any": {"keep_best_cp": 2}}```, ```"release": {"any": {"keep_best_cp": 10}}``` - can be any number.
+```"release": {"any": {"keep_best_cp": 2}}```, ```"release": {"any": {"keep_best_cp": 10}}``` - can be any number. In the latter case for every pokemon type bot will keep no more that 10 best CP pokemon.
+
+If you wish to limit your pokemon bag as a whole, not type-wise, use `all`:
+```"release": {"all": {"keep_best_cp": 200}}```. In this case bot looks for 200 best CP pokemon in bag independently of their type. For example, if you have 150 Snorlax with 1500 CP and 100 Pidgeys with CP 100, bot will keep 150 Snorlax and 50 Pidgeys for a total of 200 best CP pokemon.
 
 ### Keep the best custom pokemon configuration (dev branch)
 [[back to top](#table-of-contents)]
@@ -532,7 +535,7 @@ This task will fetch current pokemon spawns from /raw_data of an PokemonGo-Map i
       "snipe_high_prio_threshold": 400,
       "update_map": true,
       "mode": "priority",
-      "max_extra_dist_fort": 10,   
+      "max_extra_dist_fort": 10,
       "catch": {
         "Aerodactyl": 1000,
         "Ditto": 900,
@@ -552,12 +555,12 @@ This task will fetch current pokemon spawns from /raw_data of an PokemonGo-Map i
 ### Description
 [[back to top](#table-of-contents)]
 
-Walk to the specified locations loaded from .gpx or .json file. It is highly recommended to use website such as [GPSies](http://www.gpsies.com) which allow you to export your created track in JSON file. Note that you'll have to first convert its JSON file into the format that the bot can understand. See [Example of pier39.json] below for the content. I had created a simple python script to do the conversion. 
+Walk to the specified locations loaded from .gpx or .json file. It is highly recommended to use website such as [GPSies](http://www.gpsies.com) which allow you to export your created track in JSON file. Note that you'll have to first convert its JSON file into the format that the bot can understand. See [Example of pier39.json] below for the content. I had created a simple python script to do the conversion.
 
 ### Options
 [[back to top](#table-of-contents)]
 * `path_mode` - linear, loop
-   - `loop` - The bot will walk along all specified waypoints and then move directly to the first waypoint again. 
+   - `loop` - The bot will walk along all specified waypoints and then move directly to the first waypoint again.
    - `linear` - The bot will turn around at the last waypoint and along the given waypoints in reverse order.
 * `path_start_mode` - first
 * `path_file` - "/path/to/your/path.json"
@@ -568,10 +571,10 @@ Walk to the specified locations loaded from .gpx or .json file. It is highly rec
 
 ```
 {
-	"type": "FollowPath",
+  "type": "FollowPath",
     "config": {
-    	"path_mode": "linear",
-	  	"path_start_mode": "first",
+      "path_mode": "linear",
+      "path_start_mode": "first",
       "path_file": "/home/gary/bot/PokemonGo-Bot/configs/path/pier39.json"
     }
 }
@@ -579,10 +582,10 @@ Walk to the specified locations loaded from .gpx or .json file. It is highly rec
 
 Example of pier39.json
 ```
-[{"location": "37.8103848,-122.410325"}, 
-{"location": "37.8103306,-122.410435"}, 
-{"location": "37.8104662,-122.41051"}, 
-{"location": "37.8106146,-122.41059"}, 
+[{"location": "37.8103848,-122.410325"},
+{"location": "37.8103306,-122.410435"},
+{"location": "37.8104662,-122.41051"},
+{"location": "37.8106146,-122.41059"},
 {"location": "37.8105934,-122.410719"}
 ]
 ```
@@ -675,7 +678,7 @@ Periodically displays the user inventory in the terminal.
 ### Options
 [[back to top](#table-of-contents)]
 * `min_interval` : The minimum interval at which the stats are displayed, in seconds (defaults to 120 seconds). The update interval cannot be accurate as workers run synchronously.
-* `show_all_multiple_lines` : Logs all items on inventory using multiple lines. Ignores configuration of 'items' 
+* `show_all_multiple_lines` : Logs all items on inventory using multiple lines. Ignores configuration of 'items'
 * `items` : An array of items to display and their display order (implicitly), see available items below (defaults to []).
 
 Available `items` :
@@ -737,14 +740,14 @@ Simulates the user going to sleep every day for some time, the sleep time and th
 ###Example Config
 ```
 {
-	"type": "SleepSchedule",
-	"config": {
-		"time": "12:00",
-		"duration":"5:30",
-		"time_random_offset": "00:30",
-		"duration_random_offset": "00:30"
-		"wake_up_at_location": "39.408692,149.595838,590.8"
-	}
+  "type": "SleepSchedule",
+  "config": {
+    "time": "12:00",
+    "duration":"5:30",
+    "time_random_offset": "00:30",
+    "duration_random_offset": "00:30"
+    "wake_up_at_location": "39.408692,149.595838,590.8"
+  }
 }
 ```
 
@@ -763,13 +766,13 @@ Simulates the random pause of the day (speaking to someone, getting into a store
 ###Example Config
 ```
 {
-	"type": "RandomPause",
-	"config": {
-		"min_duration": "00:00:10",
-		"max_duration": "00:10:00",
-		"min_interval": "00:10:00",
-		"max_interval": "02:00:00"
-	}
+  "type": "RandomPause",
+  "config": {
+    "min_duration": "00:00:10",
+    "max_duration": "00:10:00",
+    "min_interval": "00:10:00",
+    "max_interval": "02:00:00"
+  }
 }
 ```
 
@@ -785,12 +788,12 @@ Configure how the bot should use the incubators.
 ###Example Config
 ```
 {
-	"type": "IncubateEggs",
+  "type": "IncubateEggs",
     "config": {
-		"longer_eggs_first": true,
-		"infinite": [2,5],
-		"breakable": [10]
-	}
+    "longer_eggs_first": true,
+    "infinite": [2,5],
+    "breakable": [10]
+  }
 }
 ```
 

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -8,83 +8,30 @@ from pokemongo_bot.inventory import Pokemons, Pokemon, Attack
 from pokemongo_bot.datastore import Datastore
 from operator import attrgetter
 
+
 class TransferPokemon(Datastore, BaseTask):
     SUPPORTED_TASK_API_VERSION = 1
 
     def __init__(self, bot, config):
         super(TransferPokemon, self).__init__(bot, config)
+
     def initialize(self):
         self.min_free_slot = self.config.get('min_free_slot', 5)
         self.transfer_wait_min = self.config.get('transfer_wait_min', 1)
         self.transfer_wait_max = self.config.get('transfer_wait_max', 4)
 
     def work(self):
-
         if not self._should_work():
             return
 
         pokemon_groups = self._release_pokemon_get_groups()
         for pokemon_id, group in pokemon_groups.iteritems():
             pokemon_name = Pokemons.name_for(pokemon_id)
-            keep_best, keep_best_cp, keep_best_iv = self._validate_keep_best_config(pokemon_name)
-            #TODO continue list possible criteria
-            keep_best_possible_criteria = ['cp','iv', 'iv_attack', 'iv_defense', 'iv_stamina', 'moveset.attack_perfection','moveset.defense_perfection','hp','hp_max']
-            keep_best_custom, keep_best_criteria, keep_amount = self._validate_keep_best_config_custom(pokemon_name, keep_best_possible_criteria)
+            self._release_pokemon_worst_in_group(group, pokemon_name)
 
-            best_pokemon_ids = set()
-            order_criteria = 'none'
-            if keep_best:
-                if keep_best_cp >= 1:
-                    cp_limit = keep_best_cp
-                    best_cp_pokemons = sorted(group, key=lambda x: (x.cp, x.iv), reverse=True)[:cp_limit]
-                    best_pokemon_ids = set(pokemon.unique_id for pokemon in best_cp_pokemons)
-                    order_criteria = 'cp'
-
-                if keep_best_iv >= 1:
-                    iv_limit = keep_best_iv
-                    best_iv_pokemons = sorted(group, key=lambda x: (x.iv, x.cp), reverse=True)[:iv_limit]
-                    best_pokemon_ids |= set(pokemon.unique_id for pokemon in best_iv_pokemons)
-                    if order_criteria == 'cp':
-                        order_criteria = 'cp and iv'
-                    else:
-                        order_criteria = 'iv'
-            elif keep_best_custom:
-                limit = keep_amount
-                keep_best_criteria = [str(keep_best_criteria[x]) for x in range(len(keep_best_criteria))] # not sure if the u of unicode will stay, so make it go away
-                best_pokemons = sorted(group, key=attrgetter(*keep_best_criteria), reverse=True)[:limit]
-                best_pokemon_ids = set(pokemon.unique_id for pokemon in best_pokemons)
-                order_criteria = ' then '.join(keep_best_criteria)
-
-            if keep_best or keep_best_custom:
-                # remove best pokemons from all pokemons array
-                all_pokemons = group
-                best_pokemons = []
-                for best_pokemon_id in best_pokemon_ids:
-                    for pokemon in all_pokemons:
-                        if best_pokemon_id == pokemon.unique_id:
-                            all_pokemons.remove(pokemon)
-                            best_pokemons.append(pokemon)
-
-                transfer_pokemons = [pokemon for pokemon in all_pokemons if self.should_release_pokemon(pokemon,True)]
-
-                if transfer_pokemons:
-                    if best_pokemons:
-                        self.emit_event(
-                            'keep_best_release',
-                            formatted="Keeping best {amount} {pokemon}, based on {criteria}",
-                            data={
-                                'amount': len(best_pokemons),
-                                'pokemon': pokemon_name,
-                                'criteria': order_criteria
-                            }
-                        )
-                    for pokemon in transfer_pokemons:
-                        self.release_pokemon(pokemon)
-            else:
-                group = sorted(group, key=lambda x: x.cp, reverse=True)
-                for pokemon in group:
-                    if self.should_release_pokemon(pokemon):
-                        self.release_pokemon(pokemon)
+        group = [p for p in inventory.pokemons().all()
+                 if p.in_fort is False and p.is_favorite is False]
+        self._release_pokemon_worst_in_group(group, 'all')
 
     def _should_work(self):
         return inventory.Pokemons.get_space_left() <= self.min_free_slot
@@ -104,19 +51,93 @@ class TransferPokemon(Datastore, BaseTask):
 
         return pokemon_groups
 
-    def should_release_pokemon(self, pokemon, keep_best_mode = False):
+    def _release_pokemon_worst_in_group(self, group, pokemon_name):
+        keep_best, keep_best_cp, keep_best_iv = self._validate_keep_best_config(
+            pokemon_name)
+        # TODO continue list possible criteria
+        keep_best_possible_criteria = ['cp', 'iv', 'iv_attack', 'iv_defense', 'iv_stamina',
+                                       'moveset.attack_perfection', 'moveset.defense_perfection', 'hp', 'hp_max']
+        keep_best_custom, keep_best_criteria, keep_amount = self._validate_keep_best_config_custom(
+            pokemon_name, keep_best_possible_criteria)
+
+        best_pokemon_ids = set()
+        order_criteria = 'none'
+        if keep_best:
+            if keep_best_cp >= 1:
+                cp_limit = keep_best_cp
+                best_cp_pokemons = sorted(group, key=lambda x: (
+                    x.cp, x.iv), reverse=True)[:cp_limit]
+                best_pokemon_ids = set(
+                    pokemon.unique_id for pokemon in best_cp_pokemons)
+                order_criteria = 'cp'
+
+            if keep_best_iv >= 1:
+                iv_limit = keep_best_iv
+                best_iv_pokemons = sorted(group, key=lambda x: (
+                    x.iv, x.cp), reverse=True)[:iv_limit]
+                best_pokemon_ids |= set(
+                    pokemon.unique_id for pokemon in best_iv_pokemons)
+                if order_criteria == 'cp':
+                    order_criteria = 'cp and iv'
+                else:
+                    order_criteria = 'iv'
+        elif keep_best_custom:
+            limit = keep_amount
+            # not sure if the u of unicode will stay, so make it go away
+            keep_best_criteria = [str(keep_best_criteria[x])
+                                  for x in range(len(keep_best_criteria))]
+            best_pokemons = sorted(group, key=attrgetter(
+                *keep_best_criteria), reverse=True)[:limit]
+            best_pokemon_ids = set(
+                pokemon.unique_id for pokemon in best_pokemons)
+            order_criteria = ' then '.join(keep_best_criteria)
+
+        if keep_best or keep_best_custom:
+            # remove best pokemons from all pokemons array
+            all_pokemons = group
+            best_pokemons = []
+            for best_pokemon_id in best_pokemon_ids:
+                for pokemon in all_pokemons:
+                    if best_pokemon_id == pokemon.unique_id:
+                        all_pokemons.remove(pokemon)
+                        best_pokemons.append(pokemon)
+
+            transfer_pokemons = [
+                pokemon for pokemon in all_pokemons if self.should_release_pokemon(pokemon, True)]
+
+            if transfer_pokemons:
+                if best_pokemons:
+                    self.emit_event(
+                        'keep_best_release',
+                        formatted="Keeping best {amount} {pokemon}, based on {criteria}",
+                        data={
+                            'amount': len(best_pokemons),
+                            'pokemon': pokemon_name,
+                            'criteria': order_criteria
+                        }
+                    )
+                for pokemon in transfer_pokemons:
+                    self.release_pokemon(pokemon)
+        else:
+            group = sorted(group, key=lambda x: x.cp, reverse=True)
+            for pokemon in group:
+                if self.should_release_pokemon(pokemon):
+                    self.release_pokemon(pokemon)
+
+    def should_release_pokemon(self, pokemon, keep_best_mode=False):
         release_config = self._get_release_config_for(pokemon.name)
 
         if (keep_best_mode
-            and not release_config.has_key('never_release')
-            and not release_config.has_key('always_release')
-            and not release_config.has_key('release_below_cp')
-            and not release_config.has_key('release_below_iv')):
+                and not release_config.has_key('never_release')
+                and not release_config.has_key('always_release')
+                and not release_config.has_key('release_below_cp')
+                and not release_config.has_key('release_below_iv')):
             return True
 
         cp_iv_logic = release_config.get('logic')
         if not cp_iv_logic:
-            cp_iv_logic = self._get_release_config_for('any').get('logic', 'and')
+            cp_iv_logic = self._get_release_config_for(
+                'any').get('logic', 'and')
 
         release_results = {
             'cp': False,
@@ -167,8 +188,10 @@ class TransferPokemon(Datastore, BaseTask):
             if self.bot.config.test:
                 candy_awarded = 1
             else:
-                response_dict = self.bot.api.release_pokemon(pokemon_id=pokemon.unique_id)
-                candy_awarded = response_dict['responses']['RELEASE_POKEMON']['candy_awarded']
+                response_dict = self.bot.api.release_pokemon(
+                    pokemon_id=pokemon.unique_id)
+                candy_awarded = response_dict['responses'][
+                    'RELEASE_POKEMON']['candy_awarded']
         except KeyError:
             return
 
@@ -189,13 +212,15 @@ class TransferPokemon(Datastore, BaseTask):
         )
         with self.bot.database as conn:
             c = conn.cursor()
-            c.execute("SELECT COUNT(name) FROM sqlite_master WHERE type='table' AND name='transfer_log'")
+            c.execute(
+                "SELECT COUNT(name) FROM sqlite_master WHERE type='table' AND name='transfer_log'")
 
         result = c.fetchone()
 
         while True:
             if result[0] == 1:
-                conn.execute('''INSERT INTO transfer_log (pokemon, iv, cp) VALUES (?, ?, ?)''', (pokemon.name, pokemon.iv, pokemon.cp))
+                conn.execute('''INSERT INTO transfer_log (pokemon, iv, cp) VALUES (?, ?, ?)''',
+                             (pokemon.name, pokemon.iv, pokemon.cp))
                 break
             else:
                 self.emit_event(


### PR DESCRIPTION
## Closes #4552 , Resolves #4468 
Added keyword 'all' in 'release' config which allows to discards all pokemon in bag except N best. Updated docs and added commented examples in configs.

- "release": {"all": keep_best_cp": 100} globally keeps 100 best CP pokemon;
- fixed description of 'any' in docs and configs;
- added 'all' example in config files;
- added example of 'all' to docs;
- accidentally replaced some tabs in configs to spaces (but hey, that's good - spaces are everywhere in the project).

Changes in code are exactly as described in #4552 solution suggestion (refactored contents of `for` in a separate method and added 3 new lines, that's all).