### PR TITLE
Make socket IP dynamic

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -99,18 +99,18 @@
         "type": "EvolvePokemon",
         "config": {
             "enabled": false,
-            
+
             "// evolve only pidgey and drowzee": "",
             "// evolve_list": "pidgey, drowzee",
             "// donot_evolve_list": "none",
-            
+
             "// evolve all but pidgey and drowzee": "",
             "// evolve_list": "all",
             "// donot_evolve_list": "pidgey, drowzee",
-            
+
             "evolve_list": "all",
             "donot_evolve_list": "none",
-            
+
             "first_evolve_by": "cp",
             "evolve_above_cp": 500,
             "evolve_above_iv": 0.8,
@@ -176,7 +176,7 @@
             "berry_wait_max": 5,
             "changeball_wait_min": 3,
             "changeball_wait_max": 5,
-            "newtodex_wait_min": 20, 
+            "newtodex_wait_min": 20,
             "newtodex_wait_max": 30
           }
         }
@@ -309,6 +309,6 @@
     },
 	"websocket": {
 		"start_embedded_server": true,
-		"server_url": "127.0.0.1:4000"
+		"server_url": "0.0.0.0:4000"
 	}
 }

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -138,18 +138,18 @@
         "type": "EvolvePokemon",
         "config": {
           "enabled": false,
-            
+
             "// evolve only pidgey and drowzee": "",
             "// evolve_list": "pidgey, drowzee",
             "// donot_evolve_list": "none",
-            
+
             "// evolve all but pidgey and drowzee": "",
             "// evolve_list": "all",
             "// donot_evolve_list": "pidgey, drowzee",
-            
+
             "evolve_list": "all",
             "donot_evolve_list": "none",
-            
+
           "first_evolve_by": "cp",
           "evolve_above_cp": 500,
           "evolve_above_iv": 0.8,
@@ -168,7 +168,7 @@
             "ordinary",
             "spicy",
             "cool",
-            "floral" 
+            "floral"
           ]
         }
       },
@@ -230,7 +230,7 @@
             "berry_wait_max": 5,
             "changeball_wait_min": 3,
             "changeball_wait_max": 5,
-            "newtodex_wait_min": 20, 
+            "newtodex_wait_min": 20,
             "newtodex_wait_max": 30
           }
         }
@@ -387,6 +387,6 @@
     },
 	"websocket": {
 		"start_embedded_server": true,
-		"server_url": "127.0.0.1:4000"
+		"server_url": "0.0.0.0:4000"
 	}
 }

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -99,18 +99,18 @@
         "type": "EvolvePokemon",
         "config": {
             "enabled": false,
-            
+
             "// evolve only pidgey and drowzee": "",
             "// evolve_list": "pidgey, drowzee",
             "// donot_evolve_list": "none",
-            
+
             "// evolve all but pidgey and drowzee": "",
             "// evolve_list": "all",
             "// donot_evolve_list": "pidgey, drowzee",
-            
+
             "evolve_list": "all",
             "donot_evolve_list": "none",
-            
+
             "first_evolve_by": "cp",
             "evolve_above_cp": 500,
             "evolve_above_iv": 0.8,
@@ -176,7 +176,7 @@
             "berry_wait_max": 3,
             "changeball_wait_min": 2,
             "changeball_wait_max": 3,
-            "newtodex_wait_min": 20, 
+            "newtodex_wait_min": 20,
             "newtodex_wait_max": 30
           }
         }
@@ -575,6 +575,6 @@
     },
 	"websocket": {
 		"start_embedded_server": true,
-		"server_url": "127.0.0.1:4000"
+		"server_url": "0.0.0.0:4000"
 	}
 }

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -99,18 +99,18 @@
         "type": "EvolvePokemon",
         "config": {
             "enabled": false,
-            
+
             "// evolve only pidgey and drowzee": "",
             "// evolve_list": "pidgey, drowzee",
             "// donot_evolve_list": "none",
-            
+
             "// evolve all but pidgey and drowzee": "",
             "// evolve_list": "all",
             "// donot_evolve_list": "pidgey, drowzee",
-            
+
             "evolve_list": "all",
             "donot_evolve_list": "none",
-            
+
             "first_evolve_by": "cp",
             "evolve_above_cp": 500,
             "evolve_above_iv": 0.8,
@@ -292,6 +292,6 @@
     },
 	"websocket": {
 		"start_embedded_server": true,
-		"server_url": "127.0.0.1:4000"
+		"server_url": "0.0.0.0:4000"
 	}
 }

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -99,18 +99,18 @@
         "type": "EvolvePokemon",
         "config": {
             "enabled": false,
-            
+
             "// evolve only pidgey and drowzee": "",
             "// evolve_list": "pidgey, drowzee",
             "// donot_evolve_list": "none",
-            
+
             "// evolve all but pidgey and drowzee": "",
             "// evolve_list": "all",
             "// donot_evolve_list": "pidgey, drowzee",
-            
+
             "evolve_list": "all",
             "donot_evolve_list": "none",
-            
+
             "first_evolve_by": "cp",
             "evolve_above_cp": 500,
             "evolve_above_iv": 0.8,
@@ -541,6 +541,6 @@
     },
 	"websocket": {
 		"start_embedded_server": true,
-		"server_url": "127.0.0.1:4000"
+		"server_url": "0.0.0.0:4000"
 	}
 }


### PR DESCRIPTION
## Short Description:
This PR will make the socket use a dynamic IP `0.0.0.0`, instead of fixed `127.0.0.1`, making it easier to run on any IP, preventing a [web](https://github.com/PokemonGoF/PokemonGo-Web) socket-io connection error.

## Improves:
- Connectivity of the web repository

## FYI
- Must be used in conjuction with [this PR](https://github.com/PokemonGoF/PokemonGo-Web/pull/67)