### PR TITLE
Bot treats all pokemon as VIP fix

### DIFF
--- a/pokemongo_bot/cell_workers/complete_tutorial.py
+++ b/pokemongo_bot/cell_workers/complete_tutorial.py
@@ -13,7 +13,6 @@ class CompleteTutorial(BaseTask):
     SUPPORTED_TASK_API_VERSION = 1
 
     def initialize(self):
-        self.api = self.bot.api
         self.nickname = self.config.get('nickname','')
         self.team = self.config.get('team',0)
         self.tutorial_run = True
@@ -96,7 +95,7 @@ class CompleteTutorial(BaseTask):
         # You just need to call the API with the pokemon you choose
         # Probably can't get MewTwo as first pokemon though
         first_pokemon_id = random.choice([1, 4, 7])
-        response_dict = self.api.encounter_tutorial_complete(
+        response_dict = self.bot.api.encounter_tutorial_complete(
             pokemon_id=first_pokemon_id)
         try:
             if response_dict['responses']['ENCOUNTER_TUTORIAL_COMPLETE']['result'] == 1:
@@ -128,7 +127,7 @@ class CompleteTutorial(BaseTask):
 
     def _set_avatar(self):
         avatar = self._random_avatar()
-        response_dict = self.api.set_avatar(player_avatar=avatar)
+        response_dict = self.bot.api.set_avatar(player_avatar=avatar)
         status = response_dict['responses']['SET_AVATAR']['status']
         try:
             if status == 1:
@@ -147,7 +146,7 @@ class CompleteTutorial(BaseTask):
             return False
 
     def _set_nickname(self, nickname):
-        response_dict = self.api.claim_codename(codename=nickname)
+        response_dict = self.bot.api.claim_codename(codename=nickname)
         try:
             result = response_dict['responses']['CLAIM_CODENAME']['status']
             if result == 1:
@@ -170,7 +169,7 @@ class CompleteTutorial(BaseTask):
             return False
 
     def _set_tutorial_state(self, completed):
-        response_dict = self.api.mark_tutorial_complete(tutorials_completed=[
+        response_dict = self.bot.api.mark_tutorial_complete(tutorials_completed=[
                                                         completed], send_marketing_emails=False, send_push_notifications=False)
         try:
             self._player = response_dict['responses'][
@@ -189,7 +188,7 @@ class CompleteTutorial(BaseTask):
             return True
 
         sleep(10)
-        response_dict = self.api.set_player_team(team=self.team)
+        response_dict = self.bot.api.set_player_team(team=self.team)
         try:
             result = response_dict['responses']['SET_PLAYER_TEAM']['status']
             if result == 1:

--- a/pokemongo_bot/cell_workers/evolve_pokemon.py
+++ b/pokemongo_bot/cell_workers/evolve_pokemon.py
@@ -18,7 +18,6 @@ class EvolvePokemon(BaseTask):
 
     def initialize(self):
         self.start_time = 0
-        self.api = self.bot.api
         self.evolve_list = self.config.get('evolve_list', [])
         self.donot_evolve_list = self.config.get('donot_evolve_list', [])
         self.min_evolve_speed = self.config.get('min_evolve_speed', 25)
@@ -148,7 +147,7 @@ class EvolvePokemon(BaseTask):
         if pokemon.name in cache:
             return False
 
-        response_dict = self.api.evolve_pokemon(pokemon_id=pokemon.unique_id)
+        response_dict = self.bot.api.evolve_pokemon(pokemon_id=pokemon.unique_id)
         if response_dict.get('responses', {}).get('EVOLVE_POKEMON', {}).get('result', 0) == 1:
             xp = response_dict.get("responses", {}).get("EVOLVE_POKEMON", {}).get("experience_awarded", 0)
             evolution = response_dict.get("responses", {}).get("EVOLVE_POKEMON", {}).get("evolved_pokemon_data", {})

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -44,7 +44,7 @@ LOGIC_TO_FUNCTION = {
     'andor': lambda x, y, z: x and y or z
 }
 
-DEBUG_ON = True
+DEBUG_ON = False
 
 class PokemonCatchWorker(BaseTask):
 

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -44,7 +44,7 @@ LOGIC_TO_FUNCTION = {
     'andor': lambda x, y, z: x and y or z
 }
 
-DEBUG_ON = False
+DEBUG_ON = True
 
 class PokemonCatchWorker(BaseTask):
 
@@ -286,20 +286,20 @@ class PokemonCatchWorker(BaseTask):
         if pokemon_config.get('always_catch', False):
             return True
 
-        if pokemon_config.get('catch_above_ncp'):
+        if pokemon_config.get('catch_above_ncp',-1) >= 0:
             if pokemon.cp_percent >= pokemon_config.get('catch_above_ncp'):
                 catch_results['ncp'] = True
 
-        if pokemon_config.get('catch_above_cp'):
+        if pokemon_config.get('catch_above_cp',-1) >= 0:
             if pokemon.cp >= pokemon_config.get('catch_above_cp'):
                 catch_results['cp'] = True
                 
-        if pokemon_config.get('catch_below_cp'):
+        if pokemon_config.get('catch_below_cp',-1) >= 0:
             if pokemon.cp <= pokemon_config.get('catch_below_cp'):
                 catch_results['cp'] = True
 
 
-        if pokemon_config.get('catch_above_iv'):
+        if pokemon_config.get('catch_above_iv',-1) >= 0:
             if pokemon.iv > pokemon_config.get('catch_above_iv', pokemon.iv):
                 catch_results['iv'] = True
 

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -44,6 +44,7 @@ LOGIC_TO_FUNCTION = {
     'andor': lambda x, y, z: x and y or z
 }
 
+DEBUG_ON = False
 
 class PokemonCatchWorker(BaseTask):
 
@@ -125,8 +126,11 @@ class PokemonCatchWorker(BaseTask):
         pokemon_data = response['wild_pokemon']['pokemon_data'] if 'wild_pokemon' in response else response['pokemon_data']
         pokemon = Pokemon(pokemon_data)
 
+        # check if vip pokemon
+        is_vip = self._is_vip_pokemon(pokemon)
+
         # skip ignored pokemon
-        if not self._should_catch_pokemon(pokemon):
+        if not self._should_catch_pokemon(pokemon) and not is_vip:
             if not hasattr(self.bot,'skipped_pokemon'):
                 self.bot.skipped_pokemon = []
 
@@ -150,7 +154,6 @@ class PokemonCatchWorker(BaseTask):
             )
             return WorkerResult.SUCCESS
 
-        is_vip = self._is_vip_pokemon(pokemon)
         if inventory.items().get(ITEM_POKEBALL).count < 1:
             if inventory.items().get(ITEM_GREATBALL).count < 1:
                 if inventory.items().get(ITEM_ULTRABALL).count < 1:
@@ -283,19 +286,22 @@ class PokemonCatchWorker(BaseTask):
         if pokemon_config.get('always_catch', False):
             return True
 
-        catch_ncp = pokemon_config.get('catch_above_ncp', pokemon.cp_percent)
-        if pokemon.cp_percent >= catch_ncp:
-            catch_results['ncp'] = True
+        if pokemon_config.get('catch_above_ncp'):
+            if pokemon.cp_percent >= pokemon_config.get('catch_above_ncp'):
+                catch_results['ncp'] = True
 
-        catch_cp = pokemon_config.get('catch_above_cp', pokemon.cp)
-        catch_below_cp = pokemon_config.get('catch_below_cp', pokemon.cp)
-        if catch_cp <= pokemon.cp <= catch_below_cp:
-            catch_results['cp'] = True
+        if pokemon_config.get('catch_above_cp'):
+            if pokemon.cp >= pokemon_config.get('catch_above_cp'):
+                catch_results['cp'] = True
+                
+        if pokemon_config.get('catch_below_cp'):
+            if pokemon.cp <= pokemon_config.get('catch_below_cp'):
+                catch_results['cp'] = True
 
 
-        catch_iv = pokemon_config.get('catch_above_iv', pokemon.iv)
-        if pokemon.iv >= catch_iv:
-            catch_results['iv'] = True
+        if pokemon_config.get('catch_above_iv'):
+            if pokemon.iv > pokemon_config.get('catch_above_iv', pokemon.iv):
+                catch_results['iv'] = True
 
 
         catch_results['fa'] = ( len(pokemon_config.get('fast_attack', [])) == 0 or unicode(pokemon.fast_attack) in map(lambda x: unicode(x), pokemon_config.get('fast_attack', [])))
@@ -314,6 +320,21 @@ class PokemonCatchWorker(BaseTask):
             'iv': catch_results['iv']
         }
         
+        if DEBUG_ON:
+            print "Debug information for match rules..."
+            print "catch_results ncp = {}".format(catch_results['ncp'])
+            print "catch_results cp = {}".format(catch_results['cp'])
+            print "catch_results iv = {}".format(catch_results['iv'])
+            print "cr = {}".format(cr)
+            print "catch_above_ncp = {}".format(pokemon_config.get('catch_above_ncp'))
+            print "catch_above_cp iv = {}".format(pokemon_config.get('catch_above_cp'))
+            print "catch_below_cp iv = {}".format(pokemon_config.get('catch_below_cp'))
+            print "catch_above_iv iv = {}".format(pokemon_config.get('catch_above_iv'))
+            print "Pokemon {}".format(pokemon.name)
+            print "pokemon ncp = {}".format(pokemon.cp_percent)
+            print "pokemon cp = {}".format(pokemon.cp)
+            print "pokemon iv = {}".format(pokemon.iv)
+
         if LOGIC_TO_FUNCTION[pokemon_config.get('logic', default_logic)](*cr.values()):
             return catch_results['fa'] and catch_results['ca']
         else:
@@ -327,7 +348,7 @@ class PokemonCatchWorker(BaseTask):
         # Not seen pokemons also will become vip if it's not disabled in config
         if self.bot.config.vips.get(pokemon.name) == {} or (self.treat_unseen_as_vip and not self.pokedex.seen(pokemon.pokemon_id)):
             return True
-        return self._pokemon_matches_config(self.bot.config.vips, pokemon, default_logic='or')
+        return False
 
     def _pct(self, rate_by_ball):
         return '{0:.2f}'.format(rate_by_ball * 100)

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -53,7 +53,6 @@ class PokemonCatchWorker(BaseTask):
         super(PokemonCatchWorker, self).__init__(bot, config)
 
     def initialize(self):
-        self.api = self.bot.api
         self.position = self.bot.position
         self.pokemon_list = self.bot.pokemon_list
         self.inventory = inventory.items()
@@ -213,7 +212,7 @@ class PokemonCatchWorker(BaseTask):
         player_latitude = self.pokemon['latitude']
         player_longitude = self.pokemon['longitude']
 
-        request = self.api.create_request()
+        request = self.bot.api.create_request()
         if 'spawn_point_id' in self.pokemon:
             spawn_point_id = self.pokemon['spawn_point_id']
             self.spawn_point_guid = spawn_point_id
@@ -369,7 +368,7 @@ class PokemonCatchWorker(BaseTask):
             }
         )
 
