### PR TITLE
Implemented more granular parameters for Telegram notifications

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -12,7 +12,12 @@
         "config": {
           "enabled": false,
           "master": null,
-          "alert_catch": ["all"]
+          "// old syntax, still supported: alert_catch": ["all"],
+	  "// new syntax:": {},
+	  "alert_catch": {
+		  "all": {"operator": "and", "cp": 1300, "iv": 0.95},
+		  "Snorlax": {"operator": "or", "cp": 900, "iv": 0.9}
+	  }
         }
       },
       {

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -144,7 +144,7 @@ class MoveToMapPokemon(BaseTask):
                 pokemon['longitude'],
             )
 
-            if pokemon['dist'] > self.config['max_distance'] or not self.config['snipe']:
+            if pokemon['dist'] > self.config['max_distance'] and not self.config['snipe']:
                 continue
 
             # pokemon not reachable with mean walking speed (by config)

--- a/pokemongo_bot/event_handlers/telegram_handler.py
+++ b/pokemongo_bot/event_handlers/telegram_handler.py
@@ -21,10 +21,22 @@ class TelegramHandler(EventHandler):
             if event == 'level_up':
                 msg = "level up ({})".format(data["current_level"])
             elif event == 'pokemon_caught':
-                if data["pokemon"] in self.pokemons or self.pokemons[0]=="all":
-                    msg = "Caught {} CP: {}, IV: {}".format(data["pokemon"],data["cp"],data["iv"])
+                if isinstance(self.pokemons, list):
+                    if data["pokemon"] in self.pokemons or "all" in self.pokemons:
+                        msg = "Caught {} CP: {}, IV: {}".format(data["pokemon"],data["cp"],data["iv"])
+                    else:
+                        return
                 else:
-                    return
+                    if data["pokemon"] in self.pokemons:
+                        trigger = self.pokemons[data["pokemon"]]
+                    elif "all" in self.pokemons:
+                        trigger = self.pokemons["all"]
+                    else:
+                        return
+                    if (not "operator" in trigger or trigger["operator"] == "and") and data["cp"] >= trigger["cp"] and data["iv"] >= trigger["iv"] or ("operator" in trigger and trigger["operator"] == "or" and (data["cp"] >= trigger["cp"] or data["iv"] >= trigger["iv"])):
+                        msg = "Caught {} CP: {}, IV: {}".format(data["pokemon"],data["cp"],data["iv"])
+                    else:
+                        return
             else:
                 return
             self.tbot.sendMessage(chat_id=master, parse_mode='Markdown', text=msg)


### PR DESCRIPTION
## Short Description:
"alert_catch" now can be either a list as before (alert on every catch of the corresponding pokemon) or a dictionary of dictionaries, of the form:
"alert_catch": {
   "PokemonName": { "operator": "and/or", "iv": 0.9, "cp": 1000}
}
