### PR TITLE
Add $TIMEZONE environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,22 +16,19 @@ FROM alpine
 
 ARG BUILD_REPO=PokemonGoF/PokemonGo-Bot
 ARG BUILD_BRANCH=master
-ARG TIMEZONE=Etc/UTC
 
 LABEL build_repo=$BUILD_REPO build_branch=$BUILD_BRANCH
 
 WORKDIR /usr/src/app
 VOLUME ["/usr/src/app/configs", "/usr/src/app/web"]
 
-RUN apk -U --no-cache add python py-pip \
+RUN apk -U --no-cache add python py-pip tzdata \
     && rm -rf /var/cache/apk/* \
     && find / -name '*.pyc' -o -name '*.pyo' | xargs -rn1 rm -f
 
 ADD http://pgoapi.com/pgoencrypt.tar.gz /tmp/pgoencrypt.tar.gz
 ADD https://raw.githubusercontent.com/$BUILD_REPO/$BUILD_BRANCH/requirements.txt .
-RUN apk -U --no-cache add --virtual .build-dependencies python-dev gcc make musl-dev git tzdata \
-    && cp -fa /usr/share/zoneinfo/$TIMEZONE /etc/localtime \
-    && echo $TIMEZONE > /etc/timezone \
+RUN apk -U --no-cache add --virtual .build-dependencies python-dev gcc make musl-dev git \
     && tar zxf /tmp/pgoencrypt.tar.gz -C /tmp \
     && make -C /tmp/pgoencrypt/src \
     && cp /tmp/pgoencrypt/src/libencrypt.so /usr/src/app/encrypt.so \
@@ -48,4 +45,14 @@ RUN apk -U --no-cache add --virtual .pgobot-dependencies wget ca-certificates ta
     && apk del .pgobot-dependencies \
     && rm -rf /var/cache/apk/* /tmp/pgobot-version
 
-ENTRYPOINT ["python", "pokecli.py"]
+RUN printf "#!/bin/sh\n\
+\n\
+TIMEZONE=\${TIMEZONE:-Etc/UTC}\n\
+\n\
+ln -sfn /usr/share/zoneinfo/\$TIMEZONE /etc/localtime\n\
+echo \$TIMEZONE > /etc/timezone\n\
+\n\
+python pokecli.py \$@\n" > /entrypoint.sh \
+    && chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
      - ./configs:/usr/src/app/configs
      - ./data:/usr/src/app/data
      - ./web:/usr/src/app/web
+    environment:
+     - TIMEZONE=Etc/UTC
     stdin_open: true
     tty: true
   bot1-pokegoweb:

--- a/docker-compose_tor.yml
+++ b/docker-compose_tor.yml
@@ -23,6 +23,8 @@ services:
      - ./configs:/usr/src/app/configs
      - ./data:/usr/src/app/data
      - ./web:/usr/src/app/web
+    environment:
+     - TIMEZONE=Etc/UTC
     stdin_open: true
     tty: true
   bot1-pokegoweb:


### PR DESCRIPTION
## Short Description:
Using $TIMEZONE env variable to change docker container's timezone

## Fixes:
- #4234 

Set environment TIMEZONE=Etc/UTC
```
⋊> ~/h/PokemonGo-Bot on update-dockerfile ⨯ docker-compose up
Creating pokemongobot_bot1-pokego_1
Creating pokemongobot_bot1-pokegoweb_1
Attaching to pokemongobot_bot1-pokego_1, pokemongobot_bot1-pokegoweb_1
bot1-pokegoweb_1  | Serving HTTP on 0.0.0.0 port 8000
bot1-pokego_1     | 2016-08-30 17:52:20,815 [       cli] [INFO] PokemonGO Bot v1.0
bot1-pokego_1     | 2016-08-30 17:52:20,822 [       cli] [INFO] commit: not found
```

Set environment TIMEZONE=Asia/Taipei
```
⋊> ~/h/PokemonGo-Bot on update-dockerfile ⨯ docker-compose up
Recreating pokemongobot_bot1-pokego_1
Recreating pokemongobot_bot1-pokegoweb_1
Attaching to pokemongobot_bot1-pokego_1, pokemongobot_bot1-pokegoweb_1
bot1-pokegoweb_1  | Serving HTTP on 0.0.0.0 port 8000
bot1-pokego_1     | 2016-08-31 01:52:42,717 [       cli] [INFO] PokemonGO Bot v1.0
bot1-pokego_1     | 2016-08-31 01:52:42,726 [       cli] [INFO] commit: not found
```