### PR TITLE
run.sh can't handle pip requiremens using ">"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ yoyo-migrations==5.0.3
 paho-mqtt==1.2
 Geohash==1.0
 python-telegram-bot==5.0.0
-discord_simple>0.0.1.14
+discord_simple==0.0.1.15


### PR DESCRIPTION
## Short Description:
"discord_simple >" works for pip but run.sh parses the requirements file and matches more strictly.
Down the line, changing the parser would be best, imho.

## Fixes/Resolves/Closes (please use correct syntax):
#5318
