### PR TITLE
Fix for run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -3,14 +3,14 @@ pokebotpath=$(cd "$(dirname "$0")"; pwd)
 auth=""
 config=""
 if [ ! -z $1 ]; then
-  auth=$1
-else
-  auth="./configs/auth.json"
-fi
-if [ ! -z $2 ]; then
-  config=$2
+  config=$1
 else
   config="./configs/config.json"
+fi
+if [ ! -z $2 ]; then
+  auth=$2
+else
+  auth="./configs/auth.json"
 fi
 cd $pokebotpath
 source bin/activate


### PR DESCRIPTION

## Fix for run.sh

## Fixes
- Currently `run.sh` requires an auth file as the first parameter for `pokecli.py` to run, which forces everyone to use auth files.
- Swapped config and auth position so old command of `./run.sh ./configs/myconfig.json` works again.

Note: Those running `./run.sh ./configs/myauth.json ./configs/configalexnew.json` need to swap the parameters back.
