### PR TITLE
Hotfix: Fix release logic on no rule supplied

### DIFF
--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -170,6 +170,7 @@ class TransferPokemon(BaseTask):
             return False
 
         if release_config.get('always_release', False):
+            print "FUCKITYFUCK"
             return True
 
         release_cp = release_config.get('release_below_cp', 0)
@@ -177,14 +178,18 @@ class TransferPokemon(BaseTask):
         release_ivcp = release_config.get('release_below_ivcp', 0)
 
         release_results = {}
-        if (cp_iv_logic == 'and'):
-            release_results['cp'] = (release_config.get('release_below_cp', -1) != 0) and (not release_cp or pokemon.cp < release_cp)
-            release_results['iv'] = (release_config.get('release_below_iv', -1) != 0) and (not release_iv or pokemon.iv < release_iv)
-            release_results['ivcp'] = (release_config.get('release_below_ivcp', -1) != 0) and (not release_ivcp or pokemon.ivcp < release_ivcp)
+        # Check if any rules supplied
+        if (release_cp == 0 and release_iv == 0 and release_ivcp == 0): # No rules supplied, assume all false
+            release_results = {'cp': False, 'iv': False, 'ivcp': False}
         else:
-            release_results['cp'] = release_cp and pokemon.cp < release_cp
-            release_results['iv'] = release_iv and pokemon.iv < release_iv
-            release_results['ivcp'] = release_ivcp and pokemon.ivcp < release_ivcp
+            if (cp_iv_logic == 'and'):
+                release_results['cp'] = (release_config.get('release_below_cp', -1) != 0) and (not release_cp or pokemon.cp < release_cp)
+                release_results['iv'] = (release_config.get('release_below_iv', -1) != 0) and (not release_iv or pokemon.iv < release_iv)
+                release_results['ivcp'] = (release_config.get('release_below_ivcp', -1) != 0) and (not release_ivcp or pokemon.ivcp < release_ivcp)
+            else:
+                release_results['cp'] = release_cp and pokemon.cp < release_cp
+                release_results['iv'] = release_iv and pokemon.iv < release_iv
+                release_results['ivcp'] = release_ivcp and pokemon.ivcp < release_ivcp
             
         logic_to_function = {
             'or': lambda x, y, z: x or y or z,

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -180,12 +180,12 @@ class TransferPokemon(BaseTask):
         # Check if any rules supplied
         if (release_cp == 0 and release_iv == 0 and release_ivcp == 0): # No rules supplied, assume all false
             release_results = {'cp': False, 'iv': False, 'ivcp': False}
-        else:
-            if (cp_iv_logic == 'and'):
+        else # One or more rules supplied, evaluate
+            if (cp_iv_logic == 'and'): # "and" logic assumes true if not provided
                 release_results['cp'] = (release_config.get('release_below_cp', -1) != 0) and (not release_cp or pokemon.cp < release_cp)
                 release_results['iv'] = (release_config.get('release_below_iv', -1) != 0) and (not release_iv or pokemon.iv < release_iv)
                 release_results['ivcp'] = (release_config.get('release_below_ivcp', -1) != 0) and (not release_ivcp or pokemon.ivcp < release_ivcp)
-            else:
+            else: # "or" logic assumes false if not provided
                 release_results['cp'] = release_cp and pokemon.cp < release_cp
                 release_results['iv'] = release_iv and pokemon.iv < release_iv
                 release_results['ivcp'] = release_ivcp and pokemon.ivcp < release_ivcp

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -170,7 +170,6 @@ class TransferPokemon(BaseTask):
             return False
 
         if release_config.get('always_release', False):
-            print "FUCKITYFUCK"
             return True
 
         release_cp = release_config.get('release_below_cp', 0)


### PR DESCRIPTION
## Short Description:

If no cp/iv/ivcp release rules are provided for a given pokemon, the bot assumes "and" logic and releases it anyway. This is definitely not desirable. 

Changed so that if no cp/iv/ivcp rule is provided, the bot assumes false for everything.

## Fixes/Resolves/Closes (please use correct syntax):
- #5587
