### PR TITLE
UnicodeDecodeError catch

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -798,9 +798,8 @@ def fix_nested_config(config):
 def parse_unicode_str(string):
     try:
         return string.decode('utf8')
-    except UnicodeEncodeError:
+    except (UnicodeEncodeError,UnicodeDecodeError):
         return string
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Short Description:

If non-unicode string passed to parse_unicode_str, bot crashes. Previously was catching only UnicodeEncodeError, added UnicodeDecodeError as well.

## Fixes/Resolves/Closes (please use correct syntax):
- #5266 