### PR TITLE
Restore vip functionality

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -365,7 +365,7 @@ class PokemonCatchWorker(BaseTask):
         # Not seen pokemons also will become vip if it's not disabled in config
         if self.bot.config.vips.get(pokemon.name) == {} or (self.treat_unseen_as_vip and not self.pokedex.seen(pokemon.pokemon_id)):
             return True
-        return False
+        return self._pokemon_matches_config(self.bot.config.vips, pokemon, default_logic='or')
 
     def _pct(self, rate_by_ball):
         return '{0:.2f}'.format(rate_by_ball * 100)

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -365,8 +365,8 @@ class PokemonCatchWorker(BaseTask):
         # Not seen pokemons also will become vip if it's not disabled in config
         if self.bot.config.vips.get(pokemon.name) == {} or (self.treat_unseen_as_vip and not self.pokedex.seen(pokemon.pokemon_id)):
             return True
-        return False
-
+        return self._pokemon_matches_config(self.bot.config.vips, pokemon, default_logic='or')
+        
     def _pct(self, rate_by_ball):
         return '{0:.2f}'.format(rate_by_ball * 100)
 

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 import os
 import time
 import json
-import logging
 import sys
 
 from random import random, randrange, uniform
@@ -14,7 +14,7 @@ from pokemongo_bot.inventory import Pokemon
 from pokemongo_bot.worker_result import WorkerResult
 from pokemongo_bot.base_dir import _base_dir
 from datetime import datetime, timedelta
-from utils import getSeconds
+from .utils import getSeconds
 
 from pprint import pprint
 
@@ -365,8 +365,8 @@ class PokemonCatchWorker(BaseTask):
         # Not seen pokemons also will become vip if it's not disabled in config
         if self.bot.config.vips.get(pokemon.name) == {} or (self.treat_unseen_as_vip and not self.pokedex.seen(pokemon.pokemon_id)):
             return True
-        return self._pokemon_matches_config(self.bot.config.vips, pokemon, default_logic='or')
-        
+        return False
+
     def _pct(self, rate_by_ball):
         return '{0:.2f}'.format(rate_by_ball * 100)
 

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -44,7 +44,7 @@ LOGIC_TO_FUNCTION = {
     'andor': lambda x, y, z: x and y or z
 }
 
-DEBUG_ON = True
+DEBUG_ON = False
 
 class PokemonCatchWorker(BaseTask):
 

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -44,7 +44,7 @@ LOGIC_TO_FUNCTION = {
     'andor': lambda x, y, z: x and y or z
 }
 
-DEBUG_ON = False
+DEBUG_ON = True
 
 class PokemonCatchWorker(BaseTask):
 
@@ -285,20 +285,20 @@ class PokemonCatchWorker(BaseTask):
         if pokemon_config.get('always_catch', False):
             return True
 
-        if pokemon_config.get('catch_above_ncp'):
+        if pokemon_config.get('catch_above_ncp',-1) >= 0:
             if pokemon.cp_percent >= pokemon_config.get('catch_above_ncp'):
                 catch_results['ncp'] = True
 
-        if pokemon_config.get('catch_above_cp'):
+        if pokemon_config.get('catch_above_cp',-1) >= 0:
             if pokemon.cp >= pokemon_config.get('catch_above_cp'):
                 catch_results['cp'] = True
                 
-        if pokemon_config.get('catch_below_cp'):
+        if pokemon_config.get('catch_below_cp',-1) >= 0:
             if pokemon.cp <= pokemon_config.get('catch_below_cp'):
                 catch_results['cp'] = True
 
 
-        if pokemon_config.get('catch_above_iv'):
+        if pokemon_config.get('catch_above_iv',-1) >= 0:
             if pokemon.iv > pokemon_config.get('catch_above_iv', pokemon.iv):
                 catch_results['iv'] = True
 

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -44,6 +44,7 @@ LOGIC_TO_FUNCTION = {
     'andor': lambda x, y, z: x and y or z
 }
 
+DEBUG_ON = False
 
 class PokemonCatchWorker(BaseTask):
 
@@ -124,8 +125,11 @@ class PokemonCatchWorker(BaseTask):
         pokemon_data = response['wild_pokemon']['pokemon_data'] if 'wild_pokemon' in response else response['pokemon_data']
         pokemon = Pokemon(pokemon_data)
 
+        # check if vip pokemon
+        is_vip = self._is_vip_pokemon(pokemon)
+
         # skip ignored pokemon
