### PR TITLE
fix regex pattern for gps coordinates

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -1284,7 +1284,7 @@ class PokemonGoBot(object):
         # Check if the given location is already a coordinate.
         if ',' in location_name:
             possible_coordinates = re.findall(
-                "[-]?\d{1,3}[.]\d{3,7}", location_name
+                "[-]?\d{1,3}(?:[.]\d+)?", location_name
             )
             if len(possible_coordinates) >= 2:
                 # 2 matches, this must be a coordinate. We'll bypass the Google


### PR DESCRIPTION
## Short Description:
fixes limited input for gps-coordinates in json files in FollowPath worker.
Too short Numbers like 1.23 were not recognised by the old logic.
Instead you would have to write 1.230.
The new pattern now also supports natural numbers like 1 and 2 as well as 1.1 and 2.2

## Fixes/Closes
https://github.com/PokemonGoF/PokemonGo-Bot/issues/5413