### PR TITLE
Bug fix on FollowPath, MoveToFort and PolylineGenerator

### DIFF
--- a/pokemongo_bot/cell_workers/follow_path.py
+++ b/pokemongo_bot/cell_workers/follow_path.py
@@ -141,7 +141,7 @@ class FollowPath(BaseTask):
             return WorkerResult.SUCCESS
 
         if self.status == STATUS_LOITERING and time.time() < self.loiter_end_time:
-            return WorkerResult.SUCCESS
+            return WorkerResult.RUNNING
 
         last_lat, last_lng, last_alt = self.bot.position
 
@@ -187,12 +187,12 @@ class FollowPath(BaseTask):
             }
         )
         
-        if dist <= 1 or (self.bot.config.walk_min > 0 and is_at_destination) or (self.status == STATUS_LOITERING and time.time() >= self.loiter_end_time):
+        if (self.bot.config.walk_min > 0 and is_at_destination) or (self.status == STATUS_LOITERING and time.time() >= self.loiter_end_time):
             if "loiter" in point and self.status != STATUS_LOITERING:
                 self.logger.info("Loitering for {} seconds...".format(point["loiter"]))
                 self.status = STATUS_LOITERING
                 self.loiter_end_time = time.time() + point["loiter"]
-                return WorkerResult.SUCCESS
+                return WorkerResult.RUNNING
             if (self.ptr + 1) == len(self.points):
                 if self.path_mode == 'single':
                     self.status = STATUS_FINISHED

--- a/pokemongo_bot/cell_workers/move_to_fort.py
+++ b/pokemongo_bot/cell_workers/move_to_fort.py
@@ -109,7 +109,7 @@ class MoveToFort(BaseTask):
                     formatted='Arrived at fort.'
                 )
 
-        return WorkerResult.SUCCESS
+        return WorkerResult.RUNNING
 
     def _get_nearest_fort_on_lure_way(self, forts):
 

--- a/pokemongo_bot/test/polyline_generator_test.py
+++ b/pokemongo_bot/test/polyline_generator_test.py
@@ -1,9 +1,8 @@
-import unittest, pickle, os
+import os
+import pickle
+import unittest
 import requests_mock
-from mock import patch, Mock
 from pokemongo_bot.walkers.polyline_generator import Polyline
-import datetime
-import time
 
 ex_orig = (47.1706378, 8.5167405)
 ex_dest = (47.1700271, 8.518072999999998)
@@ -11,9 +10,8 @@ ex_speed = 2.5
 ex_total_distance = 194
 ex_resp_directions = 'example_directions.pickle'
 ex_resp_elevations = 'example_elevations.pickle'
-ex_enc_polyline = 'o_|~Gsl~r@??h@LVDf@LDcBFi@AUEUQg@EKCI?G?GBG@EBEJKNC??'
-ex_nr_samples = 78
-
+ex_enc_polyline = 'o_%7C~Gsl~r@??h@LVDf@LDcBFi@AUEUQg@EKCI?G?GBG@EBEJKNC??'
+ex_nr_samples = 64
 
 
 class PolylineTestCase(unittest.TestCase):
@@ -31,7 +29,7 @@ class PolylineTestCase(unittest.TestCase):
             m.get('https://maps.googleapis.com/maps/api/elevation/json?path=enc:{}&samples={}'.format(
                 ex_enc_polyline, ex_nr_samples
             ), json=ex_elevations, status_code=200)
-            self.polyline = Polyline(ex_orig, ex_dest, ex_speed)
+            self.polyline = Polyline(ex_orig, ex_dest)
 
     def test_first_point(self):
         self.assertEqual(self.polyline._points[0], ex_orig)
@@ -40,7 +38,7 @@ class PolylineTestCase(unittest.TestCase):
         self.assertEqual(self.polyline._points[-1], ex_dest)
 
     def test_nr_of_elevations_returned(self):
