### PR TITLE
Give a breakdown of the remaining eggs instead of just showing many e…

### DIFF
--- a/pokemongo_bot/cell_workers/incubate_eggs.py
+++ b/pokemongo_bot/cell_workers/incubate_eggs.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from datetime import datetime, timedelta
 
 from pokemongo_bot import inventory
@@ -170,7 +171,7 @@ class IncubateEggs(BaseTask):
                 continue
             if "player_stats" in inv_data:
                 self.km_walked = inv_data.get("player_stats", {}).get("km_walked", 0)
-        
+
         self.used_incubators = temp_used_incubators
         if self.used_incubators:
             self.used_incubators.sort(key=lambda x: x.get("km"))
@@ -206,7 +207,7 @@ class IncubateEggs(BaseTask):
                 formatted= "Error trying to hatch egg."
             )
             return False
- 
+
         for i in range(len(pokemon_list)):
             pokemon = pokemon_list[i]
             msg = "Egg hatched with a {name} (CP {cp} - NCP {ncp} - IV {iv_ads} {iv_pct}), {exp} exp, {stardust} stardust and {candy} candies."
@@ -227,7 +228,7 @@ class IncubateEggs(BaseTask):
             # hatching egg gets exp too!
             inventory.player().exp += xp[i]
             self.bot.stardust += stardust[i]
-            
+
             with self.bot.database as conn:
                 c = conn.cursor()
                 c.execute("SELECT COUNT(name) FROM sqlite_master WHERE type='table' AND name='eggs_hatched_log'")
@@ -244,7 +245,7 @@ class IncubateEggs(BaseTask):
                         formatted="eggs_hatched_log table not found, skipping log"
                     )
                     break
-            
+
         self.bot.metrics.hatched_eggs(len(pokemon_list))
         return True
 
@@ -253,12 +254,13 @@ class IncubateEggs(BaseTask):
             return
 
         eggs = ['{:.2f}/{} km'.format(e['km_needed']-e['km']+self.km_walked, e['km_needed']) for e in self.used_incubators]
+        all_eggs = Counter([egg['km'] for egg in self.eggs])
 
         self.emit_event(
             'next_egg_incubates',
             formatted='Eggs incubating: [{eggs}] (Eggs left: {eggs_left}, Incubating: {eggs_inc})',
             data={
-                'eggs_left': len(self.eggs),
+                'eggs_left': sorted(all_eggs.iteritems()),
                 'eggs_inc': len(self.used_incubators),
                 'eggs': ', '.join(eggs)
             }


### PR DESCRIPTION
## Short Description:

In the logs, when IncubateEggs task is enabled, you can see something like this. The problem with this is that I don't know how many 10km/5km/2km eggs I have.

`[IncubateEggs] [INFO] Eggs incubating: [4.38/5.0 km] (Eggs left: 8, Incubating: 1)`

The change will allow to see a breakdown of how many of each particular egg is left, eg. 5km has 8 eggs.

`[IncubateEggs] [INFO] Eggs incubating: [4.38/5.0 km] (Eggs left: [(5.0, 8)], Incubating: 1)`

