### PR TITLE
Fix incubate eggs

### DIFF
--- a/pokemongo_bot/cell_workers/incubate_eggs.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs.py
@@ -130,17 +130,10 @@ class IncubateEggs(BaseTask):
         temp_used_incubators = []
         temp_ready_breakable_incubators = []
         temp_ready_infinite_incubators = []
-        inv = reduce(
-            dict.__getitem__,
-            ["responses", "GET_INVENTORY", "inventory_delta", "inventory_items"],
-            inventory.jsonify_inventory()
-        )
+        inv = inventory.jsonify_inventory()
         for inv_data in inv:
             inv_data = inv_data.get("inventory_item_data", {})
             if "egg_incubators" in inv_data:
-                temp_used_incubators = []
-                temp_ready_breakable_incubators = []
-                temp_ready_infinite_incubators = []
                 incubators = inv_data.get("egg_incubators", {}).get("egg_incubator",[])
                 if isinstance(incubators, basestring):  # checking for old response
                     incubators = [incubators]

--- a/pokemongo_bot/inventory.py
+++ b/pokemongo_bot/inventory.py
@@ -1178,6 +1178,7 @@ class Inventory(object):
         self.items = Items()
         self.pokemons = Pokemons()
         self.player = Player(self.bot)  # include inventory inside Player?
+        self.egg_incubators = None
         self.refresh()
         self.item_inventory_size = None
         self.pokemon_inventory_size = None
@@ -1189,6 +1190,8 @@ class Inventory(object):
         inventory = inventory['responses']['GET_INVENTORY']['inventory_delta']['inventory_items']
         for i in (self.pokedex, self.candy, self.items, self.pokemons, self.player):
             i.refresh(inventory)
+
+        self.egg_incubators = [x["inventory_item_data"] for x in inventory if "egg_incubators" in x["inventory_item_data"]]
 
         self.update_web_inventory()
 
@@ -1234,8 +1237,11 @@ class Inventory(object):
         for item_id, item in self.items._data.items():
             json_inventory.append({"inventory_item_data": {"item": {"item_id": item_id, "count": item.count}}})
 
-        for pokemon in self.pokemons.all():
+        for pokemon in self.pokemons.all_with_eggs():
             json_inventory.append({"inventory_item_data": {"pokemon_data": pokemon._data}})
+
+        for inc in self.egg_incubators:
+            json_inventory.append({"inventory_item_data": inc})
 
         return json_inventory
 


### PR DESCRIPTION
## Short Description:
Due to removal of api call on `incubate_eggs`, eggs weren't incubating.
Fixed it by adding `egg_incubators` item to json inventory file.

## Fixes/Resolves/Closes (please use correct syntax):
- Fixes [#4947](https://github.com/PokemonGoF/PokemonGo-Bot/issues/4947)
