### PR TITLE
corrected init value of self.last_update in step_walker

### DIFF
--- a/pokemongo_bot/walkers/step_walker.py
+++ b/pokemongo_bot/walkers/step_walker.py
@@ -23,7 +23,9 @@ class StepWalker(object):
             self.dest_alt = dest_alt
 
         self.saved_location = None
-        self.last_update = 0
+        # last_update should be init time otherwise "1 - min(now - self.last_update, 1)" = 1 - min(now - 0),1 = 0
+        # and you'd teleport on first .step() and would impact all task that are creating a StepWalker object on each .work()
+        self.last_update = time.time()
 
     def step(self, speed=None):
         now = time.time()


### PR DESCRIPTION
Fixes:
- bug introduced in https://github.com/PokemonGoF/PokemonGo-Bot/pull/5184
- last_update should be init time otherwise "1 - min(now - self.last_update, 1)" = 1 - min(now - 0),1 = 0
we would  move a distance of "speed" in the first .step() without sleeping [this impact all task that are creating a StepWalker object on each .work() potentially resulting in teleport]
