### PR TITLE
CampFort - Check pokeballs before camping

### DIFF
--- a/pokemongo_bot/cell_workers/camp_fort.py
+++ b/pokemongo_bot/cell_workers/camp_fort.py
@@ -23,7 +23,6 @@ class CampFort(BaseTask):
         self.move_until = 0
         self.last_position_update = 0
         self.walker = None
-        self.announced_out_of_balls = False
 
         self.config_max_distance = self.config.get("max_distance", 2000)
         self.config_min_forts_count = self.config.get("min_forts_count", 2)
@@ -34,20 +33,20 @@ class CampFort(BaseTask):
     def work(self):
         if not self.enabled:
             return WorkerResult.SUCCESS
-            
-        # Let's make sure we have balls before we sit at a lure!
-        # See also catch_pokemon.py
-        if sum([inventory.items().get(ball.value).count for ball in
-            [Item.ITEM_POKE_BALL, Item.ITEM_GREAT_BALL, Item.ITEM_ULTRA_BALL]]) <= 0:
-            if not self.announced_out_of_balls:
-                self.logger.info('No pokeballs left, refuse to sit at lure!')
-                self.announced_out_of_balls = True
-            return WorkerResult.SUCCESS
 
         self.announced_out_of_balls = False
         now = time.time()
 
         if now < self.move_until:
+            return WorkerResult.SUCCESS
+
+        # Let's make sure we have balls before we sit at a lure!
+        # See also catch_pokemon.py
+        if sum([inventory.items().get(ball.value).count for ball in
+            [Item.ITEM_POKE_BALL, Item.ITEM_GREAT_BALL, Item.ITEM_ULTRA_BALL]]) <= 0:
+            self.logger.info('No pokeballs left, refuse to sit at lure!')
+            # Move away from lures for a time
+            self.move_until = now + self.config_moving_time
             return WorkerResult.SUCCESS
 
         if 0 < self.stay_until < now:

--- a/pokemongo_bot/cell_workers/camp_fort.py
+++ b/pokemongo_bot/cell_workers/camp_fort.py
@@ -46,6 +46,8 @@ class CampFort(BaseTask):
             [Item.ITEM_POKE_BALL, Item.ITEM_GREAT_BALL, Item.ITEM_ULTRA_BALL]]) <= 0:
             self.logger.info('No pokeballs left, refuse to sit at lure!')
             # Move away from lures for a time
+            self.destination = None
+            self.stay_until = 0
             self.move_until = now + self.config_moving_time
             return WorkerResult.SUCCESS
 

--- a/pokemongo_bot/cell_workers/camp_fort.py
+++ b/pokemongo_bot/cell_workers/camp_fort.py
@@ -7,6 +7,8 @@ from pokemongo_bot.constants import Constants
 from pokemongo_bot.human_behaviour import random_lat_long_delta, random_alt_delta
 from pokemongo_bot.walkers.polyline_walker import PolylineWalker
 from pokemongo_bot.worker_result import WorkerResult
+from pokemongo_bot.item_list import Item
+from pokemongo_bot import inventory
 
 
 class CampFort(BaseTask):
@@ -29,6 +31,13 @@ class CampFort(BaseTask):
         self.config_moving_time = self.config.get("moving_time", 600)
 
     def work(self):
+        # Let's make sure we have balls before we sit at a lure!
+        # See also catch_pokemon.py
+        if sum([inventory.items().get(ball.value).count for ball in
+            [Item.ITEM_POKE_BALL, Item.ITEM_GREAT_BALL, Item.ITEM_ULTRA_BALL]]) <= 0:
+            self.logger.info('Not any pokeballs left, refuse to sit at lure!')
+            return WorkerResult.ERROR
+
         if not self.enabled:
             return WorkerResult.SUCCESS
 


### PR DESCRIPTION
## Short Description:
I noticed that the bot doesn't move when camping at a lure, but had run
out of pokeballs. This will first check IF we have any pokeballs left.
If we have no pokeballs left, abandon the lure (to move to a fort to get
more pokeballs) when we got some pokeballs again, will move back to the
lure.