### PR TITLE
When daily spin limit is reached, let it continue working instead of …

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ If you do not want any data to be gathered, you can turn off this feature by set
  * bruno-kenji
  * Gobberwart
  * javajohnHub
+ * kolinkorr839
 
 ## Disclaimer
 ©2016 Niantic, Inc. ©2016 Pokémon. ©1995–2016 Nintendo / Creatures Inc. / GAME FREAK inc. © 2016 Pokémon/Nintendo Pokémon and Pokémon character names are trademarks of Nintendo. The Google Maps Pin is a trademark of Google Inc. and the trade dress in the product design is a trademark of Google Inc. under license to The Pokémon Company. Other trademarks are the property of their respective owners.

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -215,7 +215,7 @@ The behaviors of the bot are configured via the `tasks` key in the `config.json`
   * `spin_wait_max`: Default 5 | Maximum wait time after fort spin
   * `daily_spin_limit`: Default 2000 | Daily spin limit
   * `min_interval`: Default 120 | When daily spin limit is reached, how often should the warning message be shown
-  * `bypass_daily_limit`: Default `False` | Disable the spin daily limit protection
+  * `exit_on_limit_reached`: Default `True` | Code will exits if daily_spin_limit is reached
 * HandleSoftBan
 * IncubateEggs
   * `enable`: Disable or enable this task.

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -213,6 +213,9 @@ The behaviors of the bot are configured via the `tasks` key in the `config.json`
   * `enable`: Disable or enable this task.
   * `spin_wait_min`: Default 3 | Minimum wait time after fort spin
   * `spin_wait_max`: Default 5 | Maximum wait time after fort spin
+  * `daily_spin_limit`: Default 2000 | Daily spin limit
+  * `min_interval`: Default 120 | When daily spin limit is reached, how often should the warning message be shown
+  * `bypass_daily_limit`: Default `False` | Disable the spin daily limit protection
 * HandleSoftBan
 * IncubateEggs
   * `enable`: Disable or enable this task.

--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -35,7 +35,7 @@ class SpinFort(BaseTask):
         self.spin_wait_min = self.config.get("spin_wait_min", 2)
         self.spin_wait_max = self.config.get("spin_wait_max", 3)
         self.min_interval = int(self.config.get('min_interval', 120))
-        self.bypass_daily_limit = self.config.get("bypass_daily_limit", False)
+        self.exit_on_limit_reached = self.config.get("exit_on_limit_reached", True)
 
     def should_run(self):
         has_space_for_loot = inventory.Items.has_space_for_loot()
@@ -54,7 +54,7 @@ class SpinFort(BaseTask):
             c = conn.cursor()
             c.execute("SELECT DISTINCT COUNT(pokestop) FROM pokestop_log WHERE dated >= datetime('now','-1 day')")
         if c.fetchone()[0] >= self.config.get('daily_spin_limit', 2000):
-           if not self.bypass_daily_limit:
+           if self.exit_on_limit_reached:
                self.emit_event('spin_limit', formatted='WARNING! You have reached your daily spin limit')
                sys.exit(2)
 

--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -61,6 +61,7 @@ class SpinFort(BaseTask):
            if datetime.now() >= self.next_update:
                self.emit_event('spin_limit', formatted='WARNING! You have reached your daily spin limit')
                self._compute_next_update()
+               return WorkerResult.SUCCESS
 
         if not self.should_run() or len(forts) == 0:
             return WorkerResult.SUCCESS


### PR DESCRIPTION
# Short Description:

When the daily spin limit is reached, the script exits. This change allow the script to continue but gives a warning that the spin limit is reached every 120 seconds (default which can be changed).

Sample output:
```
[2016-09-19 11:54:53] [  SpinFort] [INFO] Spun pokestop First Street. Experience awarded: 50. Items awarded: 1x Potion, 2x Pokeball
[2016-09-19 11:54:53] [  SpinFort] [INFO] WARNING! You have reached your daily spin limit
[2016-09-19 11:54:58] [MoveToFort] [INFO] Moving towards pokestop Mosaic Seats - 0.07km
[2016-09-19 11:55:03] [MoveToFort] [INFO] Moving towards pokestop Mosaic Seats - 0.06km
[2016-09-19 11:55:09] [MoveToFort] [INFO] Moving towards pokestop Mosaic Seats - 0.04km
[2016-09-19 11:55:10] [  SpinFort] [INFO] Spun pokestop Mosaic Seats. Experience awarded: 50. Items awarded: 3x Pokeball
```