### PR TITLE
use strip instead of replace for names with spaces

### DIFF
--- a/pokemongo_bot/cell_workers/evolve_pokemon.py
+++ b/pokemongo_bot/cell_workers/evolve_pokemon.py
@@ -42,10 +42,10 @@ class EvolvePokemon(BaseTask):
 
     def _validate_config(self):
         if isinstance(self.evolve_list, basestring):
-            self.evolve_list = [str(pokemon_name).lower().replace(" ","") for pokemon_name in self.evolve_list.split(',')]
+            self.evolve_list = [str(pokemon_name).lower().strip() for pokemon_name in self.evolve_list.split(',')]
             
         if isinstance(self.donot_evolve_list, basestring):
-            self.donot_evolve_list = [str(pokemon_name).lower().replace(" ","") for pokemon_name in self.donot_evolve_list.split(',')]
+            self.donot_evolve_list = [str(pokemon_name).lower().strip() for pokemon_name in self.donot_evolve_list.split(',')]
 
         if 'evolve_speed' in self.config:
             self.logger.warning("evolve_speed is deprecated, instead please use 'min_evolve_speed' and 'max_evolved_speed'.")


### PR DESCRIPTION
once again because my pull request is now at [PokemonGo-Bot-Backup](https://github.com/PokemonGoF/PokemonGo-Bot-Backup/pull/21).

The configuration of evolve_list and donot_evolve_list doesn't work for "Nidoran F" and "Nidoran M" because when splitting the commaseparated string to an array their names are completely stripped of whitespaces with .replace(" ", "") leading to "NidoranF" and "NidoranM". To prevent this .strip() should be used to trim only leading and trailing whitespaces.

see [DeXtroTip's comment](https://github.com/PokemonGoF/PokemonGo-Bot-Backup/pull/21#issuecomment-247088572):
> Before, it was using strip() and then someone said it didn't work because "Nidoran F" and "Nidoran M" names in bot are stored as "NidoranF" and "NidoranM", that's why it was change to replace().
**EDIT** - I've checked and the bot actually stores the names as "Nidoran F" and "Nidoran M" so it should simply use strip() and not replace()