### PR TITLE
Improvements of #4732, revert broken changes from #4742, some pep-8

### DIFF
--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -87,6 +87,7 @@ SNIPE_SKIP_IN_ROUND = 30
 
 DEBUG_ON = False
 
+
 class MoveToMapPokemon(BaseTask):
     """Task for moving a trainer to a Pokemon."""
     SUPPORTED_TASK_API_VERSION = 1
@@ -109,8 +110,9 @@ class MoveToMapPokemon(BaseTask):
                 open(data_file)
             )
         self.alt = uniform(self.bot.config.alt_min, self.bot.config.alt_max)
+
     def get_pokemon_from_social(self):
-    	if not hasattr(self.bot, 'mqtt_pokemon_list'):
+        if not hasattr(self.bot, 'mqtt_pokemon_list'):
             return []
         if not self.bot.mqtt_pokemon_list or len(self.bot.mqtt_pokemon_list) <= 0:
             return []
@@ -151,6 +153,7 @@ class MoveToMapPokemon(BaseTask):
                 continue
             pokemon_list.append(pokemon)
         return pokemon_list
+
     def get_pokemon_from_map(self):
         try:
             req = requests.get('{}/{}?gyms=false&scanned=false'.format(self.config['address'], self.map_path))
@@ -356,8 +359,9 @@ class MoveToMapPokemon(BaseTask):
 
         nearest_fort = self.get_nearest_fort_on_the_way(pokemon)
 
-        if pokemon['is_vip'] or nearest_fort is None :
-            self.bot.capture_locked = True # lock catching while moving to vip pokemon or no fort around
+        if pokemon['is_vip'] or nearest_fort is None:
+            # lock catching(with pokemon_id specified) while moving to vip pokemon or no fort around
+            self.bot.capture_locked = pokemon['pokemon_id']
             step_walker = self._move_to(pokemon)
             if not step_walker.step():
 

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -228,21 +228,19 @@ class PokemonCatchWorker(Datastore, BaseTask):
         }
 
         candies = inventory.candies().get(pokemon.pokemon_id).quantity
-        threshold = pokemon_config.get('candy_threshold', -1 )
-        if( threshold > 0 and candies >= threshold  ):
+        threshold = pokemon_config.get('candy_threshold', -1)
+        if (threshold > 0 and candies >= threshold):
             self.emit_event(
                 'ignore_candy_above_thresold',
                 level='info',
                 formatted='Amount of candies for {name} is {amount}, greater than threshold {threshold}',
                 data={
                     'name': pokemon.name,
-                    'amount': candies ,
-                    'threshold' : threshold
+                    'amount': candies,
+                    'threshold': threshold
                 }
             )
             return False
-
-
 
         if pokemon_config.get('never_catch', False):
             return False
@@ -261,6 +259,10 @@ class PokemonCatchWorker(Datastore, BaseTask):
         catch_iv = pokemon_config.get('catch_above_iv', 0.8)
         if pokemon.iv > catch_iv:
             catch_results['iv'] = True
+
+        # check if encountered pokemon is our locked pokemon
+        if self.bot.capture_locked and self.bot.capture_locked != pokemon.pokemon_id:
+            return False
 
         return LOGIC_TO_FUNCTION[pokemon_config.get('logic', default_logic)](*catch_results.values())
 


### PR DESCRIPTION
## Short Description:
Improvements of #4732, revert broken changes from #4742, some pep-8

## Fixes/Resolves/Closes (please use correct syntax):
- #4742 revert broken changes
- #4732 logic improved - Some times locked VIP pokemon accured before bot reach position gathered from pokego-map, now bot will no longer skip that pokemon, while moving to locked coordinates.
- some pep-8

