### PR TITLE
Fix summary for 1st run of fresh acct

### DIFF
--- a/pokemongo_bot/metrics.py
+++ b/pokemongo_bot/metrics.py
@@ -7,15 +7,15 @@ class Metrics(object):
     def __init__(self, bot):
         self.bot = bot
         self.start_time = time.time()
-        self.dust = {'start': -1, 'latest': -1}
-        self.xp = {'start': -1, 'latest': -1}
-        self.distance = {'start': -1, 'latest': -1}
-        self.encounters = {'start': -1, 'latest': -1}
-        self.throws = {'start': -1, 'latest': -1}
-        self.captures = {'start': -1, 'latest': -1}
-        self.visits = {'start': -1, 'latest': -1}
-        self.unique_mons = {'start': -1, 'latest': -1}
-        self.evolutions = {'start': -1, 'latest': -1}
+        self.dust = {'start': 0, 'latest': 0}
+        self.xp = {'start': 0, 'latest': 0}
+        self.distance = {'start': 0, 'latest': 0}
+        self.encounters = {'start': 0, 'latest': 0}
+        self.throws = {'start': 0, 'latest': 0}
+        self.captures = {'start': 0, 'latest': 0}
+        self.visits = {'start': 0, 'latest': 0}
+        self.unique_mons = {'start': 0, 'latest': 0}
+        self.evolutions = {'start': 0, 'latest': 0}
 
         self.releases = 0
         self.highest_cp = {'cp': 0, 'desc': ''}
@@ -111,31 +111,14 @@ class Metrics(object):
                         playerdata = item['inventory_item_data']['player_stats']
 
                         self.xp['latest'] = playerdata.get('experience', 0)
-                        if self.xp['start'] < 0: self.xp['start'] = self.xp['latest']
-
                         self.visits['latest'] = playerdata.get('poke_stop_visits', 0)
-                        if self.visits['start'] < 0: self.visits['start'] = self.visits['latest']
-
                         self.captures['latest'] = playerdata.get('pokemons_captured', 0)
-                        if self.captures['start'] < 0: self.captures['start'] = self.captures['latest']
-
                         self.distance['latest'] = playerdata.get('km_walked', 0)
-                        if self.distance['start'] < 0: self.distance['start'] = self.distance['latest']
-
                         self.encounters['latest'] = playerdata.get('pokemons_encountered', 0)
-                        if self.encounters['start'] < 0: self.encounters['start'] = self.encounters['latest']
-
                         self.throws['latest'] = playerdata.get('pokeballs_thrown', 0)
-                        if self.throws['start'] < 0: self.throws['start'] = self.throws['latest']
-
                         self.unique_mons['latest'] = playerdata.get('unique_pokedex_entries', 0)
-                        if self.unique_mons['start'] < 0: self.unique_mons['start'] = self.unique_mons['latest']
-
                         self.visits['latest'] = playerdata.get('poke_stop_visits', 0)
-                        if self.visits['start'] < 0: self.visits['start'] = self.visits['latest']
-
                         self.evolutions['latest'] = playerdata.get('evolutions', 0)
-                        if self.evolutions['start'] < 0: self.evolutions['start'] = self.evolutions['latest']
                     elif 'pokedex_entry' in item['inventory_item_data']:
                         entry = item['inventory_item_data']['pokedex_entry'].get('pokemon_id')
                         if entry: uniq_pokemon_list.add(entry)


### PR DESCRIPTION
When running a brand spanking new account for the 1st time, we printed an invalid summary report.

- Switched default values
- Removed default value check that assigned start to latest

From what I can tell, there was no need to assign everything to -1 if we have a fresh account then assign all start values to latest at the end.

Closes half of #4687