### PR TITLE
Hotfix crash on telegram /login if args != 2

### DIFF
--- a/pokemongo_bot/event_handlers/telegram_handler.py
+++ b/pokemongo_bot/event_handlers/telegram_handler.py
@@ -92,7 +92,11 @@ class TelegramClass:
         return
 
     def authenticate(self, update):
-        (command, password) = update.message.text.split(' ')
+        args = update.message.text.split(' ')
+        if len(args) != 2:
+            self.chat_handler.sendMessage(chat_id=update.message.chat_id, parse_mode='Markdown', text="Invalid password")
+            return
+        password = args[1]
         if password != self.config.get('password', None):
             self.chat_handler.sendMessage(chat_id=update.message.chat_id, parse_mode='Markdown', text="Invalid password")
         else:


### PR DESCRIPTION
## Short Description:

On telegram /login command, if incorrect number of arguments specified (eg. "/login my password"), hangs telegram with `ValueError: too many values to unpack.

## Fixes/Resolves/Closes (please use correct syntax):
- N/A issue found during testing

