### PR TITLE
Switch the keep alive timeout from 60 to 10

### DIFF
--- a/pokemongo_bot/event_handlers/social_handler.py
+++ b/pokemongo_bot/event_handlers/social_handler.py
@@ -71,7 +71,7 @@ class MyMQTTClass:
             self._mqttc.on_publish = self.mqtt_on_publish
             self._mqttc.on_disconnect = self.on_disconnect
 
-            self._mqttc.connect("broker.pikabot.org", 1883, 60)
+            self._mqttc.connect("broker.pikabot.org", 1883, 10)
             # Enable this line if you are doing the snip code, off stress
             # self._mqttc.loop_start()
         except TypeError:


### PR DESCRIPTION
Switch the keep alive timeout from 60 to 10 to reduce the chance of remote disconnect event.