### PR TITLE
TransferPokemon: Release logic fix

### DIFF
--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -166,12 +166,6 @@ class TransferPokemon(BaseTask):
             cp_iv_logic = self._get_release_config_for(
                 'any').get('logic', 'and')
 
-        release_results = {
-            'cp': False,
-            'iv': False,
-            'ivcp': False
-        }
-
         if release_config.get('never_release', False):
             return False
 
@@ -179,17 +173,19 @@ class TransferPokemon(BaseTask):
             return True
 
         release_cp = release_config.get('release_below_cp', 0)
-        if pokemon.cp < release_cp:
-            release_results['cp'] = True
-
         release_iv = release_config.get('release_below_iv', 0)
-        if pokemon.iv < release_iv:
-            release_results['iv'] = True
-
         release_ivcp = release_config.get('release_below_ivcp', 0)
-        if pokemon.ivcp < release_ivcp:
-            release_results['ivcp'] = True
 
+        release_results = {}
+        if (cp_iv_logic == 'and'):
+            release_results['cp'] = (release_config.get('release_below_cp', -1) != 0) and (not release_cp or pokemon.cp < release_cp)
+            release_results['iv'] = (release_config.get('release_below_iv', -1) != 0) and (not release_iv or pokemon.iv < release_iv)
+            release_results['ivcp'] = (release_config.get('release_below_ivcp', -1) != 0) and (not release_ivcp or pokemon.ivcp < release_ivcp)
+        else:
+            release_results['cp'] = release_cp and pokemon.cp < release_cp
+            release_results['iv'] = release_iv and pokemon.iv < release_iv
+            release_results['ivcp'] = release_ivcp and pokemon.ivcp < release_ivcp
+            
         logic_to_function = {
             'or': lambda x, y, z: x or y or z,
             'and': lambda x, y, z: x and y and z


### PR DESCRIPTION
## Short Description:

Logic in transferpokemon task is incorrect. Works for "or" but not for "and". This fix is based on #5510 which appears to be inactive.

## Fixes/Resolves/Closes (please use correct syntax):
- #5507 
- #5480 
- #5562

