### PR TITLE
Fix bot crash at start if permabanned

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -80,6 +80,9 @@ def main():
 
     def initialize(config):
         bot = PokemonGoBot(config)
+        return bot
+        
+    def start_bot(bot,config):
         bot.start()
         initialize_task(bot,config)
         bot.metrics.capture_stats()
@@ -113,6 +116,7 @@ def main():
         while not finished:
             try:
                 bot = initialize(config)
+                bot = start_bot(bot,config)
                 config_changed = check_mod(config_file)
 
                 bot.event_manager.emit(


### PR DESCRIPTION
## Short Description:
Bot not initialised (still set to "False") before trying to access event manager caused the following error:

```
"2016-08-27 20:10:17,371 [sentry.errors.uncaught] [ERROR] [u"AttributeError: 'bool' object has no attribute 'event_manager'", u' File "pokecli.py", line 746, in ', u' File "pokecli.py", line 170, in main']"
```

Separated bot initialize and start methods.

## Fixes/Resolves/Closes (please use correct syntax):
- #4817 
