### PR TITLE
Sniper task: Keeping 'missing' Pokemon + sorting order correction

### DIFF
--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -6,6 +6,7 @@ import requests
 import calendar
 
 from random import uniform
+from operator import itemgetter, methodcaller
 from datetime import datetime
 from pokemongo_bot import inventory
 from pokemongo_bot.item_list import Item

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -278,7 +278,7 @@ class Sniper(BaseTask):
                 if pokemon.get('vip', False):
                     self._trace('{} is not catchable and bad IV (if any), however its a VIP!'.format(pokemon.get('pokemon_name')))
                 else:
-                    if pokemon['missing']:
+                    if pokemon.get('missing', False):
                         self._trace('{} is not catchable, not VIP and bad IV (if any), however its a missing one.'.format(pokemon.get('pokemon_name')))
                     else:
                         self._trace('{} is not catchable, nor a VIP or a missing one and bad IV (if any). Skipping...'.format(pokemon.get('pokemon_name')))

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -277,8 +277,11 @@ class Sniper(BaseTask):
                 if pokemon.get('vip', False):
                     self._trace('{} is not catchable and bad IV (if any), however its a VIP!'.format(pokemon.get('pokemon_name')))
                 else:
-                    self._trace('{} is not catachable, nor a VIP and bad IV (if any). Skipping...'.format(pokemon.get('pokemon_name')))
-                    return False
+                    if pokemon['missing']:
+                        self._trace('{} is not catchable, not VIP and bad IV (if any), however its a missing one.'.format(pokemon.get('pokemon_name')))
+                    else:
+                        self._trace('{} is not catachable, nor a VIP or a missing one and bad IV (if any). Skipping...'.format(pokemon.get('pokemon_name')))
+                        return False
 
         return True
 
@@ -362,8 +365,7 @@ class Sniper(BaseTask):
 
             if targets:
                 # Order the targets (descending)
-                for attr in self.order:
-                    targets.sort(key=lambda pokemon: pokemon[attr], reverse=True)
+                targets = sorted(targets, key=itemgetter(*self.order), reverse=True)
 
                 shots = 0
 

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -281,7 +281,7 @@ class Sniper(BaseTask):
                     if pokemon['missing']:
                         self._trace('{} is not catchable, not VIP and bad IV (if any), however its a missing one.'.format(pokemon.get('pokemon_name')))
                     else:
-                        self._trace('{} is not catachable, nor a VIP or a missing one and bad IV (if any). Skipping...'.format(pokemon.get('pokemon_name')))
+                        self._trace('{} is not catchable, nor a VIP or a missing one and bad IV (if any). Skipping...'.format(pokemon.get('pokemon_name')))
                         return False
 
         return True


### PR DESCRIPTION
- A 'missing' only Pokemon (not on the catch_list, no VIP and with a bad IV) will now be keep on the list as a potential target if 'missing' is specified on the order option

- The sorting of the target list is now cumulative.
For example, if the order option is [missing, vip, priority], then the list will be ordered by 'missing' first, and then VIP's, and finally by Priority. Actually, the list is only ordered by the last order option specified on the config (only by priority on this example)

Screenshot example of a cumulative [missing, priority, iv, vip] order list

![pgo_log](https://cloud.githubusercontent.com/assets/12796711/18752200/f4d77bd6-80e1-11e6-8775-a3a8f86e852b.png)
