### PR TITLE
Larger times for recycling in example configs

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -119,8 +119,8 @@
           "recycle_wait_min": 3,
           "recycle_wait_max": 5,
           "recycle_force": true,
-          "recycle_force_min": "00:00:00",
-          "recycle_force_max": "00:01:00"
+          "recycle_force_min": "00:01:00",
+          "recycle_force_max": "00:05:00"
         }
       },
       {

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -131,8 +131,8 @@
           "recycle_wait_min": 3,
           "recycle_wait_max": 5,
           "recycle_force": true,
-          "recycle_force_min": "00:00:00",
-          "recycle_force_max": "00:01:00"
+          "recycle_force_min": "00:01:00",
+          "recycle_force_max": "00:05:00"
         }
       },
       {

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -119,8 +119,8 @@
           "recycle_wait_min": 1,
           "recycle_wait_max": 4,
           "recycle_force": true,
-          "recycle_force_min": "00:00:00",
-          "recycle_force_max": "00:01:00"
+          "recycle_force_min": "00:01:00",
+          "recycle_force_max": "00:05:00"
         }
       },
       {

--- a/configs/config.json.optimizer.example
+++ b/configs/config.json.optimizer.example
@@ -180,8 +180,8 @@
           "recycle_wait_min": 3,
           "recycle_wait_max": 5,
           "recycle_force": true,
-          "recycle_force_min": "00:00:00",
-          "recycle_force_max": "00:01:00"
+          "recycle_force_min": "00:01:00",
+          "recycle_force_max": "00:05:00"
         }
       },
         {

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -119,8 +119,8 @@
           "recycle_wait_min": 3,
           "recycle_wait_max": 5,
           "recycle_force": true,
-          "recycle_force_min": "00:00:00",
-          "recycle_force_max": "00:01:00"
+          "recycle_force_min": "00:01:00",
+          "recycle_force_max": "00:05:00"
         }
       },
       {

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -118,8 +118,8 @@
           "recycle_wait_min": 3,
           "recycle_wait_max": 5,
           "recycle_force": true,
-          "recycle_force_min": "00:00:00",
-          "recycle_force_max": "00:01:00"
+          "recycle_force_min": "00:01:00",
+          "recycle_force_max": "00:05:00"
         }
       },
 	    {


### PR DESCRIPTION
## Short Description:

Minor update to example configs to set the values for recycling schedule to a sensible value (1 to 5 minutes). Previous times were far too low for the majority of users.

## Fixes/Resolves/Closes (please use correct syntax):
- Minor issue from #4513 

Times given in previous examples were too low (0 to 1 minute). Changed
to t to 5 minutes.