### PR TITLE
Fix no ncp config in vips config

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -286,7 +286,7 @@
     },
     "vips" : {
          "Any pokemon put here directly force to use Berry & Best Ball to capture, to secure the capture rate": {},
-        "any": {"catch_above_cp": 1200, "catch_above_iv": 0.9, "logic": "or" },
+        "any": {"catch_above_cp": 1200, "catch_above_iv": 0.9, "catch_above_ncp": 0.9, "logic": "or" },
         "Lapras": {},
         "Moltres": {},
         "Zapdos": {},

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -365,7 +365,7 @@
     },
     "vips" : {
         "Any pokemon put here directly force to use Berry & Best Ball to capture, to secure the capture rate": {},
-        "any": {"catch_above_cp": 1200, "catch_above_iv": 0.9, "logic": "or" },
+        "any": {"catch_above_cp": 1200, "catch_above_iv": 0.9, "catch_above_ncp": 0.9, "logic": "or" },
         "Lapras": {},
         "Moltres": {},
         "Zapdos": {},

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -552,7 +552,7 @@
     },
     "vips" : {
          "Any pokemon put here directly force to use Berry & Best Ball to capture, to secure the capture rate": {},
-        "any": {"catch_above_cp": 1200, "catch_above_iv": 0.9, "logic": "or" },
+        "any": {"catch_above_cp": 1200, "catch_above_iv": 0.9, "catch_above_ncp": 0.9, "logic": "or" },
         "Lapras": {},
         "Moltres": {},
         "Zapdos": {},

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -518,7 +518,7 @@
     },
     "vips" : {
          "Any pokemon put here directly force to use Berry & Best Ball to capture, to secure the capture rate": {},
-        "any": {"catch_above_cp": 1200, "catch_above_iv": 0.9, "logic": "or" },
+        "any": {"catch_above_cp": 1200, "catch_above_iv": 0.9, "catch_above_ncp": 0.9, "logic": "or" },
         "Lapras": {},
         "Moltres": {},
         "Zapdos": {},


### PR DESCRIPTION
Fix:
- Bot always considers all pokemons as vip