### PR TITLE
fix inventory, only call level_up_reward api when needed, up-to-date …

### DIFF
--- a/pokemongo_bot/cell_workers/evolve_pokemon.py
+++ b/pokemongo_bot/cell_workers/evolve_pokemon.py
@@ -142,6 +142,7 @@ class EvolvePokemon(Datastore, BaseTask):
             inventory.pokemons().remove(pokemon.unique_id)
             new_pokemon = inventory.Pokemon(evolution)
             inventory.pokemons().add(new_pokemon)
+            inventory.player().exp += xp
 
             sleep(uniform(self.min_evolve_speed, self.max_evolve_speed))
             evolve_result = True

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -526,7 +526,9 @@ class PokemonCatchWorker(Datastore, BaseTask):
 
                 try:
                     inventory.pokemons().add(pokemon)
-                    exp_gain = sum(response_dict['responses']['CATCH_POKEMON']['capture_award']['xp'])
+                    exp_gain = sum(response_dict['responses']['CATCH_POKEMON']['capture_award']['xp'])  
+                    # update player's exp
+                    inventory.player().exp += exp_gain
 
                     self.emit_event(
                         'pokemon_caught',

--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -202,6 +202,9 @@ class SpinFort(Datastore, BaseTask):
         return forts
 
     def get_items_awarded_from_fort_spinned(self, response_dict):
+        experience_awarded = response_dict['responses']['FORT_SEARCH'].get('experience_awarded', 0)
+        inventory.player().exp += experience_awarded
+
         items_awarded = response_dict['responses']['FORT_SEARCH'].get('items_awarded', {})
         if items_awarded:
             tmp_count_items = {}

--- a/pokemongo_bot/inventory.py
+++ b/pokemongo_bot/inventory.py
@@ -113,7 +113,7 @@ class Player(_BaseInventoryComponent):
     def exp(self, value):
         # if new exp is larger than or equal to next_level_xp
         if value >= self.next_level_xp:
-            self.level = self.level + 1
+            self.level = self._level + 1
             # increase next_level_xp to a big amount
             # will be fix on the next heartbeat
             self.next_level_xp += 10000000

--- a/pokemongo_bot/inventory.py
+++ b/pokemongo_bot/inventory.py
@@ -94,7 +94,6 @@ class Player(_BaseInventoryComponent):
         self.next_level_xp = None
         self.pokemons_captured = None
         self.poke_stop_visits = None
-        self.last_lvl_up_reward = time.time()  # ts of last lvl_up_reward api call
         self.player_stats = None
         super(_BaseInventoryComponent, self).__init__()
 
@@ -104,11 +103,6 @@ class Player(_BaseInventoryComponent):
 
     @level.setter
     def level(self, value):
-        if self._level != value:
-            now = time.time()
-            if now - self.last_lvl_up_reward > self.ttl:
-                self.bot.api.level_up_rewards(level=self.level)
-
         self._level = value
 
     @property
@@ -117,10 +111,12 @@ class Player(_BaseInventoryComponent):
 
     @exp.setter
     def exp(self, value):
-        if self._exp != value:
-            now = time.time()
-            if now - self.last_lvl_up_reward > self.ttl:
-                self.bot.api.level_up_rewards(level=self.level)
+        # if new exp is larger than or equal to next_level_xp
+        if value >= self.next_level_xp:
+            self.level = self.level + 1
+            # increase next_level_xp to a big amount
+            # will be fix on the next heartbeat
+            self.next_level_xp += 10000000
 
         self._exp = value
 
@@ -131,9 +127,9 @@ class Player(_BaseInventoryComponent):
         if not item:
             item = {}
 
+        self.next_level_xp = item.get('next_level_xp', 0)
         self.exp = item.get('experience', 0)
         self.level = item.get('level', 0)
-        self.next_level_xp = item.get('next_level_xp', 0)
         self.pokemons_captured = item.get('pokemons_captured', 0)
         self.poke_stop_visits = item.get('poke_stop_visits', 0)
 


### PR DESCRIPTION
## Short Description:
- get rid of redundant level_up_rewards api call.
- update player exp on spin fort, pokemon caught, evolve pokemon

## Fixes/Resolves/Closes (please use correct syntax):
-
-
-
