### PR TITLE
Added six>=1.9.0 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ requests==2.10.0
 requests-mock==1.0.0
 s2sphere==0.2.4
 gpsoauth==0.3.0
+six>=1.9.0
 protobuf-to-dict==0.1.0
 googlemaps==2.4.4
 colorama==0.3.7


### PR DESCRIPTION
## Short Description:

six>=1.9.0 is required for protobuf-to-dict 0.1.0 but not installed as a requirement by default. Added to requirements.txt

## Fixes/Resolves/Closes (please use correct syntax):
- #5509 
