### PR TITLE
Fix issues people are having with updating to new api

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.11.0
 networkx==1.11
--e git+https://github.com/pogodevorg/pgoapi.git/@5e550f656b318227f021801c796b8a80ad917b93#egg=pgoapi
+git+https://github.com/pogodevorg/pgoapi.git/@5e550f656b318227f021801c796b8a80ad917b93#egg=pgoapi
 geopy==1.11.0
 geographiclib==1.46.3
 protobuf==3.0.0b4

--- a/run.sh
+++ b/run.sh
@@ -22,7 +22,7 @@ then
 fi
 git fetch -a
 installed=(`pip list 2>/dev/null |sed -e 's/ //g' -e 's/(/:/' -e 's/)//' -e 's/[-_]//g' | awk '{print tolower($0)}'`)
-required=(`cat requirements.txt | sed -e 's/.*pgoapi$/pgoapi==1.1.8/' -e 's/[-_]//g' -e 's/==\(.*\)/:\1/' | awk '{print tolower($0)}'`)
+required=(`cat requirements.txt | sed -e 's/.*pgoapi$/pgoapi==1.1.6/' -e 's/[-_]//g' -e 's/==\(.*\)/:\1/' | awk '{print tolower($0)}'`)
 for package in ${required[@]}
 do
   if [[ ! (${installed[*]} =~ $package) ]];


### PR DESCRIPTION
For most people theres no need for the `-e` for installing the api and it often causes issues installing with pip.

Also fix run.sh