### PR TITLE
MoveToMapPokemon sniping fix

### DIFF
--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -245,7 +245,7 @@ class MoveToMapPokemon(BaseTask):
                     exists = True
 
                     # Also, if the IDs arent valid, update them!
-                    if not pokemon['encounter_id'] or not pokemon['spawnpoint_id']:
+                    if not pokemon['encounter_id'] or not pokemon['spawn_point_id']:
                         pokemon['encounter_id'] = nearby_pokemon['encounter_id']
                         pokemon['spawn_point_id'] = nearby_pokemon['spawn_point_id']
                         pokemon['disappear_time'] = nearby_pokemon['last_modified_timestamp_ms'] if is_wild else nearby_pokemon['expiration_timestamp_ms']

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -108,18 +108,15 @@ class PokemonCatchWorker(BaseTask):
         if not response_dict:
             return WorkerResult.ERROR
 
-        try:
-            responses = response_dict['responses']
-            response = responses[self.response_key]
-            if response[self.response_status_key] != ENCOUNTER_STATUS_SUCCESS and response[self.response_status_key] != INCENSE_ENCOUNTER_AVAILABLE:
-                if response[self.response_status_key] == ENCOUNTER_STATUS_NOT_IN_RANGE:
-                    self.emit_event('pokemon_not_in_range', formatted='Pokemon went out of range!')
-                elif response[self.response_status_key] == INCENSE_ENCOUNTER_NOT_AVAILABLE:
-                    self.emit_event('pokemon_not_in_range', formatted='Incensed Pokemon went out of range!')
-                elif response[self.response_status_key] == ENCOUNTER_STATUS_POKEMON_INVENTORY_FULL:
-                    self.emit_event('pokemon_inventory_full', formatted='Your Pokemon inventory is full! Could not catch!')
-                return WorkerResult.ERROR
-        except KeyError:
+        responses = response_dict['responses']
+        response = responses[self.response_key]
+        if response[self.response_status_key] != ENCOUNTER_STATUS_SUCCESS and response[self.response_status_key] != INCENSE_ENCOUNTER_AVAILABLE:
+            if response[self.response_status_key] == ENCOUNTER_STATUS_NOT_IN_RANGE:
+                self.emit_event('pokemon_not_in_range', formatted='Pokemon went out of range!')
+            elif response[self.response_status_key] == INCENSE_ENCOUNTER_NOT_AVAILABLE:
+                self.emit_event('pokemon_not_in_range', formatted='Incensed Pokemon went out of range!')
+            elif response[self.response_status_key] == ENCOUNTER_STATUS_POKEMON_INVENTORY_FULL:
+                self.emit_event('pokemon_inventory_full', formatted='Your Pokemon inventory is full! Could not catch!')
             return WorkerResult.ERROR
 
         # get pokemon data


### PR DESCRIPTION
## Short Description:

Two issues with MoveToMapPokemon:

- "Does not exist anymore" error

Fixed by changing "spawnpoint_id" to "spawn_point_id"

- If above doesn't occur, doesn't catch anything, just teleports back then moves on

Fixed by removing try block from pokemon_catch_worker. It is possible that a different exception MIGHT occur here now, but I haven't seen it, and it's better than doing nothing.

## Fixes/Resolves/Closes (please use correct syntax):
- #5523 