### PR TITLE
Fix order/display of IV and CP in Telegram /caught function

### DIFF
--- a/pokemongo_bot/event_handlers/chat_handler.py
+++ b/pokemongo_bot/event_handlers/chat_handler.py
@@ -189,12 +189,12 @@ class ChatHandler:
 
         with self.bot.database as conn:
             cur = conn.cursor()
-            cur.execute("SELECT * FROM catch_log ORDER BY " + order + " DESC LIMIT " + str(num))
+            cur.execute("SELECT pokemon, cp, iv FROM catch_log ORDER BY " + order + " DESC LIMIT " + str(num))
             caught = cur.fetchall()
             outMsg = ''
             if caught:
                 for x in caught:
-                    outMsg += '*' + x[0] + '* ' + '(_CP:_ ' + str(int(x[2])) + ') (_IV:_ ' + str(x[1]) + ')\n'
+                    outMsg += '*' + x[0] + '* ' + '(_CP:_ ' + str(int(x[1])) + ') (_IV:_ ' + str(x[2]) + ')\n'
                 self.sendMessage(chat_id=chat_id, parse_mode='Markdown', text="".join(str(outMsg)))
             else:
                 self.sendMessage(chat_id=chat_id, parse_mode='Markdown', text="No Pokemon Caught Yet.\n")


### PR DESCRIPTION
## Short Description:
When using the /caught function in Telegram, the CP is always 0 (or 1 in case of a perfect iv) and IV holds the CP. This PR fixes that. 

It now also retrieves only the needed information from the database in a set order; something I suggest you/we do more often, seeing as you almost always select all columns. (Which might even cause these kinds of bugs in case the order of the columns changes in the table).

## Fixes/Resolves/Closes:
None

