### PR TITLE
remove equip_badge call, iso version does not add eqiup_badge to play…

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -1215,20 +1215,7 @@ class PokemonGoBot(Datastore):
                         data={'badge': badgename,
                               'level' : badgelevel }
                     )
-
-                    #todo move equip badge into its own task once working
-                    #should work but gives errors :'(s
-                    #response = self.api.equip_badge(badge_type=badge)
-                    response = {'responses': "awaiting further testing on api call to equip_badge"}
-                    self.event_manager.emit(
-                        'badges',
-                        sender=self,
-                        level='info',
-                        formatted='equiped badge: {badge}',
-                        data={'badge': response['responses']}
-                    )
                     human_behaviour.action_delay(3,10)
-
 
         try:
             self.web_update_queue.put_nowait(True)  # do this outside of thread every tick


### PR DESCRIPTION
## Short Description:
having testing the iso version on awarded badges and what changes in the player data. it seems equip_badge call is not needed as the player_data does not change. As such deletion of commented out code and message which is not required. The delay is still required as badges do take time to display and accept and if multiple badges are awarded each badge needs to be accepted before the next is displayed. Note you can capture multiple pokemon before the awards show up so it is built into the heartbeat and the heartbeat seems to be delayed till you are back on the map and have not issued another event/action.

## Resolves:
resolves #4522 