### PR TITLE
Fix max distance when sniping

### DIFF
--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -132,7 +132,7 @@ class MoveToMapPokemon(BaseTask):
                 pokemon['longitude'],
             )
 
-            if pokemon['dist'] > self.config['max_distance'] and not self.config['snipe']:
+            if pokemon['dist'] > self.config['max_distance'] or not self.config['snipe']:
                 continue
 
             # pokemon not reachable with mean walking speed (by config)


### PR DESCRIPTION
## Short Description:
People were complaining about the sniping not adhering to the maximum distance. This was caused by a statement that didn't trigger whenever snipe was turned on.

## Fixes/Resolves/Closes (please use correct syntax):
-
-
-