-        total_seconds = self.polyline.get_total_distance() / self.polyline.speed
+        total_seconds = self.polyline.get_total_distance() / 3
         self.assertAlmostEqual(total_seconds, ex_nr_samples, places=0)
 
     def test_total_distance(self):
@@ -48,4 +46,3 @@ class PolylineTestCase(unittest.TestCase):
 
     def test_get_last_pos(self):
         self.assertEquals(self.polyline.get_last_pos(), self.polyline._last_pos)
-

--- a/pokemongo_bot/test/polyline_walker_test.py
+++ b/pokemongo_bot/test/polyline_walker_test.py
@@ -1,11 +1,11 @@
-import unittest, pickle, os
-import datetime, time
+import os
+import pickle
+import unittest
 
 from geographiclib.geodesic import Geodesic
 from mock import MagicMock, patch, mock
 
 import requests_mock
-from pokemongo_bot.walkers.polyline_generator import Polyline
 from pokemongo_bot.walkers.polyline_generator import PolylineObjectHandler
 from pokemongo_bot.walkers.polyline_walker import PolylineWalker
 
@@ -16,10 +16,8 @@ ex_speed = 2.5
 ex_total_distance = 194
 ex_resp_directions = 'example_directions.pickle'
 ex_resp_elevations = 'example_elevations.pickle'
-ex_enc_polyline = 'o_|~Gsl~r@??h@LVDf@LDcBFi@AUEUQg@EKCI?G?GBG@EBEJKNC??'
-ex_nr_samples = 78
-
-
+ex_enc_polyline = 'o_%7C~Gsl~r@??h@LVDf@LDcBFi@AUEUQg@EKCI?G?GBG@EBEJKNC??'
+ex_nr_samples = 64
 
 
 class TestPolylineWalker(unittest.TestCase):
@@ -55,7 +53,7 @@ class TestPolylineWalker(unittest.TestCase):
             m.get("https://maps.googleapis.com/maps/api/elevation/json?path=enc:{}&samples={}".format(
                 ex_enc_polyline, ex_nr_samples
             ), json=ex_elevations, status_code=200)
-            self.polyline = PolylineObjectHandler.cached_polyline(ex_orig, ex_dest, ex_speed)
+            self.polyline = PolylineObjectHandler.cached_polyline(ex_orig, ex_dest)
 
         self.bot.position = [ex_orig[0], ex_orig[1], self.polyline.get_alt(ex_orig)]
 
@@ -66,11 +64,10 @@ class TestPolylineWalker(unittest.TestCase):
     def test_polyline_fetched(self):
         self.assertEqual(self.polyline._points[0], ex_orig)
         self.assertEqual(self.polyline._points[-1], ex_dest)
-        total_seconds = self.polyline.get_total_distance() / self.polyline.speed
+        total_seconds = self.polyline.get_total_distance() / 3
         self.assertAlmostEqual(total_seconds, ex_nr_samples, places=0)
         self.assertEquals(self.polyline.get_total_distance(), ex_total_distance)
         self.assertEquals(self.polyline.get_last_pos(), self.polyline._last_pos)
-
 
     def test_one_small_speed(self):
         walk_max = self.bot.config.walk_max
@@ -103,7 +100,6 @@ class TestPolylineWalker(unittest.TestCase):
         self.bot.config.walk_max = walk_max
         self.bot.config.walk_min = walk_min
 
-
     def test_one_small_speed_big_precision(self):
         walk_max = self.bot.config.walk_max
         walk_min = self.bot.config.walk_min
@@ -134,7 +130,6 @@ class TestPolylineWalker(unittest.TestCase):
 
         self.bot.config.walk_max = walk_max
         self.bot.config.walk_min = walk_min
-
 
     def test_intermediary_speed(self):
         walk_max = self.bot.config.walk_max
@@ -203,8 +198,6 @@ class TestPolylineWalker(unittest.TestCase):
         walk_min = self.bot.config.walk_min
         speed = 300
         precision = 0.0
