### PR TITLE
Hot fix for pokemon_catch_worker.py

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -283,18 +283,18 @@ class PokemonCatchWorker(BaseTask):
         if pokemon_config.get('always_catch', False):
             return True
 
-        catch_ncp = pokemon_config.get('catch_above_ncp', pokemon.cp_percent)
-        if pokemon.cp_percent >= catch_ncp:
+        catch_ncp = pokemon_config.get('catch_above_ncp', 0.8)
+        if pokemon.cp_percent > catch_ncp:
             catch_results['ncp'] = True
 
-        catch_cp = pokemon_config.get('catch_above_cp', pokemon.cp)
-        catch_below_cp = pokemon_config.get('catch_below_cp', pokemon.cp)
-        if catch_cp <= pokemon.cp <= catch_below_cp:
+        catch_cp = pokemon_config.get('catch_above_cp', 1200)
+        catch_below_cp = pokemon_config.get('catch_below_cp', 10)
+        if catch_cp < pokemon.cp or pokemon.cp < catch_below_cp:
             catch_results['cp'] = True
 
 
-        catch_iv = pokemon_config.get('catch_above_iv', pokemon.iv)
-        if pokemon.iv >= catch_iv:
+        catch_iv = pokemon_config.get('catch_above_iv', 0.8)
+        if pokemon.iv > catch_iv:
             catch_results['iv'] = True
 
 


### PR DESCRIPTION
## Hot fix for pokemon_catch_worker.py

## Fixes/Resolves/Closes (please use correct syntax):
- #5457

@DBa2016 If you do something like this: `catch_ncp = pokemon_config.get('catch_above_ncp', pokemon.cp_percent)`.
`pokemon.cp_percent >= catch_ncp:` is a tautology for all our users who don't have `catch_above_ncp ` set. E.g. some users have `any: {"always_catch" : true}`

I've set some fall-back values for you here and changed the logic a little (`catch_cp <= pokemon.cp <= catch_below_cp` seems to be a contradiction, I'm not sure). 

Feel free to edit them once you've found a stable fix. Please be more careful next time. :)