### PR TITLE
Use real position for spins

### DIFF
--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -180,20 +180,13 @@ class SpinFort(Datastore, BaseTask):
     def get_forts_in_range(self):
         forts = self.bot.get_forts(order_by_distance=True)
         forts = filter(lambda fort: fort["id"] not in self.bot.fort_timeouts, forts)
-        if self.bot.config.replicate_gps_xy_noise:
-            forts = filter(lambda fort: distance(
-                self.bot.noised_position[0],
-                self.bot.noised_position[1],
-                fort['latitude'],
-                fort['longitude']
-            ) <= Constants.MAX_DISTANCE_FORT_IS_REACHABLE, forts)
-        else:
-            forts = filter(lambda fort: distance(
-                self.bot.position[0],
-                self.bot.position[1],
-                fort['latitude'],
-                fort['longitude']
-            ) <= Constants.MAX_DISTANCE_FORT_IS_REACHABLE, forts)
+
+        forts = filter(lambda fort: distance(
+            self.bot.position[0],
+            self.bot.position[1],
+            fort['latitude'],
+            fort['longitude']
+        ) <= Constants.MAX_DISTANCE_FORT_IS_REACHABLE, forts)
 
         return forts
 


### PR DESCRIPTION
- Removed use of noised position for fort spins

I'll leave this up for discussion. In my opinion, we use noise to better mimic phone GPS data. With that, however, we should be using our "actual" position for interacting in the world. Thoughts?

Closes last bit of #4760