-        dlat = 47.1700271
-        dlng = 8.518072999999998
 
         self.bot.config.walk_max = speed
         self.bot.config.walk_min = speed
@@ -234,8 +227,6 @@ class TestPolylineWalker(unittest.TestCase):
         walk_min = self.bot.config.walk_min
         speed = 300
         precision = 2.5
-        dlat = 47.1700271
-        dlng = 8.518072999999998
 
         self.bot.config.walk_max = speed
         self.bot.config.walk_min = speed

--- a/pokemongo_bot/walkers/polyline_generator.py
+++ b/pokemongo_bot/walkers/polyline_generator.py
@@ -22,7 +22,7 @@ class PolylineObjectHandler:
     _run = False
 
     @staticmethod
-    def cached_polyline(origin, destination, speed, google_map_api_key=None):
+    def cached_polyline(origin, destination, google_map_api_key=None):
         '''
         Google API has limits, so we can't generate new Polyline at every tick...
         '''
@@ -49,7 +49,7 @@ class PolylineObjectHandler:
                 PolylineObjectHandler._run = True
                 PolylineObjectHandler._instability = 20  # next N moves use same cache
 
-            PolylineObjectHandler._cache = Polyline(origin, destination, speed, google_map_api_key)
+            PolylineObjectHandler._cache = Polyline(origin, destination, google_map_api_key)
         else:
             # valid cache found
             PolylineObjectHandler._instability -= 1
@@ -59,8 +59,7 @@ class PolylineObjectHandler:
 
 
 class Polyline(object):
-    def __init__(self, origin, destination, speed, google_map_api_key=None):
-        self.speed = float(speed)
+    def __init__(self, origin, destination, google_map_api_key=None):
         self.origin = origin
         self.destination = tuple(destination)
         self.DIRECTIONS_API_URL = 'https://maps.googleapis.com/maps/api/directions/json?mode=walking'
@@ -94,7 +93,7 @@ class Polyline(object):
         self._step_keys = sorted(self._step_dict.keys())
         self._last_step = 0
 
-        self._nr_samples = int(min(self.get_total_distance() / self.speed + 1, 512))
+        self._nr_samples = int(max(min(self.get_total_distance() / 3, 512), 2))
         self.ELEVATION_API_URL = 'https://maps.googleapis.com/maps/api/elevation/json?path=enc:'
         self.ELEVATION_URL = '{}{}&samples={}'.format(self.ELEVATION_API_URL,
                                                       self._polyline, self._nr_samples)

--- a/pokemongo_bot/walkers/polyline_walker.py
+++ b/pokemongo_bot/walkers/polyline_walker.py
@@ -7,7 +7,7 @@ from pokemongo_bot.human_behaviour import random_alt_delta
 
 class PolylineWalker(StepWalker):
     def get_next_position(self, origin_lat, origin_lng, origin_alt, dest_lat, dest_lng, dest_alt, distance):
-        polyline = PolylineObjectHandler.cached_polyline((self.bot.position[0], self.bot.position[1]), (dest_lat, dest_lng), distance, google_map_api_key=self.bot.config.gmapkey)
+        polyline = PolylineObjectHandler.cached_polyline((self.bot.position[0], self.bot.position[1]), (dest_lat, dest_lng), google_map_api_key=self.bot.config.gmapkey)
 
         while True:
             _, (dest_lat, dest_lng) = polyline._step_dict[polyline._step_keys[polyline._last_step]]


### PR DESCRIPTION
- Fix a crash with PolylineGenerator when speed is zero
- Fix a bug in FollowPath that think destination is reached each time we walk one step of a Polyline
- Fix FollowPath and MoveToFort tasks not returning RUNNING when they are actually the ones dictating the position.

Should fix issues users are having when they put FollowSpiral after a MoveToFort or a FollowPath. With this fix, the FollowSpiral will only be used if MoveToFort/FollowPath has nothing to do.

Fix #5362, #5333, #5186, #5367