### PR TITLE
travis build time improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: python
 python:
   - "2.7"
-addons:
- apt:
-   packages:
-   - protobuf-compiler
-   - protobuf-c-compiler
-   - python-protobuf
 install:
-  - pip install -r requirements.txt
-  - pip install pylint
+  - wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - conda install -y protobuf pylint -q
+  - pip install --ignore-installed -U -r requirements.txt --src="$HOME/pgoapi"
 script:
-  - python pylint-recursive.py
-  - python json-validate.py configs/*.json.*
   - python -m unittest discover -v -p "*_test.py"
+  - python json-validate.py configs/*.json.*
+  - python pylint-recursive.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ script:
   - python -m unittest discover -v -p "*_test.py"
   - python json-validate.py configs/*.json.*
   - python pylint-recursive.py
+cache: pip
+


### PR DESCRIPTION
## Short Description:

Improve CI build time (down to 2~3min from around 9min)

**Results of the unit tests will now be available after the just first about a minute from the build start if you follow the Details link**


## Fixes/Resolves/Closes (please use correct syntax):
- recompile of numpy takes too long
- build pgoapi with a different src dir the TRAVIS_BUILD_DIR in order for the pgoapi project files to not be inspected by pylint!
- changed ordered of the travis scripts to run in order of probability of failure and importance:

1. - test cases ( look at the travis Details and you'll to see the tests FAILED/ok before the build finishes)

2. - json validation...

3. -  pylint-recursive.py