### PR TITLE
improve docker pull speed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,24 +23,23 @@ LABEL build_repo=$BUILD_REPO build_branch=$BUILD_BRANCH
 WORKDIR /usr/src/app
 VOLUME ["/usr/src/app/configs", "/usr/src/app/web"]
 
-ADD https://raw.githubusercontent.com/$BUILD_REPO/$BUILD_BRANCH/requirements.txt .
 RUN apk -U --no-cache add python py-pip \
-    && apk --no-cache add --virtual .build-dependencies python-dev gcc make musl-dev git tzdata \
-    && cp -fa /usr/share/zoneinfo/$TIMEZONE /etc/localtime \
-    && echo $TIMEZONE > /etc/timezone \
-    && ln -s locale.h /usr/include/xlocale.h \
-    && pip install --no-cache-dir -r requirements.txt \
-    && apk del .build-dependencies \
-    && rm -rf /var/cache/apk/* /usr/include/xlocale.h \
+    && rm -rf /var/cache/apk/* \
     && find / -name '*.pyc' -o -name '*.pyo' | xargs -rn1 rm -f
 
 ADD http://pgoapi.com/pgoencrypt.tar.gz /tmp/pgoencrypt.tar.gz
-RUN apk --no-cache add --virtual .pgoencrypt-dependencies gcc make musl-dev \
+ADD https://raw.githubusercontent.com/$BUILD_REPO/$BUILD_BRANCH/requirements.txt .
+RUN apk -U --no-cache add --virtual .build-dependencies python-dev gcc make musl-dev git tzdata \
+    && cp -fa /usr/share/zoneinfo/$TIMEZONE /etc/localtime \
+    && echo $TIMEZONE > /etc/timezone \
     && tar zxf /tmp/pgoencrypt.tar.gz -C /tmp \
     && make -C /tmp/pgoencrypt/src \
     && cp /tmp/pgoencrypt/src/libencrypt.so /usr/src/app/encrypt.so \
-    && apk del .pgoencrypt-dependencies \
-    && rm -rf /var/cache/apk/* /tmp/pgoencrypt /tmp/pgoencrypt.tar.gz
+    && ln -s locale.h /usr/include/xlocale.h \
+    && pip install --no-cache-dir -r requirements.txt \
+    && apk del .build-dependencies \
+    && rm -rf /var/cache/apk/* /tmp/pgoencrypt* /usr/include/xlocale.h \
+    && find / -name '*.pyc' -o -name '*.pyo' | xargs -rn1 rm -f
 
 ADD https://api.github.com/repos/$BUILD_REPO/commits/$BUILD_BRANCH /tmp/pgobot-version
 RUN apk -U --no-cache add --virtual .pgobot-dependencies wget ca-certificates tar jq \


### PR DESCRIPTION
## Short Description:

- docker pull speeded up when it need to update image layers (only pokemongo-bot src)
- it's not very often that we need to rebuild pgoencrypt

```
⋊> ~ curl -sI http://pgoapi.com/pgoencrypt.tar.gz | grep Last-Modified                                                                                                                                                                00:52:09
Last-Modified: Sun, 07 Aug 2016 00:36:22 GMT
```