### PR TITLE
Fixes in PolylineWalker

### DIFF
--- a/pokemongo_bot/walkers/polyline_generator.py
+++ b/pokemongo_bot/walkers/polyline_generator.py
@@ -27,7 +27,7 @@ class PolylineObjectHandler:
             abs_offset = haversine.haversine(tuple(origin), PolylineObjectHandler._cache.get_last_pos())*1000
         else:
             abs_offset = float("inf")
-        is_old_cache = lambda : abs_offset < 8 # Consider cache old if we identified an offset more then 8 m
+        is_old_cache = lambda : abs_offset > 8 # Consider cache old if we identified an offset more then 8 m
         new_dest_set = lambda : tuple(destination) != PolylineObjectHandler._cache.destination
 
         if PolylineObjectHandler._run and (not is_old_cache()):

--- a/pokemongo_bot/walkers/polyline_walker.py
+++ b/pokemongo_bot/walkers/polyline_walker.py
@@ -1,5 +1,6 @@
 from random import uniform
 
+from pokemongo_bot.cell_workers.utils import distance
 from pokemongo_bot.walkers.step_walker import StepWalker
 from polyline_generator import PolylineObjectHandler
 
@@ -19,3 +20,10 @@ class PolylineWalker(StepWalker):
         self.pol_alt = self.polyline.get_alt() or self.actual_alt
         super(PolylineWalker, self).__init__(self.bot, self.pol_lat, self.pol_lon,
                                              self.pol_alt, fixed_speed=self.speed)
+
+    def step(self):
+        step = super(PolylineWalker, self).step()
+        if not (distance(self.pol_lat, self.pol_lon, self.dest_lat, self.dest_lng) > 10 and step):
+            return False
+        else:
+            return True

--- a/pokemongo_bot/walkers/polyline_walker.py
+++ b/pokemongo_bot/walkers/polyline_walker.py
@@ -8,7 +8,7 @@ class PolylineWalker(StepWalker):
 
     def __init__(self, bot, dest_lat, dest_lng):
         self.bot = bot
-        self.speed = self.bot.config.walk_min
+        self.speed = uniform(self.bot.config.walk_min, self.bot.config.walk_max)
         self.dest_lat, self.dest_lng = dest_lat, dest_lng
         self.actual_pos = tuple(self.bot.position[:2])
         self.actual_alt = self.bot.position[-1]
@@ -18,4 +18,4 @@ class PolylineWalker(StepWalker):
         self.pol_lat, self.pol_lon = self.polyline.get_pos()
         self.pol_alt = self.polyline.get_alt() or self.actual_alt
         super(PolylineWalker, self).__init__(self.bot, self.pol_lat, self.pol_lon,
-                                             self.pol_alt, fixed_speed=True)
+                                             self.pol_alt, fixed_speed=self.speed)

--- a/pokemongo_bot/walkers/polyline_walker.py
+++ b/pokemongo_bot/walkers/polyline_walker.py
@@ -11,10 +11,11 @@ class PolylineWalker(StepWalker):
         self.speed = self.bot.config.walk_min
         self.dest_lat, self.dest_lng = dest_lat, dest_lng
         self.actual_pos = tuple(self.bot.position[:2])
+        self.actual_alt = self.bot.position[-1]
         self.polyline = PolylineObjectHandler.cached_polyline(self.actual_pos,
                                                               (self.dest_lat, self.dest_lng),
                                                               self.speed, google_map_api_key=self.bot.config.gmapkey)
         self.pol_lat, self.pol_lon = self.polyline.get_pos()
-        self.pol_alt = self.polyline.get_alt() or uniform(self.bot.config.alt_min, self.bot.config.alt_max)
+        self.pol_alt = self.polyline.get_alt() or self.actual_alt
         super(PolylineWalker, self).__init__(self.bot, self.pol_lat, self.pol_lon,
                                              self.pol_alt, fixed_speed=True)

--- a/pokemongo_bot/walkers/step_walker.py
+++ b/pokemongo_bot/walkers/step_walker.py
@@ -7,7 +7,7 @@ from pokemongo_bot.human_behaviour import random_lat_long_delta, sleep, random_a
 
 class StepWalker(object):
 
-    def __init__(self, bot, dest_lat, dest_lng, dest_alt=None, fixed_speed=False):
+    def __init__(self, bot, dest_lat, dest_lng, dest_alt=None, fixed_speed=None):
         self.bot = bot
         self.api = bot.api
 
@@ -25,9 +25,9 @@ class StepWalker(object):
         else:
             self.alt = dest_alt
             
-        if fixed_speed:
+        if fixed_speed != None:
             # PolylineWalker uses a fixed speed!
-            self.speed = self.bot.config.walk_min
+            self.speed = fixed_speed
         else:
             self.speed = uniform(self.bot.config.walk_min, self.bot.config.walk_max)
 


### PR DESCRIPTION
Scenario:
- when there is no cached Polyline we get a None back from the .get_alt()
- when altitude is 0  we get 0 from .get_alt

Issue:
- In polylineWalker I was checking if .get_alt() or uniform(min_alt, max_lat) that clearly fails when altitude is zero.

Fixes:
- will fallback to read the previous position of the bot in the alt 0 or None case
- set the speed in PolylineWalker and passthrough to StepWalker


Additional very Important Fixes:
- Polyline Walker should return False if final destination not reached (might have teleported in some follow workers)
- fixed cache validation.. (this was causing API quota reached)