### PR TITLE
Resolve issue #4227 - MoveToMapPokemon stop catching when VIP

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -100,6 +100,7 @@ class PokemonGoBot(Datastore):
         self.heartbeat_counter = 0
         self.last_heartbeat = time.time()
 
+        self.capture_locked = False  # lock catching while moving to VIP pokemon
 
     def start(self):
         self._setup_event_system()

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -325,12 +325,14 @@ class MoveToMapPokemon(BaseTask):
 
         nearest_fort = self.get_nearest_fort_on_the_way(pokemon)
 
-        if nearest_fort is None :
+        if pokemon['is_vip'] or nearest_fort is None :
+            self.bot.capture_locked = True # lock catching while moving to vip pokemon or no fort around
             step_walker = self._move_to(pokemon)
             if not step_walker.step():
 
                 if pokemon['dist'] < Constants.MAX_DISTANCE_POKEMON_IS_REACHABLE:
                     self._encountered(pokemon)
+                    self.bot.capture_locked = False # unlock catch_worker
                     self.add_caught(pokemon)
                     return WorkerResult.SUCCESS
                 else :

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -241,6 +241,9 @@ class PokemonCatchWorker(Datastore, BaseTask):
         if pokemon.iv > catch_iv:
             catch_results['iv'] = True
 
+        if self.bot.capture_locked: # seems there is another more preferable pokemon, catching is locked
+            return False
+
         return LOGIC_TO_FUNCTION[pokemon_config.get('logic', default_logic)](*catch_results.values())
 
     def _should_catch_pokemon(self, pokemon):


### PR DESCRIPTION
## Short Description:

## Fixes/Resolves/Closes (please use correct syntax):
- #4227 
- When using move_to_map_pokemon if vip pokemon around, go to that pokemon, skip all forts and appeared pokemons.

p.s. works fine for me already for 5h (3 bots)
