### PR TITLE
Fix #5268 + Pokemon bag print ordered by cp

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -1078,6 +1078,7 @@ class PokemonGoBot(object):
         self.logger.info('Pokemon:')
 
         for pokes in pokemon_list:
+            pokes.sort(key=lambda p: p.cp, reverse=True)
             line_p = '#{} {}'.format(pokes[0].pokemon_id, pokes[0].name)
             if show_count:
                 line_p += '[{}]'.format(len(pokes))

--- a/pokemongo_bot/cell_workers/evolve_pokemon.py
+++ b/pokemongo_bot/cell_workers/evolve_pokemon.py
@@ -1,7 +1,7 @@
 from random import uniform
 
 from pokemongo_bot import inventory
-from pokemongo_bot.human_behaviour import sleep
+from pokemongo_bot.human_behaviour import sleep, action_delay
 from pokemongo_bot.inventory import Pokemon
 from pokemongo_bot.item_list import Item
 from pokemongo_bot.base_task import BaseTask
@@ -143,7 +143,7 @@ class EvolvePokemon(BaseTask):
             inventory.pokemons().add(new_pokemon)
             inventory.player().exp += xp
 
-            sleep(uniform(self.min_evolve_speed, self.max_evolve_speed))
+            action_delay(self.min_evolve_speed, self.max_evolve_speed)
             evolve_result = True
         else:
             # cache pokemons we can't evolve. Less server calls


### PR DESCRIPTION
## Short Description:
Fixed #5268. It was using function sleep() and is uses the jitters() which sometimes caused the evolve_time to me above or under the specified min and max.
Other change but not about that bug. Added print order by cp when printing Pokemon bag at start because it was random.

## Fixes/Resolves/Closes (please use correct syntax):
- #5268 
