### PR TITLE
Nickname: Remove spaces from Nidorans

### DIFF
--- a/pokemongo_bot/cell_workers/nickname_pokemon.py
+++ b/pokemongo_bot/cell_workers/nickname_pokemon.py
@@ -331,6 +331,10 @@ class NicknamePokemon(BaseTask):
         moveset = pokemon.moveset
 
         pokemon.name = self._localize(pokemon.name)
+        
+        # Remove spaces from Nidoran M/F 
+        pokemon.name = pokemon.name.replace("Nidoran M","NidoranM")
+        pokemon.name = pokemon.name.replace("Nidoran F","NidoranF")
 
         #
         # Generate new nickname


### PR DESCRIPTION
## Short Description:
When generating a new nickname, remove spaces from Nidorans (convert "Nidoran M/F" into "NidoranM/F")

## Fixes/Resolves/Closes (please use correct syntax):
- #3718

This addresses the request in #3718. Not sure if any expansion needed.