### PR TITLE
Fixed "log logged in" typo

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -223,7 +223,7 @@ def main():
                     'api_error',
                     sender=bot,
                     level='info',
-                    formatted='Log logged in, reconnecting in {:d}'.format(wait_time)
+                    formatted='Not logged in, reconnecting in {:d} seconds'.format(wait_time)
                 )
                 time.sleep(wait_time)
             except ServerBusyOrOfflineException:


### PR DESCRIPTION
## Short Description:

Pokecli.py displays "Log logged in, reconnecting in 900". Changed to "Not logged in, reconnecting in 900 seconds"

This is a resubmission of a PR that was lost when repo was restored.