### PR TITLE
pokecli.py wait_time not defined

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -213,6 +213,7 @@ def main():
                 )
                 time.sleep(36000)
             except NoPlayerPositionSetException:
+                wait_time = config.reconnecting_timeout * 60
                 bot.event_manager.emit(
                     'api_error',
                     sender=bot,

--- a/pokecli.py
+++ b/pokecli.py
@@ -145,11 +145,11 @@ def main():
         finished = False
 
         while not finished:
-            try:
+           wait_time = config.reconnecting_timeout * 60
+           try:
                 bot = initialize(config)
                 bot = start_bot(bot, config)
                 config_changed = check_mod(config_file)
-                wait_time = config.reconnecting_timeout * 60
 
                 bot.event_manager.emit(
                     'bot_start',

--- a/pokecli.py
+++ b/pokecli.py
@@ -145,8 +145,8 @@ def main():
         finished = False
 
         while not finished:
-           wait_time = config.reconnecting_timeout * 60
-           try:
+            wait_time = config.reconnecting_timeout * 60
+            try:
                 bot = initialize(config)
                 bot = start_bot(bot, config)
                 config_changed = check_mod(config_file)

--- a/pokecli.py
+++ b/pokecli.py
@@ -149,6 +149,7 @@ def main():
                 bot = initialize(config)
                 bot = start_bot(bot, config)
                 config_changed = check_mod(config_file)
+                wait_time = config.reconnecting_timeout * 60
 
                 bot.event_manager.emit(
                     'bot_start',
@@ -180,7 +181,6 @@ def main():
                 report_summary(bot)
 
             except NotLoggedInException:
-                wait_time = config.reconnecting_timeout * 60
                 bot.event_manager.emit(
                     'api_error',
                     sender=bot,
@@ -213,7 +213,6 @@ def main():
                 )
                 time.sleep(36000)
             except NoPlayerPositionSetException:
-                wait_time = config.reconnecting_timeout * 60
                 bot.event_manager.emit(
                     'api_error',
                     sender=bot,


### PR DESCRIPTION
## Short Description:

NoPlayerPositionSetException tries to sleep for "wait_time" but "wait_time" isn't defined. Causes bot crash.

## Fixes/Resolves/Closes (please use correct syntax):
- #5280 
