### PR TITLE
teleporting do not update last-location

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -609,6 +609,10 @@ class PokemonGoBot(Datastore):
         if alt is None:
             alt = self.api._position_alt
 
+        # dont cache when teleport_to
+        if self.api.teleporting:
+            return
+
         if cells == []:
             location = self.position[0:2]
             cells = self.find_close_cells(*location)

--- a/pokemongo_bot/api_wrapper.py
+++ b/pokemongo_bot/api_wrapper.py
@@ -27,6 +27,7 @@ class ApiWrapper(Datastore, PGoApi):
         PGoApi.__init__(self)
         # Set to default, just for CI...
         self.actual_lat, self.actual_lng, self.actual_alt = PGoApi.get_position(self)
+        self.teleporting = False
         self.noised_lat, self.noised_lng, self.noised_alt = self.actual_lat, self.actual_lng, self.actual_alt
 
         self.useVanillaRequest = False
@@ -81,14 +82,15 @@ class ApiWrapper(Datastore, PGoApi):
             self.useVanillaRequest = False
         return ret_value
 
-    def set_position(self, lat, lng, alt=None):
+    def set_position(self, lat, lng, alt=None, teleporting=False):
         self.actual_lat = lat
         self.actual_lng = lng
         if None != alt:
             self.actual_alt = alt
         else:
             alt = self.actual_alt
-
+        self.teleporting = teleporting
+        
         if self.config.replicate_gps_xy_noise:
             lat_noise = gps_noise_rng(self.config.gps_xy_noise_range)
             lng_noise = gps_noise_rng(self.config.gps_xy_noise_range)

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -228,7 +228,7 @@ class MoveToMapPokemon(BaseTask):
         api_encounter_response = catch_worker.create_encounter_api_call()
         time.sleep(SNIPE_SLEEP_SEC)
         self._teleport_back(last_position)
-        self.bot.api.set_position(last_position[0], last_position[1], self.alt)
+        self.bot.api.set_position(last_position[0], last_position[1], self.alt, False)
         time.sleep(SNIPE_SLEEP_SEC)
         self.bot.heartbeat()
         catch_worker.work(api_encounter_response)
@@ -350,7 +350,7 @@ class MoveToMapPokemon(BaseTask):
             formatted='Teleporting to {poke_name}. ({poke_dist})',
             data=self._pokemon_event_data(pokemon)
         )
-        self.bot.api.set_position(pokemon['latitude'], pokemon['longitude'], self.alt)
+        self.bot.api.set_position(pokemon['latitude'], pokemon['longitude'], self.alt, True)
         self._encountered(pokemon)
 
     def _encountered(self, pokemon):


### PR DESCRIPTION
## Short Description:
When the teleport_to avoid update last-location-% s.json.
CTRL-c interrupt occurs at this time, restart again will cause a significant shift abnormality

## Fixes/Resolves/Closes (please use correct syntax):
-
-
-
