### PR TITLE
Fix PokemonOptimizer ValueError

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_optimizer.py
+++ b/pokemongo_bot/cell_workers/pokemon_optimizer.py
@@ -313,7 +313,7 @@ class PokemonOptimizer(BaseTask):
         sorted_pokemon = self.sort_pokemon_list_to_keep(pokemon_list, rule)
 
         if len(sorted_pokemon) == 0:
-            return ([], [], [])
+            return ([], [], [], [])
 
         top = max(rule.get("top", 0), 0)
         index = int(math.ceil(top)) - 1


### PR DESCRIPTION
Original output:
```
Traceback (most recent call last):
  File "pokecli.py", line 843, in <module>
    main()
  File "pokecli.py", line 202, in main
    bot.tick()
  File "/home/cmezh/pogo/pokemongo_bot/__init__.py", line 744, in tick
    if worker.work() == WorkerResult.RUNNING:
  File "/home/cmezh/pogo/pokemongo_bot/cell_workers/pokemon_optimizer.py", line 136, in work
    keep, try_evolve, try_upgrade, buddy = self.get_best_pokemon_for_rule(pokemon_list, rule)
ValueError: need more than 3 values to unpack
```