### PR TITLE
Bot ignores incubate eggs config #4766

### DIFF
--- a/pokemongo_bot/cell_workers/incubate_eggs.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs.py
@@ -60,15 +60,16 @@ class IncubateEggs(BaseTask):
             for egg in self.eggs:
                 if egg["used"] or egg["km"] == -1:
                     continue
-                
+
+                km = int(egg["km"])
+
                 # test if the incubator is of type breakable
                 if incubator.get('uses_remaining') is not None:
-                    if egg["km"] not in self.breakable_incubator:
+                    if km not in self.breakable_incubator:
                         continue
-                    
                 # test if the incubator is of type infinite
-                if incubator.get('uses_remaining') is None:
-                    if egg["km"] not in self.infinite_incubator:
+                else:
+                    if km not in self.infinite_incubator:
                         continue
                 
                 self.emit_event(


### PR DESCRIPTION
## Short Description

egg["km"] returns decimal 2.0 , 5.0 or 10.0.
The config uses integers.

Convert egg["km"] return value to integers.

## Fixes/Resolves/Closes (please use correct syntax):
- #4766 
-
-
