### PR TITLE
[Sniper] Extend support for different source formats

### DIFF
--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -62,6 +62,8 @@ class SniperSource(object):
                 expiration = result.get(self.mappings.expiration.param)
                 encounter = result.get(self.mappings.encounter.param)
                 spawnpoint = result.get(self.mappings.spawnpoint.param)
+                
+                print name
 
                 # If this is a composite param, split it ("coords": "-31.415553, -64.190480")
                 if self.mappings.latitude.param == self.mappings.longitude.param:
@@ -153,6 +155,7 @@ class SniperSource(object):
             
     def _fixname(self,name):
         name = name.replace("mr-mime","mr. mime")
+        name = name.replace("farfetchd","farfetch'd")
         return name
 
 

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -56,7 +56,7 @@ class SniperSource(object):
             for result in results:
                 iv = result.get(self.mappings.iv.param)
                 id = result.get(self.mappings.id.param)
-                name = result.get(self.mappings.name.param)
+                name = self._fixname(result.get(self.mappings.name.param))
                 latitude = result.get(self.mappings.latitude.param)
                 longitude = result.get(self.mappings.longitude.param)
                 expiration = result.get(self.mappings.expiration.param)
@@ -150,6 +150,11 @@ class SniperSource(object):
             raise ValueError("Source not available")
         except:
             raise
+            
+    def _fixname(self,name):
+        name = name.replace("mr-mime","mr. mime")
+        return name
+
 
 # Represents the JSON params mappings
 class SniperSourceMapping(object):

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -34,7 +34,17 @@ class SniperSource(object):
         results = response.json()
 
         # If the results is a dict, retrieve the list from it by the given key. This will return a list afterall.
-        return results.get(self.key, []) if isinstance(results, dict) else results
+        if isinstance(results, dict): 
+            results = results.get(self.key, []) 
+            
+        # If results is STILL a dict (eg. each pokemon is its own dict), need to build data from nested json (example whereispokemon.net)
+        while isinstance(results,dict):
+            tmpResults = []
+            for key, value in results.iteritems(): 
+                tmpResults.append(value)
+                results = tmpResults
+                
+        return results
 
     def fetch(self):
         pokemons = []


### PR DESCRIPTION
## Short Description:

I came across a source which provides json data in a nested format, eg. instead of `{'id':1, 'name': 'pokemonname", 'lat':'blahblah' etc.}` it's `{'id':1 {'name': 'pokemonname", 'lat':'blahblah' etc.}}`

Added code to check if still a dict after getting key and looping until we get lowest nest level.

Probably not going to happen often, but we might as well support as many variations of json sources as possible.

Also adds some functionality to "fix" names that are known to cause issues, example "mr-mime" -> "mr mime". Not much there yet, but we can add to it as we find more.

Note: This does not impact existing working sources, which should be converted from dict to list by this point.

## Fixes/Resolves/Closes (please use correct syntax):
- N/A
