### PR TITLE
Add poke lvl

### DIFF
--- a/pokemongo_bot/inventory.py
+++ b/pokemongo_bot/inventory.py
@@ -868,6 +868,9 @@ class Pokemon(object):
         # Current pokemon level (half of level is a normal value)
         self.level = LevelToCPm.level_from_cpm(self.cp_m)
 
+        if 'level' not in self._data:
+            self._data['level'] = self.level
+
         # Maximum health points
         self.hp_max = data['stamina_max']
         # Current health points


### PR DESCRIPTION
## Short Description:

add poke level information to ._data so that it will show in the inventory-* dump.
This can then be used to display pokemon level in the web ui.

## Fixes/Resolves/Closes (please use correct syntax):
-
-
-
