### PR TITLE
[Sniper] Fix cache, and name matching tweak

### DIFF
--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -337,10 +337,8 @@ class Sniper(BaseTask):
             # Check if already in list of pokemon we've tried
             if self._is_cached(pokemon):
                 # Do nothing. Either we already got this, or it doesn't really exist
-                print "Already tried"
                 self._trace('{} already sniped! Skipping...'.format(pokemon['pokemon_name']))
             else:
-                print "Not already tried"
                 # Backup position before anything
                 last_position = self.bot.position[0:2]
 

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -174,6 +174,8 @@ class SniperSource(object):
                 print "Unknown Pokemon name {}. Assuming it is {}".format(name, closest_name)
 
             return closest_name
+        
+        return name
 
 # Represents the JSON params mappings
 class SniperSourceMapping(object):

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -4,6 +4,7 @@ import time
 import json
 import requests
 import calendar
+import difflib
 
 from random import uniform
 from operator import itemgetter, methodcaller
@@ -56,7 +57,7 @@ class SniperSource(object):
             for result in results:
                 iv = result.get(self.mappings.iv.param)
                 id = result.get(self.mappings.id.param)
-                name = self._fixname(result.get(self.mappings.name.param))
+                name = self._get_closest_name(self._fixname(result.get(self.mappings.name.param)))
                 latitude = result.get(self.mappings.latitude.param)
                 longitude = result.get(self.mappings.longitude.param)
                 expiration = result.get(self.mappings.expiration.param)
@@ -159,6 +160,20 @@ class SniperSource(object):
             name = name.replace("Nidoran\u2640","nidoran f")
         return name
 
+    def _get_closest_name(self, name):
+        if not name:
+            return
+            
+        pokemon_names = [p.name for p in inventory.pokemons().STATIC_DATA]
+        closest_names = difflib.get_close_matches(name, pokemon_names, 1)
+
+        if closest_names:
+            closest_name = closest_names[0]
+
+            if name != closest_name:
+                print "Unknown Pokemon name {}. Assuming it is {}".format(name, closest_name)
+
+            return closest_name
 
 # Represents the JSON params mappings
 class SniperSourceMapping(object):

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -5,7 +5,6 @@ import json
 import requests
 import calendar
 import difflib
-import hashlib
 
 from random import uniform
 from operator import itemgetter, methodcaller

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -227,7 +227,7 @@ class Sniper(BaseTask):
     MIN_SECONDS_ALLOWED_FOR_CELL_CHECK = 10
     MIN_SECONDS_ALLOWED_FOR_REQUESTING_DATA = 5
     MIN_BALLS_FOR_CATCHING = 10
-    MAX_CACHE_LIST_SIZE = 500
+    MAX_CACHE_LIST_SIZE = 300
 
     def __init__(self, bot, config):
         super(Sniper, self).__init__(bot, config)

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -152,8 +152,11 @@ class SniperSource(object):
             raise
             
     def _fixname(self,name):
-        name = name.replace("mr-mime","mr. mime")
-        name = name.replace("farfetchd","farfetch'd")
+        if name:
+            name = name.replace("mr-mime","mr. mime")
+            name = name.replace("farfetchd","farfetch'd")
+            name = name.replace("Nidoran\u2642","nidoran m")
+            name = name.replace("Nidoran\u2640","nidoran f")
         return name
 
 

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -169,10 +169,6 @@ class SniperSource(object):
 
         if closest_names:
             closest_name = closest_names[0]
-
-            if name != closest_name:
-                print "Unknown Pokemon name {}. Assuming it is {}".format(name, closest_name)
-
             return closest_name
         
         return name


### PR DESCRIPTION
## Short Description:

Two issues fixed here. 

1. Existing cache is not persistent, and gets reset every time the task runs, which results in repeated failed attempts to catch non-existent/otherwise failed pokemon. Even if cache hits, still generates an unnecessary log message. Changed to persistent cache, and check before attempting to snipe.

2. Name matching can be flaky depending on sources. Added method to manually fix names we know about, or use difflib (as with pokemonoptimizer) to try and match any we haven't already caught. Note that difflib alone is not sufficient for this, eg. it thinks source name "mr-mime" is a Grimer. Close but no cigar.