### PR TITLE
Format output to fit in stdout codepage. Fix #5144.

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -24,6 +24,7 @@ OR OTHER DEALINGS IN THE SOFTWARE.
 
 Author: tjado <https://github.com/tejado>
 """
+from __future__ import unicode_literals
 
 import argparse
 import codecs
@@ -32,8 +33,6 @@ import logging
 import os
 import ssl
 import sys
-reload(sys)
-sys.setdefaultencoding('utf8')
 import time
 import signal
 import string
@@ -128,10 +127,12 @@ def main():
             return f.read()[:8]
 
     try:
-        logger.info('PokemonGO Bot v1.0')
-        logger.info('commit: ' + get_commit_hash())
+        codecs.register(lambda name: codecs.lookup("utf-8") if name == "cp65001" else None)
         sys.stdout = codecs.getwriter('utf8')(sys.stdout)
         sys.stderr = codecs.getwriter('utf8')(sys.stderr)
+
+        logger.info('PokemonGO Bot v1.0')
+        logger.info('commit: ' + get_commit_hash())
 
         config, config_file = init_config()
         if not config:

--- a/pokemongo_bot/event_handlers/colored_logging_handler.py
+++ b/pokemongo_bot/event_handlers/colored_logging_handler.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import logging
+import sys
 
 from pokemongo_bot.event_manager import EventHandler
 
@@ -135,4 +136,4 @@ class ColoredLoggingHandler(EventHandler):
             formatted_msg = '[{}] {}'.format(event, formatted_msg)
 
         logger = logging.getLogger(type(sender).__name__)
-        getattr(logger, level)(formatted_msg)
+        getattr(logger, level)(formatted_msg.encode(sys.stdout.encoding, "replace").decode("utf-8"))

--- a/pokemongo_bot/event_handlers/logging_handler.py
+++ b/pokemongo_bot/event_handlers/logging_handler.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 
 import logging
+import sys
 
 from pokemongo_bot.event_manager import EventHandler
 
@@ -19,4 +20,4 @@ class LoggingHandler(EventHandler):
             formatted_msg = '[{}] {}'.format(event, formatted_msg)
 
         logger = logging.getLogger(type(sender).__name__)
-        getattr(logger, level)(formatted_msg)
+        getattr(logger, level)(formatted_msg.encode(sys.stdout.encoding, "replace").decode("utf-8"))


### PR DESCRIPTION
+ Do not force default encoding to utf-8 (which causes issues), but adapt the output to the current encoding.
Messages going though the logging and color logging handler will always have an encoding supported by stdout.

+ Support chcp 65001 for displaying utf-8 encoded characters in console window if system is able to display them.