### PR TITLE
decouple datastore from the bot

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -94,7 +94,14 @@ def main():
         bot.workers = tree
 
     def initialize(config):
-        bot = PokemonGoBot(config)
+        from pokemongo_bot.datastore import Datastore
+
+        ds = Datastore(conn_str='/data/{}.db'.format(config.username))
+        for directory in ['pokemongo_bot', 'pokemongo_bot/cell_workers']:
+            ds.migrate(directory + '/migrations')
+
+        bot = PokemonGoBot(ds.get_connection(), config)
+
         return bot
 
     def start_bot(bot, config):

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -33,7 +33,6 @@ from pokemongo_bot.event_handlers import LoggingHandler, SocketIoHandler, Colore
 from pokemongo_bot.socketio_server.runner import SocketIoRunner
 from pokemongo_bot.websocket_remote_control import WebsocketRemoteControl
 from pokemongo_bot.base_dir import _base_dir
-from pokemongo_bot.datastore import _init_database, Datastore
 from worker_result import WorkerResult
 from tree_config_builder import ConfigException, MismatchTaskApiVersion, TreeConfigBuilder
 from inventory import init_inventory, player
@@ -46,7 +45,7 @@ class FileIOException(Exception):
     pass
 
 
-class PokemonGoBot(Datastore):
+class PokemonGoBot(object):
     @property
     def position(self):
         return self.api.actual_lat, self.api.actual_lng, self.api.actual_alt
@@ -68,10 +67,9 @@ class PokemonGoBot(Datastore):
         """
         return self._player
 
-    def __init__(self, config):
+    def __init__(self, db, config):
 
-        # Database connection MUST be setup before migrations will work
-        self.database = _init_database('/data/{}.db'.format(config.username))
+        self.database = db
 
         self.config = config
         super(PokemonGoBot, self).__init__()

--- a/pokemongo_bot/api_wrapper.py
+++ b/pokemongo_bot/api_wrapper.py
@@ -12,15 +12,13 @@ from pgoapi.pgoapi import PGoApi, PGoApiRequest, RpcApi
 from pgoapi.protos.POGOProtos.Networking.Requests.RequestType_pb2 import RequestType
 from pgoapi.protos.POGOProtos.Networking.Envelopes.Signature_pb2 import Signature
 from pgoapi.utilities import get_time
-from pokemongo_bot.datastore import Datastore
 from human_behaviour import sleep, gps_noise_rng
 from pokemongo_bot.base_dir import _base_dir
 
 class PermaBannedException(Exception):
     pass
 
-
-class ApiWrapper(Datastore, PGoApi):
+class ApiWrapper(PGoApi, object):
     DEVICE_ID = None
 
     def __init__(self, config=None):

--- a/pokemongo_bot/cell_workers/evolve_pokemon.py
+++ b/pokemongo_bot/cell_workers/evolve_pokemon.py
@@ -5,10 +5,9 @@ from pokemongo_bot.human_behaviour import sleep
 from pokemongo_bot.inventory import Pokemon
 from pokemongo_bot.item_list import Item
 from pokemongo_bot.base_task import BaseTask
-from pokemongo_bot.datastore import Datastore
 
 
-class EvolvePokemon(Datastore, BaseTask):
+class EvolvePokemon(BaseTask):
     SUPPORTED_TASK_API_VERSION = 1
     def __init__(self, bot, config):
         super(EvolvePokemon, self).__init__(bot, config)

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -13,7 +13,6 @@ from pokemongo_bot.base_task import BaseTask
 from pokemongo_bot.human_behaviour import sleep, action_delay
 from pokemongo_bot.inventory import Pokemon
 from pokemongo_bot.worker_result import WorkerResult
-from pokemongo_bot.datastore import Datastore
 from pokemongo_bot.base_dir import _base_dir
 from datetime import datetime, timedelta
 from utils import getSeconds
@@ -42,7 +41,7 @@ LOGIC_TO_FUNCTION = {
 }
 
 
-class PokemonCatchWorker(Datastore, BaseTask):
+class PokemonCatchWorker(BaseTask):
 
     def __init__(self, pokemon, bot, config):
         self.pokemon = pokemon

--- a/pokemongo_bot/cell_workers/pokemon_optimizer.py
+++ b/pokemongo_bot/cell_workers/pokemon_optimizer.py
@@ -7,7 +7,6 @@ import os
 from pokemongo_bot import inventory
 from pokemongo_bot.base_dir import _base_dir
 from pokemongo_bot.base_task import BaseTask
-from pokemongo_bot.datastore import Datastore
 from pokemongo_bot.human_behaviour import sleep, action_delay
 from pokemongo_bot.item_list import Item
 from pokemongo_bot.worker_result import WorkerResult
@@ -19,7 +18,7 @@ ERROR_NO_ITEMS_REMAINING = 4
 ERROR_LOCATION_UNSET = 5
 
 
-class PokemonOptimizer(Datastore, BaseTask):
+class PokemonOptimizer(BaseTask):
     SUPPORTED_TASK_API_VERSION = 1
 
     def __init__(self, bot, config):

--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -15,7 +15,6 @@ from pokemongo_bot.worker_result import WorkerResult
 from pokemongo_bot.base_task import BaseTask
 from pokemongo_bot.base_dir import _base_dir
 from utils import distance, format_time, fort_details
-from pokemongo_bot.datastore import Datastore
 
 SPIN_REQUEST_RESULT_SUCCESS = 1
 SPIN_REQUEST_RESULT_OUT_OF_RANGE = 2
@@ -23,7 +22,7 @@ SPIN_REQUEST_RESULT_IN_COOLDOWN_PERIOD = 3
 SPIN_REQUEST_RESULT_INVENTORY_FULL = 4
 
 
-class SpinFort(Datastore, BaseTask):
+class SpinFort(BaseTask):
     SUPPORTED_TASK_API_VERSION = 1
 
     def __init__(self, bot, config):

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -5,12 +5,11 @@ from pokemongo_bot import inventory
 from pokemongo_bot.human_behaviour import action_delay
 from pokemongo_bot.base_task import BaseTask
 from pokemongo_bot.inventory import Pokemons, Pokemon, Attack
-from pokemongo_bot.datastore import Datastore
 from operator import attrgetter
 from random import randrange
 
 
-class TransferPokemon(Datastore, BaseTask):
+class TransferPokemon(BaseTask):
     SUPPORTED_TASK_API_VERSION = 1
 
     def __init__(self, bot, config):


### PR DESCRIPTION
## Short Description:

The Datastore is being initialized multiple times, resulting in multiple duplicate migrations.

## Fixes/Resolves/Closes (please use correct syntax):
- Initialize the Datastore once, migrate once, and done with it.
- Pass the datastore connection to the bot.
- Easier to mock datastore since it's no longer initialized inside PokemonGoBot()
