### PR TITLE
Minimize docker image (continuation of #4730)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,8 @@ RUN apk -U --no-cache add python py-pip \
     && rm -rf /var/cache/apk/* /tmp/pgoencrypt /usr/include/xlocale.h \
     && find / -name '*.pyc' -o -name '*.pyo' -exec rm -f {} \;
 
-RUN apk -U --no-cache add --virtual .install-dependencies wget ca-certificates tar \
-    && wget -q -O- https://github.com/$BUILD_REPO/archive/$BUILD_BRANCH.tar.gz | tar zxf - --strip-components=1 -C /usr/src/app \
-    && apk del .install-dependencies \
-    && rm -rf /var/cache/apk/*
+ADD https://github.com/$BUILD_REPO/archive/$BUILD_BRANCH.tar.gz /tmp
+RUN cat /tmp/$BUILD_BRANCH.tar.gz | tar zxf - --strip-components=1 -C /usr/src/app \
+    && rm /tmp/$BUILD_BRANCH.tar.gz
 
 ENTRYPOINT ["python", "pokecli.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,9 @@ RUN apk -U --no-cache add python py-pip \
     && find / -name '*.pyc' -o -name '*.pyo' -exec rm -f {} \;
 
 ADD https://github.com/$BUILD_REPO/archive/$BUILD_BRANCH.tar.gz /tmp
-RUN cat /tmp/$BUILD_BRANCH.tar.gz | tar zxf - --strip-components=1 -C /usr/src/app \
+RUN apk -U --no-cache add --virtual .tar-deps tar \
+    && cat /tmp/$BUILD_BRANCH.tar.gz | tar -zxf - --strip-components=1 -C /usr/src/app \
+    && apk del .tar-deps \
     && rm /tmp/$BUILD_BRANCH.tar.gz
 
 ENTRYPOINT ["python", "pokecli.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,17 +25,22 @@ VOLUME ["/usr/src/app/configs", "/usr/src/app/web"]
 
 ADD https://raw.githubusercontent.com/$BUILD_REPO/$BUILD_BRANCH/requirements.txt .
 RUN apk -U --no-cache add python py-pip \
-    && apk --no-cache add --virtual .build-dependencies python-dev gcc make musl-dev git tzdata \
+    && apk --no-cache add --virtual .build-dependencies python-dev gcc make musl-dev git tzdata tar \
     && cp -fa /usr/share/zoneinfo/$TIMEZONE /etc/localtime \
     && echo $TIMEZONE > /etc/timezone \
-    && wget -q -O- http://pgoapi.com/pgoencrypt.tar.gz | tar zxf - -C /tmp \
-    && make -C /tmp/pgoencrypt/src \
-    && cp /tmp/pgoencrypt/src/libencrypt.so /usr/src/app/encrypt.so \
     && ln -s locale.h /usr/include/xlocale.h \
     && pip install --no-cache-dir -r requirements.txt \
     && apk del .build-dependencies \
-    && rm -rf /var/cache/apk/* /tmp/pgoencrypt /usr/include/xlocale.h \
+    && rm -rf /var/cache/apk/* /usr/include/xlocale.h \
     && find / -name '*.pyc' -o -name '*.pyo' -exec rm -f {} \;
+
+ADD http://pgoapi.com/pgoencrypt.tar.gz /tmp/pgoencrypt.tar.gz
+RUN apk --no-cache add --virtual .pgoencrypt-dependencies gcc make musl-dev tar \
+    && cat /tmp/pgoencrypt.tar.gz | tar xzf - -C /tmp \
+    && make -C /tmp/pgoencrypt/src \
+    && cp /tmp/pgoencrypt/src/libencrypt.so /usr/src/app/encrypt.so \
+    && apk del .pgoencrypt-dependencies \
+    && rm -rf /var/cache/apk/* /tmp/pgoencrypt /tmp/pgoencrypt.tar.gz
 
 ADD https://github.com/$BUILD_REPO/archive/$BUILD_BRANCH.tar.gz /tmp
 RUN apk -U --no-cache add --virtual .tar-deps tar \


### PR DESCRIPTION
## Short Description:
Fixes some issues from PR #4730
## Fixes
-    busybox tar does not support --strip-components argument - added and removed regular tar in same RUN step
-   rectify cache invalidation issue in Dockerfile after merge of #4730 (because the download of the $BUILD_BRANCH.tar.gz was in a an RUN step and cache was  not invalidated - no new image would have been built)
- split pgoencrypt part into a different layer (this is in order to check if there is a new pgoencrypt version ) - executed in an different step after requirements to not cause the invalidation of the requirements build step (which is the most expensive)
