### PR TITLE
Fix bot never try to walk to not snipable pokemons

### DIFF
--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -341,16 +341,12 @@ class MoveToMapPokemon(BaseTask):
                         self.snipe(pokemon)
                         count = count +1
                         if count >= self.config.get('snipe_max_in_chain', 2):
-                            return WorkerResult.SUCCESS
-                        if count is not 1:
-                            time.sleep(self.config.get('snipe_sleep_sec', 2)*5)
+                            continue
                     else:
                         if self.config.get('debug', False):
                             self._emit_log('this pokemon is not good enough to snipe {}'.format(pokemon))
-                return WorkerResult.SUCCESS
             else:
                 return self.snipe(pokemon)
-            return WorkerResult.SUCCESS
 
         # check for pokeballs (excluding masterball)
         # checking again as we may have lost some if we sniped


### PR DESCRIPTION
## Short Description:
* When both `snipe` and `snipe_high_prio_only` are on, the bot now will try to walk to next pokemon after sniping.
* Remove unnecessary sleep in snipe chain

## Fixes/Resolves/Closes (please use correct syntax):
- Resolve #5094 

