### PR TITLE
Increase sniper's wait time, so as to avoid missing some pokemon

### DIFF
--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -331,6 +331,10 @@ class Sniper(BaseTask):
                 if (seconds_since_last_check < self.MIN_SECONDS_ALLOWED_FOR_CELL_CHECK):
                     time.sleep(self.MIN_SECONDS_ALLOWED_FOR_CELL_CHECK - seconds_since_last_check)
 
+                # Sleep a bit longer for the Pokemon to appear
+                self._log('Waiting for the Pokemon to appear...')
+                time.sleep(randint(5,10))
+
                 nearby_pokemons = []
                 nearby_stuff = self.bot.get_meta_cell()
                 self.last_cell_check_time = time.time()


### PR DESCRIPTION
## Short Description:
Wait time is too short after teleporting to the destination. As such, it does not allow enough time to appear for sniping.

Added random wait time between 5 - 10 secs in pokemongo_bot/cell_workers/sniper.py
## Fixes/Resolves/Closes (please use correct syntax):
Related to issue #5669
