### PR TITLE
Split max_distance into max_sniping_distance and max_walking_distance

### DIFF
--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -189,8 +189,10 @@
         "config": {
           "enabled": true,
           "address": "http://localhost:5000",
-          "//NOTE: Change the max_distance to adjust the max sniping range (km)": {},
-          "max_distance": 500,
+          "//NOTE: Change the max_sniping_distance to adjust the max sniping range (m)": {},
+          "max_sniping distance": 10000,
+          "//NOTE: Change the max_walking_distance to adjust the max walking range when snipe is off (m)": {},
+          "max__walking_distance": 500,
           "min_ball": 50,
           "prioritize_vips": true,
           "snipe": true,

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -612,7 +612,8 @@ This task will fetch current pokemon spawns from /raw_data of an PokemonGo-Map i
 * `prioritize_vips` - Will prioritize vips in distance and priority mode above all normal pokemon if set to true
 * `min_time` - Minimum time the pokemon has to be available before despawn
 * `min_ball` - Minimum amount of balls required to run task
-* `max_distance` - Maximum distance the pokemon is allowed to be when sniping. (km)
+* `max_sniping_distance` - Maximum distance the pokemon is allowed to be caught when sniping. (m)
+* `max_walking_distance` - Maximum distance the pokemon is allowed to be caught when sniping is turned off. (m)
 * `snipe`:
    - `True` - Will teleport to target pokemon, encounter it, teleport back then catch it
    - `False` - Will walk normally to the pokemon
@@ -634,8 +635,10 @@ This task will fetch current pokemon spawns from /raw_data of an PokemonGo-Map i
     "type": "MoveToMapPokemon",
     "config": {
       "address": "http://localhost:5000",
-      "//NOTE: Change the max_distance to adjust the max sniping range (km)": {},
-      "max_distance": 500,
+      "//NOTE: Change the max_sniping_distance to adjust the max sniping range (m)": {},
+      "max_sniping distance": 10000,
+      "//NOTE: Change the max_walking_distance to adjust the max walking range when snipe is off (m)": {},
+      "max__walking_distance": 500,
       "min_time": 60,
       "min_ball": 50,
       "prioritize_vips": true,

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -138,7 +138,10 @@ class MoveToMapPokemon(BaseTask):
                 pokemon['longitude'],
             )
 
-            if pokemon['dist'] > self.config['max_distance'] and not self.config['snipe']:
+            if pokemon['dist'] > self.config['max_sniping_distance'] and self.config['snipe']:
+                continue
+
+            if pokemon['dist'] > self.config['max_walking_distance'] and not self.config['snipe']:
                 continue
 
             # pokemon not reachable with mean walking speed (by config)
@@ -192,7 +195,10 @@ class MoveToMapPokemon(BaseTask):
                 pokemon['longitude'],
             )
 
-            if pokemon['dist'] > self.config['max_distance'] and not self.config['snipe']:
+            if pokemon['dist'] > self.config['max_sniping_distance'] and self.config['snipe']:
+                continue
+
+            if pokemon['dist'] > self.config['max_walking_distance'] and not self.config['snipe']:
                 continue
 
             # pokemon not reachable with mean walking speed (by config)


### PR DESCRIPTION
## Short Description:
Split max_distance into max_sniping_distance and max_walking_distance

## Fixes/Resolves/Closes (please use correct syntax):
- as discussed in https://github.com/PokemonGoF/PokemonGo-Bot/pull/4969


