### PR TITLE
Allow the setting of candy threshold

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,9 +1,11 @@
+
 approve_by_comment: true
-approve_regex: ^Approved
-reject_regex: ^Rejected
-reset_on_push: false
+approve_regex: '^:\+1:'
+reject_regex: '^(Rejected|:-1:)'
+reject_value: -1
+reset_on_push: true
+author_approval: ignored
 reviewers:
-  members:
-  - bbiiggppiigg
-  name: pullapprove
-  required: 1
+    required: 2
+    teams:
+        - pokemongo-bot-team

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,10 +1,9 @@
 approve_by_comment: true
-approve_regex: '^:\+1:'
-reject_regex: '^(Rejected|:-1:)'
-reject_value: -1
-reset_on_push: true
-author_approval: ignored
+approve_regex: ^Approved
+reject_regex: ^Rejected
+reset_on_push: false
 reviewers:
-    required: 2
-    teams:
-        - pokemongo-bot-team
+  members:
+  - bbiiggppiigg
+  name: pullapprove
+  required: 1

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -240,7 +240,7 @@
     "logging_color": true,
     "daily_catch_limit": 800,
     "catch": {
-      "any": {"candy_threshold" : 400 . "catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
+      "any": {"candy_threshold" : 400 , "catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},
       "// Rattata": { "always_catch" : true }
     },

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -240,7 +240,7 @@
     "logging_color": true,
     "daily_catch_limit": 800,
     "catch": {
-      "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
+      "any": {"candy_threshold" : 400 . "catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},
       "// Rattata": { "always_catch" : true }
     },

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -164,8 +164,18 @@ class PokemonGoBot(Datastore):
         self.event_manager.register_event('set_start_location')
         self.event_manager.register_event('load_cached_location')
         self.event_manager.register_event('location_cache_ignored')
+        #  ignore candy above threshold
         self.event_manager.register_event(
-            'position_update',
+            'ignore_candy_above_thresold',
+            parameters=(
+                'name',
+                'amount',
+                'threshold'
+            )
+        )
+
+        self.event_manager.register_event(
+               'position_update',
             parameters=(
                 'current_position',
                 'last_position',

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -221,6 +221,22 @@ class PokemonCatchWorker(Datastore, BaseTask):
             'iv': False,
         }
 
+        candies = inventory.candies().get(pokemon.pokemon_id).quantity
+        threshold = pokemon_config.get('candy_threshold', 400)
+        if( candies > threshold  ):
+            self.emit_event(
+                'ignore_candy_above_thresold',
+                level='info',
+                formatted='Amount of candies for {name} is {amount}, greater than threshold {threshold}',
+                data={
+                    'name': pokemon.name,
+                    'amount': candies ,
+                    'threshold' : threshold
+                }
+            )
+            return False
+
+
         if pokemon_config.get('never_catch', False):
             return False
 


### PR DESCRIPTION




## Short Description:
Allow the setting of candy threshold to ignore certain pokemon if the threshold is reached
Using a default value of 400 ( For Magikarp )

## Fixes/Resolves/Closes (please use correct syntax):

Closes #4256 

-
-
-

