### PR TITLE
Allow the setting of candy threshold

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -248,7 +248,7 @@
     "logging_color": true,
     "daily_catch_limit": 800,
     "catch": {
-      "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
+      "any": {"candy_threshold" : 400 ,"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},
       "// Rattata": { "always_catch" : true }
     },

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -164,6 +164,21 @@ class PokemonGoBot(Datastore):
         self.event_manager.register_event('set_start_location')
         self.event_manager.register_event('load_cached_location')
         self.event_manager.register_event('location_cache_ignored')
+
+        #  ignore candy above threshold
+        self.event_manager.register_event(
+            'ignore_candy_above_thresold',
+            parameters=(
+                'name',
+                'amount',
+                'threshold'
+            )
+        )
+
+
+
+
+
         self.event_manager.register_event(
             'position_update',
             parameters=(

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -222,8 +222,8 @@ class PokemonCatchWorker(Datastore, BaseTask):
         }
 
         candies = inventory.candies().get(pokemon.pokemon_id).quantity
-        threshold = pokemon_config.get('candy_threshold', 400)
-        if( candies > threshold  ):
+        threshold = pokemon_config.get('candy_threshold', False)
+        if( threshold > 0 and candies > threshold  ):
             self.emit_event(
                 'ignore_candy_above_thresold',
                 level='info',

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -221,6 +221,23 @@ class PokemonCatchWorker(Datastore, BaseTask):
             'iv': False,
         }
 
+        candies = inventory.candies().get(pokemon.pokemon_id).quantity
+        threshold = pokemon_config.get('candy_threshold', 400)
+        if( candies > threshold  ):
+            self.emit_event(
+                'ignore_candy_above_thresold',
+                level='info',
+                formatted='Amount of candies for {name} is {amount}, greater than threshold {threshold}',
+                data={
+                    'name': pokemon.name,
+                    'amount': candies ,
+                    'threshold' : threshold
+                }
+            )
+            return False
+
+
+
         if pokemon_config.get('never_catch', False):
             return False
 

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -222,8 +222,8 @@ class PokemonCatchWorker(Datastore, BaseTask):
         }
 
         candies = inventory.candies().get(pokemon.pokemon_id).quantity
-        threshold = pokemon_config.get('candy_threshold', False)
-        if( threshold > 0 and candies > threshold  ):
+        threshold = pokemon_config.get('candy_threshold', -1 )
+        if( threshold > 0 and candies >= threshold  ):
             self.emit_event(
                 'ignore_candy_above_thresold',
                 level='info',


### PR DESCRIPTION

## Short Description:
Allow setting ignore threshold based on the amount of candy
Default is set to 400 for Magikarp

## Fixes/Resolves/Closes (please use correct syntax):
Closes #4256 


