### PR TITLE
Fix #5291 and all tasks that recreate walkers and walk too fast

### DIFF
--- a/pokemongo_bot/walkers/step_walker.py
+++ b/pokemongo_bot/walkers/step_walker.py
@@ -23,7 +23,7 @@ class StepWalker(object):
             self.dest_alt = dest_alt
 
         self.saved_location = None
-        self.last_update = 0
+        self.last_update = time.time()
 
     def step(self, speed=None):
         now = time.time()


### PR DESCRIPTION
Fix #5291 and all tasks that recreate walkers and walk too fast.
Those tasks could reuse their walker instead otherwise they might end up being too slow now.

And #5293