### PR TITLE
Update telegram_handler.py to fix #5129

### DIFF
--- a/pokemongo_bot/event_handlers/telegram_handler.py
+++ b/pokemongo_bot/event_handlers/telegram_handler.py
@@ -79,7 +79,7 @@ class TelegramClass:
                         self.bot.logger.info("message from {} ({}): {}".format(update.message.from_user.username, update.message.from_user.id, update.message.text))
                         if self.master and self.master not in [update.message.from_user.id, "@{}".format(update.message.from_user.username)]:
                             continue
-                        if not re.match(r'^[0-9]+$', self.master):
+                        if self.master and not re.match(r'^[0-9]+$', str(self.master)):
                             # the "master" is not numeric, set self.master to update.message.chat_id and re-instantiate the handler
                             newconfig = self.config
                             newconfig['master'] = update.message.chat_id


### PR DESCRIPTION
## Short Description:
Fix master check for users that use telegram user id in config instead of telegram username.

## Fixes/Resolves/Closes (please use correct syntax):
Resolves #5129