### PR TITLE
Fix move_to_map_pokemon to have map_path added to url

### DIFF
--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -86,6 +86,7 @@ class MoveToMapPokemon(BaseTask):
         self.unit = self.bot.config.distance_unit
         self.cache = []
         self.min_ball = self.config.get('min_ball', 1)
+        self.address = self.config.get('address', 'http://localhost:5000')
         self.map_path = self.config.get('map_path', 'raw_data')
         self.walker = self.config.get('walker', 'StepWalker')
         self.snip_enabled = self.config.get('snipe', False)
@@ -163,11 +164,12 @@ class MoveToMapPokemon(BaseTask):
         return self.pokemons_parser(tmp_pokemon_list)
 
     def get_pokemon_from_url(self):
+        url = '{0}/{1}'.format(self.address, self.map_path)
         try:
-            request = requests.get(self.config['address'])
+            request = requests.get(url)
             response = request.json()
         except requests.exceptions.ConnectionError:
-            self._emit_failure('Could not get data from {}'.format(self.config['address']))
+            self._emit_failure('Could not get data from {}'.format(url))
             return []
         except ValueError:
             self._emit_failure('JSON format is not valid')


### PR DESCRIPTION
## Short Description:

## Fixes

- `map_path` isn't added to the url used to fetch data from PokemonGo-Map.

## Resolves/Closes

- https://github.com/PokemonGoF/PokemonGo-Bot/issues/5313
