### PR TITLE
Fix incubate eggs

### DIFF
--- a/pokemongo_bot/cell_workers/incubate_eggs.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs.py
@@ -213,7 +213,7 @@ class IncubateEggs(BaseTask):
                     pokemon['name'] = "error"
         except:
             pokemon_data = [{"name":"error", "cp":"error", "iv":"error"}]
-        if not pokemon_ids or pokemon_data[0]['name'] == "error":
+        if not pokemon_ids or not pokemon_data or pokemon_data[0]['name'] == "error":
             self.emit_event(
                 'egg_hatched',
                 data={

--- a/pokemongo_bot/cell_workers/incubate_eggs.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs.py
@@ -124,7 +124,8 @@ class IncubateEggs(BaseTask):
                         egg["used"] = True
 
     def _check_inventory(self, lookup_ids=[]):
-        inv = {}
+        if lookup_ids:
+            inventory.refresh_inventory()
         matched_pokemon = []
         temp_eggs = []
         temp_used_incubators = []
@@ -212,21 +213,18 @@ class IncubateEggs(BaseTask):
                     pokemon['name'] = "error"
         except:
             pokemon_data = [{"name":"error", "cp":"error", "iv":"error"}]
-        try:
-            if not pokemon_ids or pokemon_data[0]['name'] == "error":
-                self.emit_event(
-                    'egg_hatched',
-                    data={
-                        'pokemon': 'error',
-                        'cp': 'error',
-                        'iv': 'error',
-                        'exp': 'error',
-                        'stardust': 'error',
-                        'candy': 'error',
-                    }
-                )
-                return
-        except IndexError:
+        if not pokemon_ids or pokemon_data[0]['name'] == "error":
+            self.emit_event(
+                'egg_hatched',
+                data={
+                    'pokemon': 'error',
+                    'cp': 'error',
+                    'iv': 'error',
+                    'exp': 'error',
+                    'stardust': 'error',
+                    'candy': 'error',
+                }
+            )
             return
         for i in range(len(pokemon_data)):
             msg = "Egg hatched with a {pokemon} (CP {cp} - IV {iv}), {exp} exp, {stardust} stardust and {candy} candies."


### PR DESCRIPTION
## Short Description:
Since `incubate_eggs` task is not making an api call anymore and is using cached inventory, when an egg hatches it couldn't find it since it wouldn't appear on the inventory.
It now updates inventory after an egg hatches so it can get data about the Pokemon.

## Fixes/Resolves/Closes (please use correct syntax):
- Fixes [#4966](https://github.com/PokemonGoF/PokemonGo-Bot/issues/4966)
- Fixes [#4947](https://github.com/PokemonGoF/PokemonGo-Bot/issues/4947)
