### PR TITLE
Fix heartbeat inventory add crash

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -677,6 +677,8 @@ class PokemonGoBot(object):
             if timeout >= now:
                 self.fort_timeouts[fort["id"]] = timeout
 
+        inventory.refresh_inventory()
+
         self.tick_count += 1
 
         # Check if session token has expired
@@ -1338,8 +1340,6 @@ class PokemonGoBot(object):
                               'level': badgelevel}
                     )
                     human_behaviour.action_delay(3, 10)
-
-            inventory.refresh_inventory()
 
         try:
             self.web_update_queue.put_nowait(True)  # do this outside of thread every tick

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -114,6 +114,11 @@ class PokemonGoBot(object):
         self.heartbeat_counter = 0
         self.last_heartbeat = time.time()
         self.hb_locked = False # lock hb on snip
+        
+        # Inventory refresh limiting
+        self.inventory_refresh_threshold = 10
+        self.inventory_refresh_counter = 0
+        self.last_inventory_refresh = time.time()
 
         self.capture_locked = False  # lock catching while moving to VIP pokemon
 
@@ -677,7 +682,7 @@ class PokemonGoBot(object):
             if timeout >= now:
                 self.fort_timeouts[fort["id"]] = timeout
 
-        inventory.refresh_inventory()
+        self._refresh_inventory()
 
         self.tick_count += 1
 
@@ -1446,3 +1451,12 @@ class PokemonGoBot(object):
                 formatted='Starting new cached forts for {path}',
                 data={'path': cached_forts_path}
             )
+
+    def _refresh_inventory(self):
+        # Perform inventory update every n seconds
+        now = time.time()
+        if now - self.last_inventory_refresh >= self.inventory_refresh_threshold:
+            inventory.refresh_inventory()
+            self.last_inventory_refresh = now
+            self.inventory_refresh_counter += 1
+            

--- a/pokemongo_bot/inventory.py
+++ b/pokemongo_bot/inventory.py
@@ -416,12 +416,9 @@ class Pokemons(_BaseInventoryComponent):
 
     def add(self, pokemon):
         if pokemon.unique_id <= 0:
-            self.bot.logger.debug("Can't add a pokemon without id")
-            return
+            raise ValueError("Can't add a pokemon without id")
         if pokemon.unique_id in self._data:
-            self.bot.logger.debug("Pokemon already present in the inventory")
-            return
-            
+            raise ValueError("Pokemon already present in the inventory")
         self._data[pokemon.unique_id] = pokemon
 
     def remove(self, pokemon_unique_id):

--- a/pokemongo_bot/inventory.py
+++ b/pokemongo_bot/inventory.py
@@ -416,9 +416,12 @@ class Pokemons(_BaseInventoryComponent):
 
     def add(self, pokemon):
         if pokemon.unique_id <= 0:
-            raise ValueError("Can't add a pokemon without id")
+            self.bot.logger.debug("Can't add a pokemon without id")
+            return
         if pokemon.unique_id in self._data:
-            raise ValueError("Pokemon already present in the inventory")
+            self.bot.logger.debug("Pokemon already present in the inventory")
+            return
+            
         self._data[pokemon.unique_id] = pokemon
 
     def remove(self, pokemon_unique_id):


### PR DESCRIPTION
## Short Description:

Since heartbeat threaded, inventory refresh may occur asynchronously and may cause crash (ie. trying to add pokemon that's already there). Moved heartbeat to tick instead so should only occur when the bot isn't doing other things.

**Important note** I have included a threshold in this so that inventory_refresh occurs no more frequently than every 10 seconds, same as heartbeat. If anything, this **decreases** api calls, as tick might occur only every few minutes if doing a lot of task work.

## Fixes/Resolves/Closes (please use correct syntax):
- #5299 