### PR TITLE
Inventory refresh before hatching eggs

### DIFF
--- a/pokemongo_bot/cell_workers/incubate_eggs.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs.py
@@ -130,6 +130,11 @@ class IncubateEggs(BaseTask):
         temp_used_incubators = []
         temp_ready_breakable_incubators = []
         temp_ready_infinite_incubators = []
+        
+        # Force inventory refresh to ensure we have correct data to compare against
+        if lookup_ids:
+            inventory.refresh()
+            
         inv = inventory.jsonify_inventory()
         for inv_data in inv:
             inv_data = inv_data.get("inventory_item_data", {})


### PR DESCRIPTION
## Short Description:

Added inventory.refresh() to egg hatching, otherwise the inventory can't provide information needed for correct display.

## Fixes/Resolves/Closes (please use correct syntax):
- #4966 

Egg hatching needs a current copy of inventory (post egg hatching) to be
able to display details. Api call to refresh inventory occurs if there
are eggs to hatch.