### PR TITLE
Prevent duplicate "skip ignored pokemon" alerts

### DIFF
--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -1000,8 +1000,10 @@ Bot answer on command '/info' self stats.
 ### Options
 
 * `telegram_token` : bot token (getting [there](https://core.telegram.org/bots#6-botfather) - one token per bot)
-* `master` : id (without quotes) of bot owner, who will gett announces.
+* `master` : id (without quotes) of bot owner, who will get alerts and may issue commands.
 * `alert_catch` : dict of rules pokemons catch.
+
+The bot will only alert and respond to a valid master. If you're unsure what this is, send the bot a message from Telegram and watch the log to find out.
 
 ### Sample configuration
 [[back to top](#table-of-contents)]

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -1000,10 +1000,8 @@ Bot answer on command '/info' self stats.
 ### Options
 
 * `telegram_token` : bot token (getting [there](https://core.telegram.org/bots#6-botfather) - one token per bot)
-* `master` : id (without quotes) of bot owner, who will get alerts and may issue commands.
+* `master` : id (without quotes) of bot owner, who will gett announces.
 * `alert_catch` : dict of rules pokemons catch.
-
-The bot will only alert and respond to a valid master. If you're unsure what this is, send the bot a message from Telegram and watch the log to find out.
 
 ### Sample configuration
 [[back to top](#table-of-contents)]

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -120,6 +120,17 @@ class PokemonCatchWorker(BaseTask):
 
         # skip ignored pokemon
         if not self._should_catch_pokemon(pokemon):
+            if not hasattr(self.bot,'skipped_pokemon'):
+                self.bot.skipped_pokemon = []
+                
+            # Check if pokemon already skipped and suppress alert if so
+            for skipped_pokemon in self.bot.skipped_pokemon:
+                if pokemon.pokemon_id == skipped_pokemon.pokemon_id and \
+                    pokemon.cp_exact == skipped_pokemon.cp_exact and \
+                    pokemon.ivcp == skipped_pokemon.ivcp:
+                    return WorkerResult.SUCCESS
+                    
+            self.bot.skipped_pokemon.append(pokemon)
             self.emit_event(
                 'pokemon_appeared',
                 formatted='Skip ignored {pokemon}! [CP {cp}] [Potential {iv}] [A/D/S {iv_display}]',


### PR DESCRIPTION
## Short Description:

Persist ignored/skipped pokemon so that alerts are not continually generated.

Important note: An encountered pokemon does not have a useful unique id (at least not that I can see) so I have used pokemon_id, cp_exact and ivcp as comparison values when deciding if an alert has already been generated. That *should* be sufficient but happy to expand if necessary.

## Fixes/Resolves/Closes (please use correct syntax):
- #5174 