-        if not self._should_catch_pokemon(pokemon):
+        if not self._should_catch_pokemon(pokemon) and not is_vip:
             if not hasattr(self.bot,'skipped_pokemon'):
                 self.bot.skipped_pokemon = []
 
@@ -149,7 +153,6 @@ class PokemonCatchWorker(BaseTask):
             )
             return WorkerResult.SUCCESS
 
-        is_vip = self._is_vip_pokemon(pokemon)
         if inventory.items().get(ITEM_POKEBALL).count < 1:
             if inventory.items().get(ITEM_GREATBALL).count < 1:
                 if inventory.items().get(ITEM_ULTRABALL).count < 1:
@@ -282,19 +285,22 @@ class PokemonCatchWorker(BaseTask):
         if pokemon_config.get('always_catch', False):
             return True
 
-        catch_ncp = pokemon_config.get('catch_above_ncp', pokemon.cp_percent)
-        if pokemon.cp_percent >= catch_ncp:
-            catch_results['ncp'] = True
+        if pokemon_config.get('catch_above_ncp'):
+            if pokemon.cp_percent >= pokemon_config.get('catch_above_ncp'):
+                catch_results['ncp'] = True
 
-        catch_cp = pokemon_config.get('catch_above_cp', pokemon.cp)
-        catch_below_cp = pokemon_config.get('catch_below_cp', pokemon.cp)
-        if catch_cp <= pokemon.cp <= catch_below_cp:
-            catch_results['cp'] = True
+        if pokemon_config.get('catch_above_cp'):
+            if pokemon.cp >= pokemon_config.get('catch_above_cp'):
+                catch_results['cp'] = True
+                
+        if pokemon_config.get('catch_below_cp'):
+            if pokemon.cp <= pokemon_config.get('catch_below_cp'):
+                catch_results['cp'] = True
 
 
-        catch_iv = pokemon_config.get('catch_above_iv', pokemon.iv)
-        if pokemon.iv >= catch_iv:
-            catch_results['iv'] = True
+        if pokemon_config.get('catch_above_iv'):
+            if pokemon.iv > pokemon_config.get('catch_above_iv', pokemon.iv):
+                catch_results['iv'] = True
 
 
         catch_results['fa'] = ( len(pokemon_config.get('fast_attack', [])) == 0 or unicode(pokemon.fast_attack) in map(lambda x: unicode(x), pokemon_config.get('fast_attack', [])))
@@ -313,6 +319,21 @@ class PokemonCatchWorker(BaseTask):
             'iv': catch_results['iv']
         }
         
+        if DEBUG_ON:
+            print "Debug information for match rules..."
+            print "catch_results ncp = {}".format(catch_results['ncp'])
+            print "catch_results cp = {}".format(catch_results['cp'])
+            print "catch_results iv = {}".format(catch_results['iv'])
+            print "cr = {}".format(cr)
+            print "catch_above_ncp = {}".format(pokemon_config.get('catch_above_ncp'))
+            print "catch_above_cp iv = {}".format(pokemon_config.get('catch_above_cp'))
+            print "catch_below_cp iv = {}".format(pokemon_config.get('catch_below_cp'))
+            print "catch_above_iv iv = {}".format(pokemon_config.get('catch_above_iv'))
+            print "Pokemon {}".format(pokemon.name)
+            print "pokemon ncp = {}".format(pokemon.cp_percent)
+            print "pokemon cp = {}".format(pokemon.cp)
+            print "pokemon iv = {}".format(pokemon.iv)
+
         if LOGIC_TO_FUNCTION[pokemon_config.get('logic', default_logic)](*cr.values()):
             return catch_results['fa'] and catch_results['ca']
         else:
@@ -326,7 +347,7 @@ class PokemonCatchWorker(BaseTask):
         # Not seen pokemons also will become vip if it's not disabled in config
         if self.bot.config.vips.get(pokemon.name) == {} or (self.treat_unseen_as_vip and not self.pokedex.seen(pokemon.pokemon_id)):
             return True
-        return self._pokemon_matches_config(self.bot.config.vips, pokemon, default_logic='or')
+        return False
 
     def _pct(self, rate_by_ball):
         return '{0:.2f}'.format(rate_by_ball * 100)


### PR DESCRIPTION
Removed some functionality from VIP identification in catch while debugging. Now _pokemon_matches_config is fixed, it can be readded safely.