### PR TITLE
Add timeouts to sniper source config

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -224,6 +224,7 @@
 				{
 				    "enabled": false,
 					"url": "http://localhost:5000/raw_data",
+					"timeout": 3,
 					"key": "pokemons",
 					"mappings": {
 						"id": { "param": "pokemon_id" },
@@ -236,6 +237,7 @@
 				{
 				    "enabled": false,
 					"url": "https://pokewatchers.com/grab/",
+					"timeout": 10,
 					"mappings": {
 						"iv": { "param": "iv" },
 						"id": { "param": "pid" },
@@ -248,6 +250,7 @@
 				{
 				    "enabled": false,
 					"url": "http://pokesnipers.com/api/v1/pokemon.json",
+					"timeout": 10,
 					"key": "results",
 					"mappings": {
 						"iv": { "param": "iv" },

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -479,6 +479,7 @@
 				    "enabled": false,
 					"url": "http://localhost:5000/raw_data",
 					"key": "pokemons",
+					"timeout": 3,
 					"mappings": {
 						"id": { "param": "pokemon_id" },
 						"name": { "param": "pokemon_name" },
@@ -490,6 +491,7 @@
 				{
 				    "enabled": false,
 					"url": "https://pokewatchers.com/grab/",
+					"timeout": 10,
 					"mappings": {
 						"iv": { "param": "iv" },
 						"id": { "param": "pid" },
@@ -502,6 +504,7 @@
 				{
 				    "enabled": false,
 					"url": "http://pokesnipers.com/api/v1/pokemon.json",
+					"timeout": 10,
 					"key": "results",
 					"mappings": {
 						"iv": { "param": "iv" },

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -754,7 +754,7 @@ This task is an upgrade version of the MoveToMapPokemon task. It will fetch poke
 * `sources.key` - The JSON key that contains the results, eg.: For a JSON response such as `{ "SomeWeirdoName": [{"id": 123, ...}, {"id": 143, ...}]}`, `SomeWeirdoName` would be the key name.
 * `sources.url` - The URL that will provide the JSON.
 * `sources.enabled` - Defines whether this source is enabled or not. This has nothing to do with the task's `enabled`.
-* `sources.timeout` - How long to wait for this source to respond before giving up.
+* `sources.timeout` - How long to wait for this source to respond before giving up (default 5 seconds)
 * `mappings`- Map JSON parameters to required values.
    - `iv` - The JSON param that corresponds to the pokemon IV. Only certain sources provide this info. **NOTE:** `social` mode does not provide this info!
    - `id` - The JSON param that corresponds to the pokemon ID. (required)

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -32,7 +32,7 @@
     - [Description](#description)
     - [Options](#options)
         - [Example](#example)
-- [Sniping _(Sniper)_](#sniping-_-sniper-_)
+- [Sniping _(Sniper)_](#sniper)
     - [Description](#description)
     - [Options](#options)
         - [Example](#example)
@@ -725,7 +725,7 @@ This task will fetch current pokemon spawns from /raw_data of an PokemonGo-Map i
 }
 ```
 
-## Sniping _(Sniper)_
+## Sniper
 [[back to top](#table-of-contents)]
 
 ### Description
@@ -754,6 +754,8 @@ This task is an upgrade version of the MoveToMapPokemon task. It will fetch poke
 * `sources.key` - The JSON key that contains the results, eg.: For a JSON response such as `{ "SomeWeirdoName": [{"id": 123, ...}, {"id": 143, ...}]}`, `SomeWeirdoName` would be the key name.
 * `sources.url` - The URL that will provide the JSON.
 * `sources.enabled` - Defines whether this source is enabled or not. This has nothing to do with the task's `enabled`.
+* `sources.timeout` - How long to wait for this source to respond before giving up.
+* `mappings`- Map JSON parameters to required values.
    - `iv` - The JSON param that corresponds to the pokemon IV. Only certain sources provide this info. **NOTE:** `social` mode does not provide this info!
    - `id` - The JSON param that corresponds to the pokemon ID. (required)
    - `name` - The JSON param that corresponds to the pokemon name. (required)
@@ -781,6 +783,8 @@ This task is an upgrade version of the MoveToMapPokemon task. It will fetch poke
         "sources": [
             {
                 "url": "http://pokesnipers.com/api/v1/pokemon.json",
+                "enabled": true,
+                "timeout": 15,
                 "key": "results",
                 "mappings": {
                     "iv": { "param": "iv" },
@@ -793,6 +797,8 @@ This task is an upgrade version of the MoveToMapPokemon task. It will fetch poke
             {
                 "url": "http://localhost:5000/raw_data",
                 "key": "pokemons",
+                "enabled": true,
+                "timeout": 5,
                 "mappings": {
                     "id": { "param": "pokemon_id" },
                     "name": { "param": "pokemon_name" },
@@ -803,6 +809,8 @@ This task is an upgrade version of the MoveToMapPokemon task. It will fetch poke
             },
             {
                 "url": "https://pokewatchers.com/grab/",
+                "enabled": true,
+                "timeout": 15,
                 "mappings": {
                     "iv": { "param": "iv" },
                     "id": { "param": "pid" },

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -29,7 +29,6 @@ class SniperSource(object):
         return self.url
 
     def fetch_raw(self):
-        print "timeout: {} {}".format(self.timeout, self.url)
         some_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/52.0.2743.116 Safari/537.36'
         response = requests.get(self.url, headers={'User-Agent': some_agent}, timeout=self.timeout)
         results = response.json()
@@ -108,7 +107,7 @@ class SniperSource(object):
             if self.enabled:
                 errors = []
                 data = self.fetch_raw()
-
+                
                 # Check whether the params really exist if they have been specified like so
                 if data:
                     if self.mappings.iv.exists and self.mappings.iv.param not in data[0]:

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -23,23 +23,25 @@ class SniperSource(object):
         self.enabled = data.get('enabled', False)
         self.time_mask = data.get('time_mask', '%Y-%m-%d %H:%M:%S')
         self.mappings = SniperSourceMapping(data.get('mappings', {}))
+        self.timeout = data.get('timeout', 5)
 
     def __str__(self):
         return self.url
 
-    def fetch_raw(self, timeoutz):
+    def fetch_raw(self):
+        print "timeout: {} {}".format(self.timeout, self.url)
         some_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/52.0.2743.116 Safari/537.36'
-        response = requests.get(self.url, headers={'User-Agent': some_agent}, timeout=timeoutz)
+        response = requests.get(self.url, headers={'User-Agent': some_agent}, timeout=self.timeout)
         results = response.json()
 
         # If the results is a dict, retrieve the list from it by the given key. This will return a list afterall.
         return results.get(self.key, []) if isinstance(results, dict) else results
 
-    def fetch(self, timeout):
+    def fetch(self):
         pokemons = []
 
         try:
-            results = self.fetch_raw(timeout)
+            results = self.fetch_raw()
 
             # Parse results
             for result in results:
@@ -105,7 +107,7 @@ class SniperSource(object):
         try:
             if self.enabled:
                 errors = []
-                data = self.fetch_raw(10)
+                data = self.fetch_raw()
 
                 # Check whether the params really exist if they have been specified like so
                 if data:
@@ -424,7 +426,7 @@ class Sniper(BaseTask):
             for source in self.sources:
                 try:
                     if source.enabled:
-                        source_pokemons = source.fetch(3)
+                        source_pokemons = source.fetch()
                         self._trace("Source '{}' returned {} results".format(source.url, len(source_pokemons)))
 
                         # Merge lists, making sure to exclude repeated data. Use location as the hash key


### PR DESCRIPTION
## Short Description:

Sniper currently uses hard-coded values for timeout when trying to validate/retrieve data from sources. Some sources (eg. localhost:5000/raw_data) should have lower timeouts than others as they can be significantly slower.

This is now user-configurable per-source (default to 5 seconds) which allows users to configure higher timeouts for known slow sources, and lower timeouts for sources that should be fast.

## Fixes/Resolves/Closes (please use correct syntax):
- N/A
