### PR TITLE
fix add pokemon

### DIFF
--- a/pokemongo_bot/cell_workers/catch_pokemon.py
+++ b/pokemongo_bot/cell_workers/catch_pokemon.py
@@ -150,7 +150,8 @@ class CatchPokemon(BaseTask):
                 self.add_pokemon(pokemon)
 
     def add_pokemon(self, pokemon):
-        if pokemon['encounter_id'] not in self.pokemon:
+        if pokemon['encounter_id'] not in \
+                map(lambda pokemon: pokemon['encounter_id'], self.pokemon):
             self.pokemon.append(pokemon)
 
     def catch_pokemon(self, pokemon):


### PR DESCRIPTION
## Short Description:

We were comparing a literal to a json object which in our case is always True.
This causes self.pokemon to contains duplicate. Thus, creating multiple encounter api call to the server for the same pokemon.

## Fixes/Resolves/Closes (please use correct syntax):
-
-
-