-        response_dict = self.api.use_item_capture(
+        response_dict = self.bot.api.use_item_capture(
             item_id=berry_id,
             encounter_id=encounter_id,
             spawn_point_id=self.spawn_point_guid
@@ -544,7 +543,7 @@ class PokemonCatchWorker(BaseTask):
             if random() >= self.catch_throw_parameters_hit_rate and not is_vip:
                 hit_pokemon = 0
 
-            response_dict = self.api.catch_pokemon(
+            response_dict = self.bot.api.catch_pokemon(
                 encounter_id=encounter_id,
                 pokeball=current_ball,
                 normalized_reticle_size=throw_parameters['normalized_reticle_size'],

--- a/pokemongo_bot/walkers/step_walker.py
+++ b/pokemongo_bot/walkers/step_walker.py
@@ -10,7 +10,6 @@ from pokemongo_bot.human_behaviour import sleep, random_alt_delta
 class StepWalker(object):
     def __init__(self, bot, dest_lat, dest_lng, dest_alt=None, precision=0.5):
         self.bot = bot
-        self.api = bot.api
         self.epsilon = 0.01
         self.precision = max(precision, self.epsilon)
 
@@ -38,7 +37,7 @@ class StepWalker(object):
 
         new_position = self.get_next_position(origin_lat, origin_lng, origin_alt, self.dest_lat, self.dest_lng, self.dest_alt, speed)
 
-        self.api.set_position(new_position[0], new_position[1], new_position[2])
+        self.bot.api.set_position(new_position[0], new_position[1], new_position[2])
         self.bot.event_manager.emit("position_update",
                                     sender=self,
                                     level="debug",


### PR DESCRIPTION
## Short Description:

Bot treats all pokemon as VIP. Additionally, default rules always return true if not configured. For example:

```
    "catch": {
      "any": {"catch_above_cp": 500, "catch_above_iv": 0.65, "logic": "or"}
    },
```

Given example pokemon with cp 30, iv 0.2 and ncp 0.15, the bot would still always catch it because no "catch_above_ncp" rule is defined. This is incorrect behaviour, should return false if no condition matches or condition doesn't exist.

## Fixes/Resolves/Closes (please use correct syntax):
- #5457 
- #5476 
- #5491
