### PR TITLE
Expand simple logging options

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -228,10 +228,12 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-	"logging": {
-		"color": true,
-		"clean": false
-	},
+    "logging": {
+      "color": true,
+      "show_datetime": true,
+      "show_process_name": true,
+      "show_log_level": true
+    },
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -266,10 +266,12 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-	"logging": {
-		"color": true,
-		"clean": false
-	},
+    "logging": {
+      "color": true,
+      "show_datetime": true,
+      "show_process_name": true,
+      "show_log_level": true
+    },
     "catch": {
       "any": {"candy_threshold" : 400 ,"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -485,10 +485,12 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-	"logging": {
-		"color": true,
-		"clean": false
-	},
+    "logging": {
+      "color": true,
+      "show_datetime": true,
+      "show_process_name": true,
+      "show_log_level": true
+    },
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},

--- a/configs/config.json.optimizer.example
+++ b/configs/config.json.optimizer.example
@@ -298,10 +298,12 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-	"logging": {
-		"color": true,
-		"clean": false
-	},
+    "logging": {
+      "color": true,
+      "show_datetime": true,
+      "show_process_name": true,
+      "show_log_level": true
+    },
     "catch": {
         "any": {
             "always_catch": true

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -234,10 +234,12 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-	"logging": {
-		"color": true,
-		"clean": false
-	},
+    "logging": {
+      "color": true,
+      "show_datetime": true,
+      "show_process_name": true,
+      "show_log_level": true
+    },
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or"},
       "// Example of always catching Rattata:": {},

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -238,10 +238,12 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-	"logging": {
-		"color": true,
-		"clean": false
-	},
+    "logging": {
+      "color": true,
+      "show_datetime": true,
+      "show_process_name": true,
+      "show_log_level": true
+    },
     "catch": {
       "any": {"catch_above_cp": 0, "catch_above_iv": 0, "logic": "or" },
 

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -87,6 +87,14 @@ Document the configuration options of PokemonGo-Bot.
 | `live_config_update.tasks_only`            | false     | True: quick update for Tasks only (without re-login). False: slower update for entire config file.
 
 
+## Logging configuration
+[[back to top](#table-of-contents)]
+
+'logging'.'color' (default false) Enabled colored logging
+'logging'.'show_datetime' (default true) Show date and time in log
+'logging'.'show_process_name' (default true) Show name of process generating output in log
+'logging'.'show_log_level' (default true) Show level of log message in log (eg. "INFO")
+
 ## Configuring Tasks
 [[back to top](#table-of-contents)]
 

--- a/pokecli.py
+++ b/pokecli.py
@@ -80,6 +80,9 @@ def main():
 
     def initialize(config):
         bot = PokemonGoBot(config)
+        return bot
+        
+    def start_bot(bot,config):
         bot.start()
         initialize_task(bot,config)
         bot.metrics.capture_stats()
@@ -113,6 +116,7 @@ def main():
         while not finished:
             try:
                 bot = initialize(config)
+                bot = start_bot(bot,config)
                 config_changed = check_mod(config_file)
 
                 bot.event_manager.emit(

--- a/pokecli.py
+++ b/pokecli.py
@@ -630,7 +630,7 @@ def init_config():
          type=bool,
          default=False
     )
-
+    
     # Start to parse other attrs
     config = parser.parse_args()
     if not config.username and 'username' not in load:
@@ -650,6 +650,7 @@ def init_config():
     config.live_config_update = load.get('live_config_update', {})
     config.live_config_update_enabled = config.live_config_update.get('enabled', False)
     config.live_config_update_tasks_only = config.live_config_update.get('tasks_only', False)
+    config.logging = load.get('logging', {})
 
     if config.map_object_cache_time < 0.0:
         parser.error("--map_object_cache_time is out of range! (should be >= 0.0)")

--- a/pokecli.py
+++ b/pokecli.py
@@ -695,7 +695,10 @@ def init_config():
 
     if "daily_catch_limit" in load:
         logger.warning('The daily_catch_limit argument has been moved into the CatchPokemon Task')
-
+        
+    if "logging_color" in load:
+        logger.warning('The logging_color argument has been moved into the logging config section')
+            
     if config.walk_min < 1:
         parser.error("--walk_min is out of range! (should be >= 1.0)")
         return None

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -132,7 +132,7 @@ class PokemonGoBot(Datastore):
     def _setup_event_system(self):
         handlers = []
 
-        if self.config.logging_color:
+        if self.config.logging and 'color' in self.config.logging and self.config.logging['color']:
             handlers.append(ColoredLoggingHandler(self))
         else:
             handlers.append(LoggingHandler(self))
@@ -760,8 +760,16 @@ class PokemonGoBot(Datastore):
         logging.getLogger("pgoapi").setLevel(log_level)
         logging.getLogger("rpc_api").setLevel(log_level)
 
-        if self.config.logging_clean and not self.config.debug:
-            formatter = Formatter(fmt='[%(asctime)s] %(message)s', datefmt='%H:%M:%S')
+        if self.config.logging:
+            logging_format = '%(message)s'
+            if ('show_log_level' in self.config.logging and self.config.logging['show_log_level']) or 'show_log_level' not in self.config.logging:
+                logging_format = '[%(levelname)s] ' + logging_format
+            if ('show_process_name' in self.config.logging and self.config.logging['show_process_name']) or 'show_process_name' not in self.config.logging:
+                logging_format = '[%(name)10s] ' + logging_format
+            if ('show_datetime' in self.config.logging and self.config.logging['show_datetime']) or 'show_datetime' not in self.config.logging:
+                logging_format = '[%(asctime)s] ' + logging_format
+                
+            formatter = Formatter(fmt=logging_format)
             for handler in logging.root.handlers[:]:
                 handler.setFormatter(formatter)
 

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -764,14 +764,11 @@ class PokemonGoBot(Datastore):
             logging_format = '%(message)s'
             logging_format_options = ''
             
-            if 'show_log_level' not in self.config.logging or \
-                    ('show_log_level' in self.config.logging and self.config.logging['show_log_level']):
+            if ('show_log_level' not in self.config.logging) or self.config.logging['show_log_level']:
                 logging_format = '[%(levelname)s] ' + logging_format
-            if 'show_process_name' not in self.config.logging or \
-                    ('show_process_name' in self.config.logging and self.config.logging['show_process_name']):
+            if ('show_process_name' not in self.config.logging) or self.config.logging['show_process_name']:
                 logging_format = '[%(name)10s] ' + logging_format
-            if 'show_datetime' not in self.config.logging or \
-                    ('show_datetime' in self.config.logging and self.config.logging['show_datetime']):
+            if ('show_datetime' not in self.config.logging) or self.config.logging['show_datetime']:
                 logging_format = '[%(asctime)s] ' + logging_format
                 logging_format_options = '%Y-%m-%d %H:%M:%S'
                 

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -762,14 +762,16 @@ class PokemonGoBot(Datastore):
 
         if self.config.logging:
             logging_format = '%(message)s'
+            logging_format_options = ''
             if ('show_log_level' in self.config.logging and self.config.logging['show_log_level']) or 'show_log_level' not in self.config.logging:
                 logging_format = '[%(levelname)s] ' + logging_format
             if ('show_process_name' in self.config.logging and self.config.logging['show_process_name']) or 'show_process_name' not in self.config.logging:
                 logging_format = '[%(name)10s] ' + logging_format
             if ('show_datetime' in self.config.logging and self.config.logging['show_datetime']) or 'show_datetime' not in self.config.logging:
                 logging_format = '[%(asctime)s] ' + logging_format
+                logging_format_options = '%Y-%m-%d %H:%M:%S'
                 
-            formatter = Formatter(fmt=logging_format)
+            formatter = Formatter(logging_format,logging_format_options)
             for handler in logging.root.handlers[:]:
                 handler.setFormatter(formatter)
 

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -132,6 +132,9 @@ class PokemonGoBot(Datastore):
     def _setup_event_system(self):
         handlers = []
 
+        if self.config.logging_color:
+            self.logger.warning('The logging_color argument has been moved into the logging config section')
+                
         if self.config.logging and 'color' in self.config.logging and self.config.logging['color']:
             handlers.append(ColoredLoggingHandler(self))
         else:

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -763,11 +763,15 @@ class PokemonGoBot(Datastore):
         if self.config.logging:
             logging_format = '%(message)s'
             logging_format_options = ''
-            if ('show_log_level' in self.config.logging and self.config.logging['show_log_level']) or 'show_log_level' not in self.config.logging:
+            
+            if 'show_log_level' not in self.config.logging or \
+                    ('show_log_level' in self.config.logging and self.config.logging['show_log_level']):
                 logging_format = '[%(levelname)s] ' + logging_format
-            if ('show_process_name' in self.config.logging and self.config.logging['show_process_name']) or 'show_process_name' not in self.config.logging:
+            if 'show_process_name' not in self.config.logging or \
+                    ('show_process_name' in self.config.logging and self.config.logging['show_process_name']):
                 logging_format = '[%(name)10s] ' + logging_format
-            if ('show_datetime' in self.config.logging and self.config.logging['show_datetime']) or 'show_datetime' not in self.config.logging:
+            if 'show_datetime' not in self.config.logging or \
+                    ('show_datetime' in self.config.logging and self.config.logging['show_datetime']):
                 logging_format = '[%(asctime)s] ' + logging_format
                 logging_format_options = '%Y-%m-%d %H:%M:%S'
                 

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -132,9 +132,6 @@ class PokemonGoBot(Datastore):
     def _setup_event_system(self):
         handlers = []
 
-        if self.config.logging_color:
-            self.logger.warning('The logging_color argument has been moved into the logging config section')
-                
         if self.config.logging and 'color' in self.config.logging and self.config.logging['color']:
             handlers.append(ColoredLoggingHandler(self))
         else:


### PR DESCRIPTION
## Short Description:
Enhancements to logging output options

Adds new "logging" category to config, with the following options:
- color: t/f (replaces existing "colored_logging" setting)
- show_datetime: t/f
- show_process_name: t/f
- show_log_level

Note that this only takes effect after initial output due to the order in which things are loaded. Too much work at this stage to move everything around just for a few lines.

## Fixes/Resolves/Closes (please use correct syntax):
- Replaces PR #4821 
- Expands on #3706

