### PR TITLE
Improve telegram startup, fix master/sub issues

### DIFF
--- a/pokemongo_bot/event_handlers/chat_handler.py
+++ b/pokemongo_bot/event_handlers/chat_handler.py
@@ -91,6 +91,7 @@ class ChatHandler:
         events.remove('evolve_log')
         events.remove('transfer_log')
         events.remove('catchable_pokemon')
+        events = sorted(events)
         return events
 
 

--- a/pokemongo_bot/event_handlers/telegram_handler.py
+++ b/pokemongo_bot/event_handlers/telegram_handler.py
@@ -7,7 +7,6 @@ import thread
 import re
 import pprint
 from pokemongo_bot.datastore import Datastore
-from pokemongo_bot import inventory
 from telegram.utils import request
 from chat_handler import ChatHandler
 

--- a/pokemongo_bot/event_handlers/telegram_handler.py
+++ b/pokemongo_bot/event_handlers/telegram_handler.py
@@ -32,9 +32,8 @@ class TelegramClass:
             elif self.master is not None: # Master is not numeric, fetch from db
                 self.bot.logger.info("Telegram master is not numeric: {}".format(self.master))
                 c = conn.cursor()
-                # do we already have a user id?
                 srchmaster = re.sub(r'^@', '', self.master)
-                c.execute("SELECT uid from telegram_uids where username in ('{}', '@{}')".format(srchmaster, srchmaster))
+                c.execute("SELECT uid from telegram_uids where username = '{}'".format(srchmaster))
                 results = c.fetchall()
                 if len(results) > 0: # woohoo, we already saw a message from this master and therefore have a uid
                     self.bot.logger.info("Telegram master UID from datastore: {}".format(results[0][0]))
@@ -230,6 +229,7 @@ class TelegramClass:
         with self.bot.database as conn:
             for sub in conn.execute("select uid, event_type, parameters from telegram_subscriptions where uid = ?", [chatid]).fetchall():
                 subs.append("{} -&gt; {}".format(sub[1], sub[2]))
+        if subs == []: subs.append("No subscriptions found. Subscribe using /sub EVENTNAME. For a list of events, send /events")
         self.chat_handler.sendMessage(chat_id=chatid, parse_mode='HTML', text="\n".join(subs))
 
     def chsub(self, msg, chatid):


### PR DESCRIPTION
## Short Description:

At startup, telegram handler follows this pattern... Create bot instance -> Connect to Telegram API -> Split to new thread.

Connect might take several seconds, slowing bot startup while running in main thread.

Changed to Create bot instance -> Split to new thread -> Connect to Telegram API

For me, startup time reduced from 9 seconds to <3 consistently. YMMV.

In addition, there were some issues with bot correctly identifying and sending info to master unless explicitly set in config. Some refactoring and logic fixes made to correct this.

## Fixes/Resolves/Closes (please use correct syntax):
- #5527
