### PR TITLE
'red' not supported by logger

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -1351,7 +1351,7 @@ class PokemonGoBot(Datastore):
                 with open(cached_forts_path) as f:
                     cached_recent_forts = json.load(f)
             except (IOError, ValueError) as e:
-                self.logger.info('[x] Error while opening cached forts: %s' % e, 'red')
+                self.logger.info('[x] Error while opening cached forts: %s' % e)
                 pass
             except:
                 raise FileIOException("Unexpected error opening {}".cached_forts_path)


### PR DESCRIPTION
## Short Description:

When trying to read cached forts on first run (or if file has been deleted), tries to generate a log message, but option 'red' is not supported. Removed.

## Fixes/Resolves/Closes (please use correct syntax):
- #5042 
