### PR TITLE
Fixed release trigger

### DIFF
--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -36,7 +36,7 @@ class TransferPokemon(BaseTask):
 
     def _should_work(self):
         random_number = randrange (0,20,1) 
-        return inventory.Pokemons.get_space_left() <= self.min_free_slot - random_number
+        return inventory.Pokemons.get_space_left() <= max(1,self.min_free_slot - random_number)
 
     def _release_pokemon_get_groups(self):
         pokemon_groups = {}


### PR DESCRIPTION
## Short Description:

On TransferPokemon task, the bot randomizes min_free_slot by up to 20 (to simulate human-like behaviour?), so a value of 5 in config could actually be anything from 5 to -15. Bag limit never gets below zero, so bag has very large chance of filling up. Changed so will trigger if space <= 1 if random gives anything equal to or below 0.


## Fixes/Resolves/Closes (please use correct syntax):
- #5480