### PR TITLE
add event messaging on badge update and application delay

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -35,6 +35,7 @@ from worker_result import WorkerResult
 from tree_config_builder import ConfigException, MismatchTaskApiVersion, TreeConfigBuilder
 from inventory import init_inventory
 from sys import platform as _platform
+from pgoapi.protos.POGOProtos.Enums import BadgeType_pb2
 import struct
 
 
@@ -73,6 +74,7 @@ class PokemonGoBot(Datastore):
             open(os.path.join(_base_dir, 'data', 'pokemon.json'))
         )
         self.item_list = json.load(open(os.path.join(_base_dir, 'data', 'items.json')))
+        # @var Metrics
         self.metrics = Metrics(self)
         self.latest_inventory = None
         self.cell = None
@@ -136,6 +138,7 @@ class PokemonGoBot(Datastore):
             if self.config.websocket_remote_control:
                 remote_control = WebsocketRemoteControl(self).start()
 
+        # @var EventManager
         self.event_manager = EventManager(*handlers)
         self._register_events()
         if self.config.show_events:
@@ -575,6 +578,15 @@ class PokemonGoBot(Datastore):
         self.event_manager.register_event('pokestop_log')
         self.event_manager.register_event('softban_log')
 
+        self.event_manager.register_event(
+            'badges',
+            parameters=('badge', 'level')
+        )
+        self.event_manager.register_event(
+            'player_data',
+            parameters=('player_data', )
+        )
+
     def tick(self):
         self.health_record.heartbeat()
         self.cell = self.get_meta_cell()
@@ -835,7 +847,7 @@ class PokemonGoBot(Datastore):
         return full_path
 
     def _setup_api(self):
-        # instantiate pgoapi
+        # instantiate pgoapi @var ApiWrapper
         self.api = ApiWrapper(config=self.config)
 
         # provide player position on the earth
@@ -1147,7 +1159,46 @@ class PokemonGoBot(Datastore):
             request = self.api.create_request()
             request.get_player()
             request.check_awarded_badges()
-            request.call()
+            responses = request.call()
+
+            if responses['responses']['GET_PLAYER']['success'] == True:
+                #we get the player_data anyway, might as well store it
+                self._player = responses['responses']['GET_PLAYER']['player_data']
+                self.event_manager.emit(
+                    'player_data',
+                    sender=self,
+                    level='debug',
+                    formatted='equipped_badges: {player_data}',
+                    data={'player_data': self._player}
+                )
+            if responses['responses']['CHECK_AWARDED_BADGES']['success'] == True:
+                #store awarded_badges reponse to be used in a task or part of heartbeat
+                self._awarded_badges = responses['responses']['CHECK_AWARDED_BADGES']
+
+            if self._awarded_badges.has_key('awarded_badges'):
+                #todo: pull out the enum name and put into message
+                self.event_manager.emit(
+                    'badges',
+                    sender=self,
+                    level='info',
+                    formatted='awarded badge: {badge}, lvl {level}',
+                    data={'badge': BadgeType_pb2._BADGETYPE.values_by_number[self._awarded_badges['awarded_badges']].name,
+                          'level' : self._awarded_badges['awarded_badge_levels']}
+                )
+
+                #should work but gives errors :'(
+                #response = self.api.equip_badge(badge_type=self._awarded_badges['awarded_badges'])
+                response = {'responses' :"awaiting further testing on api call to equip_badge"}
+                self.event_manager.emit(
+                    'badges',
+                    sender=self,
+                    level='info',
+                    formatted='equiped badge: {badges}',
+                    data={'badges': response['responses']}
+                )
+                human_behaviour.action_delay(3,10)
+
+
         try:
             self.web_update_queue.put_nowait(True)  # do this outside of thread every tick
         except Queue.Full:


### PR DESCRIPTION
## Short Description:
update to store player_data and check_awarded_badges on success
emit events when awarded badge is returned and begin code changes for equip badge

## Fixes
begin fixing #4522