### PR TITLE
Add freebsd10 to known platforms

### DIFF
--- a/pokemongo_bot/cell_workers/update_live_stats.py
+++ b/pokemongo_bot/cell_workers/update_live_stats.py
@@ -229,13 +229,13 @@ class UpdateLiveStats(BaseTask):
             if platform == "linux" or platform == "linux2" or platform == "cygwin":
                 stdout.write("\x1b]2;{}\x07".format(title))
                 stdout.flush()
-            elif platform == "darwin":
+            elif platform == "darwin" or platform == "freebsd10":
                 stdout.write("\033]0;{}\007".format(title))
                 stdout.flush()
             elif platform == "win32":
                 ctypes.windll.kernel32.SetConsoleTitleA(title.encode())
             else:
-                raise RuntimeError("unsupported platform '{}'".format(platform))
+                self.bot.logger.warn("Unable to set window title. OS {} not supported.".format(platform))
         except AttributeError:
             self.emit_event(
                 'log_stats',


### PR DESCRIPTION
## Short Description:

Add freebsd10 to known platforms in update_live_stats._update_title to prevent crash.

Also removed exception on unknown platform. Replaced with logger.warn message.

## Fixes/Resolves/Closes (please use correct syntax):
- Fixes #5202 