### PR TITLE
Hotfix for #4714

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -551,7 +551,7 @@ class PokemonCatchWorker(Datastore, BaseTask):
 
                     # if it is a new pokemon to our dex, simulate app animation delay
                     if exp_gain >= 500:
-                        sleep (randrange(catchsim_newtodex_wait_min, catchsim_newtodex_wait_max))
+                        sleep (randrange(self.catchsim_newtodex_wait_min, self.catchsim_newtodex_wait_max))
 
                 except IOError as e:
                     self.logger.info('[x] Error while opening location file: %s' % e)


### PR DESCRIPTION
##Hotfix for #4714

```
Traceback (most recent call last):
  File "pokecli.py", line 705, in <module>
    main()
  File "pokecli.py", line 118, in main
    bot.tick()
  File "/Users/alex/Documents/PoGoMap/PokemonGo-Bot/pokemongo_bot/__init__.py", line 610, in tick
    if worker.work() == WorkerResult.RUNNING:
  File "/Users/alex/Documents/PoGoMap/PokemonGo-Bot/pokemongo_bot/cell_workers/catch_pokemon.py", line 44, in work
    if self.catch_pokemon(self.pokemon.pop()) == WorkerResult.ERROR:
  File "/Users/alex/Documents/PoGoMap/PokemonGo-Bot/pokemongo_bot/cell_workers/catch_pokemon.py", line 138, in catch_pokemon
    return_value = worker.work()
  File "/Users/alex/Documents/PoGoMap/PokemonGo-Bot/pokemongo_bot/cell_workers/pokemon_catch_worker.py", line 171, in work
    self._do_catch(pokemon, encounter_id, catch_rate_by_ball, is_vip=is_vip)
  File "/Users/alex/Documents/PoGoMap/PokemonGo-Bot/pokemongo_bot/cell_workers/pokemon_catch_worker.py", line 554, in _do_catch
    sleep (randrange(catchsim_newtodex_wait_min, catchsim_newtodex_wait_max))
NameError: global name 'catchsim_newtodex_wait_min' is not defined
```