### PR TITLE
Incubate eggs fix

### DIFF
--- a/pokemongo_bot/cell_workers/incubate_eggs.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs.py
@@ -35,15 +35,18 @@ class IncubateEggs(BaseTask):
         except:
             return
 
+        should_print = self._should_print()
+
         if self.used_incubators and IncubateEggs.last_km_walked != self.km_walked:
             self.used_incubators.sort(key=lambda x: x.get("km"))
             km_left = self.used_incubators[0]['km']-self.km_walked
             if km_left <= 0:
                 self._hatch_eggs()
+                should_print = False
             else:
                 self.bot.metrics.next_hatching_km(km_left)
 
-        if self._should_print():
+        if should_print:
             self._print_eggs()
             self._compute_next_update()
 

--- a/pokemongo_bot/cell_workers/incubate_eggs.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs.py
@@ -180,9 +180,6 @@ class IncubateEggs(BaseTask):
                             pokemon.get('individual_stamina', 0)
                         ]})
                     matched_pokemon.append(pokemon)
-                    #remove as egg and add as pokemon
-                    inventory.pokemons().remove(pokemon['id'])
-                    inventory.pokemons().add(inventory.Pokemon(pokemon))
                 continue
             if "player_stats" in inv_data:
                 self.km_walked = inv_data.get("player_stats", {}).get("km_walked", 0)
@@ -216,6 +213,9 @@ class IncubateEggs(BaseTask):
                 # pokemon ids seem to be offset by one
                 if pokemon['pokemon_id']!=-1:
                     pokemon['name'] = self.bot.pokemon_list[(pokemon.get('pokemon_id')-1)]['Name']
+                    #remove as egg and add as pokemon
+                    inventory.pokemons().remove(pokemon['id'])
+                    inventory.pokemons().add(inventory.Pokemon(pokemon))
                 else:
                     pokemon['name'] = "error"
         except:

--- a/pokemongo_bot/cell_workers/incubate_eggs.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs.py
@@ -180,6 +180,9 @@ class IncubateEggs(BaseTask):
                             pokemon.get('individual_stamina', 0)
                         ]})
                     matched_pokemon.append(pokemon)
+                    #remove as egg and add as pokemon
+                    inventory.pokemons().remove(pokemon['id'])
+                    inventory.pokemons().add(inventory.Pokemon(pokemon))
                 continue
             if "player_stats" in inv_data:
                 self.km_walked = inv_data.get("player_stats", {}).get("km_walked", 0)
@@ -213,7 +216,6 @@ class IncubateEggs(BaseTask):
                 # pokemon ids seem to be offset by one
                 if pokemon['pokemon_id']!=-1:
                     pokemon['name'] = self.bot.pokemon_list[(pokemon.get('pokemon_id')-1)]['Name']
-                    inventory.pokemons().add(inventory.Pokemon(pokemon))
                 else:
                     pokemon['name'] = "error"
         except:

--- a/pokemongo_bot/cell_workers/incubate_eggs.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+from pokemongo_bot import inventory
 from pokemongo_bot.human_behaviour import sleep
 from pokemongo_bot.base_task import BaseTask
 
@@ -206,14 +207,13 @@ class IncubateEggs(BaseTask):
         candy = result.get('candy_awarded', "error")
         xp = result.get('experience_awarded', "error")
         sleep(self.hatching_animation_delay)
-        self.bot.latest_inventory = None
         try:
             pokemon_data = self._check_inventory(pokemon_ids)
             for pokemon in pokemon_data:
                 # pokemon ids seem to be offset by one
                 if pokemon['pokemon_id']!=-1:
                     pokemon['name'] = self.bot.pokemon_list[(pokemon.get('pokemon_id')-1)]['Name']
-                    inventory.pokemons().add(pokemon)
+                    inventory.pokemons().add(inventory.Pokemon(pokemon))
                 else:
                     pokemon['name'] = "error"
         except:

--- a/pokemongo_bot/cell_workers/incubate_eggs.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs.py
@@ -62,9 +62,9 @@ class IncubateEggs(BaseTask):
 
         if self.ready_breakable_incubators:
             # get available eggs
-            eggs = self._filter_sort_eggs(self.infinite_incubator,
-                    self.infinite_longer_eggs_first)
-            self._apply_incubators(eggs, self.ready_infinite_incubators)
+            eggs = self._filter_sort_eggs(self.breakable_incubator,
+                    self.breakable_longer_eggs_first)
+            self._apply_incubators(eggs, self.ready_breakable_incubators)
 
 
     def _filter_sort_eggs(self, allowed, sorting):

--- a/pokemongo_bot/cell_workers/incubate_eggs.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs.py
@@ -219,6 +219,7 @@ class IncubateEggs(BaseTask):
                 # pokemon ids seem to be offset by one
                 if pokemon['pokemon_id']!=-1:
                     pokemon['name'] = self.bot.pokemon_list[(pokemon.get('pokemon_id')-1)]['Name']
+                    inventory.pokemons().add(pokemon)
                 else:
                     pokemon['name'] = "error"
         except:


### PR DESCRIPTION
## Short Description:
Fixed a bug when hatching an egg and displaying the eggs at the same time would print wrong output (something like an egg hatching '2.26/2.0 km').
Fixed a bug where breakable incubators weren't being used.
Updated cached inventory after an egg hatched, removing the egg from the inventory and adding it as pokemon.