### PR TITLE
Add Level limit

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -42,7 +42,11 @@
         }
       },
       {
-         "type": "CollectLevelUpReward"
+        "type": "CollectLevelUpReward",
+        "config": {
+          "collect_reward": true,
+          "level_limit": -1
+        }
       },
       {
         "type": "IncubateEggs",

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -53,7 +53,11 @@
         }
       },
       {
-         "type": "CollectLevelUpReward"
+        "type": "CollectLevelUpReward",
+        "config": {
+          "collect_reward": true,
+          "level_limit": -1
+        }
       },
       {
         "type": "IncubateEggs",

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -42,7 +42,11 @@
         }
       },
       {
-         "type": "CollectLevelUpReward"
+        "type": "CollectLevelUpReward",
+        "config": {
+          "collect_reward": true,
+          "level_limit": -1
+        }
       },
       {
         "type": "IncubateEggs",

--- a/configs/config.json.optimizer.example
+++ b/configs/config.json.optimizer.example
@@ -42,7 +42,11 @@
         }
       },
       {
-         "type": "CollectLevelUpReward"
+        "type": "CollectLevelUpReward",
+        "config": {
+          "collect_reward": true,
+          "level_limit": -1
+        }
       },
       {
         "type": "IncubateEggs",

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -42,7 +42,11 @@
         }
       },
       {
-         "type": "CollectLevelUpReward"
+        "type": "CollectLevelUpReward",
+        "config": {
+          "collect_reward": true,
+          "level_limit": -1
+        }
       },
       {
         "type": "IncubateEggs",

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -42,7 +42,11 @@
         }
       },
       {
-         "type": "CollectLevelUpReward"
+        "type": "CollectLevelUpReward",
+        "config": {
+          "collect_reward": true,
+          "level_limit": -1
+        }
       },
       {
         "type": "IncubateEggs",

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -125,6 +125,9 @@ The behaviors of the bot are configured via the `tasks` key in the `config.json`
   * `min_free_slot`: Default `5` | Once the pokebag has less empty slots than this amount, the transfer process is triggered. | Big values (i.e 9999) will trigger the transfer process after each catch.
 * UpdateLiveStats
 * [UpdateLiveInventory](#updateliveinventory-settings)
+* CollectLevelUpReward
+  * `collect_reward`: Default `True` | Collect level up rewards
+  * `level_limit`: Default `-1` | Bot will stop automatically after trainer reaches level limit 
 
 
 ### Example configuration:

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -126,8 +126,8 @@ The behaviors of the bot are configured via the `tasks` key in the `config.json`
 * UpdateLiveStats
 * [UpdateLiveInventory](#updateliveinventory-settings)
 * CollectLevelUpReward
-  * `collect_reward`: Default `True` | Collect level up rewards
-  * `level_limit`: Default `-1` | Bot will stop automatically after trainer reaches level limit 
+  * `collect_reward`: Default `True` | Collect level up rewards.
+  * `level_limit`: Default `-1` | Bot will stop automatically after trainer reaches level limit. Set to `-1` to disable.
 
 
 ### Example configuration:

--- a/pokemongo_bot/cell_workers/collect_level_up_reward.py
+++ b/pokemongo_bot/cell_workers/collect_level_up_reward.py
@@ -1,3 +1,5 @@
+import sys
+
 from pokemongo_bot.base_task import BaseTask
 from pokemongo_bot import inventory
 
@@ -9,29 +11,42 @@ class CollectLevelUpReward(BaseTask):
     previous_level = 0
 
     def initialize(self):
+        self._process_config()
         self.current_level = self._get_current_level()
         self.previous_level = 0
 
     def work(self):
-        self.current_level = self._get_current_level()
+        if self._should_run():
+            self.current_level = self._get_current_level()
 
-        # let's check level reward on bot initialization
-        # to be able get rewards for old bots
-        if self.previous_level == 0:
-            self._collect_level_reward()
-        # level up situation
-        elif self.current_level > self.previous_level:
-            self.emit_event(
-                'level_up',
-                formatted='Level up from {previous_level} to {current_level}',
-                data={
-                    'previous_level': self.previous_level,
-                    'current_level': self.current_level
-                }
-            )
-            self._collect_level_reward()
+            if self.collect_reward:
+                # let's check level reward on bot initialization
+                # to be able get rewards for old bots
+                if self.previous_level == 0:
+                    self._collect_level_reward()
+                # level up situation
+                elif self.current_level > self.previous_level:
+                    self.emit_event(
+                        'level_up',
+                        formatted='Level up from {previous_level} to {current_level}',
+                        data={
+                            'previous_level': self.previous_level,
+                            'current_level': self.current_level
+                        }
+                    )
+                    self._collect_level_reward()
 
-        self.previous_level = self.current_level
+            if self.level_limit != -1 and self.current_level >= self.level_limit:
+                sys.exit("You have reached your target level! Exiting now.")
+
+            self.previous_level = self.current_level
+
+    def _process_config(self):
+        self.level_limit = self.config.get('level_limit', -1)
+        self.collect_reward = self.config.get('collect_reward', True)
+
+    def _should_run(self):
+        return self.level_limit != -1 or self.collect_reward
 
     def _collect_level_reward(self):
         response_dict = self.bot.api.level_up_rewards(level=self.current_level)


### PR DESCRIPTION
## Stops bot after a set level limit

### Same as #4656 but without task name change. 

## Features
- Level limit defaults to -1, which means no level limit
- Uses same api call as collect level up reward
- #4624
