### PR TITLE
corrected logic to respect snipe = true

### DIFF
--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -144,7 +144,7 @@ class MoveToMapPokemon(BaseTask):
                 pokemon['longitude'],
             )
 
-            if pokemon['dist'] > self.config['max_distance'] or not self.config['snipe']:
+            if pokemon['dist'] > self.config['max_distance'] and not self.config['snipe']:
                 continue
 
             # pokemon not reachable with mean walking speed (by config)


### PR DESCRIPTION
- move_to_map was ignoring pokemons which were beyond "max distance" (which is normal for sniping); an "or" had to be changed to "and" in order to only ignore such pokemons if sniping was turned off.