### PR TITLE
Increase sniper's wait time, so as to avoid missing some pokemon

### DIFF
--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -331,6 +331,10 @@ class Sniper(BaseTask):
                 if (seconds_since_last_check < self.MIN_SECONDS_ALLOWED_FOR_CELL_CHECK):
                     time.sleep(self.MIN_SECONDS_ALLOWED_FOR_CELL_CHECK - seconds_since_last_check)
 
+                # Sleep a bit longer for the Pokemon to appear
+                self._log('Waiting for the Pokemon to appear...')
+                time.sleep(randint(5,10))
+
                 nearby_pokemons = []
                 nearby_stuff = self.bot.get_meta_cell()
                 self.last_cell_check_time = time.time()

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -6,6 +6,7 @@ import requests
 import calendar
 
 from random import uniform
+from random import randint
 from operator import itemgetter, methodcaller
 from datetime import datetime
 from pokemongo_bot import inventory


### PR DESCRIPTION
## Short Description:
Currently, if it falls into the if (seconds_since_last_check < self.MIN_SECONDS_ALLOWED_FOR_CELL_CHECK) statement, the wait time is around 1 second and that does not give enough time for the Pokemon to show up. It ended up missing some of the Pokemon.

Added wait time between 5-10 second to allow the Pokemon to show up

## Fixes/Resolves/Closes (please use correct syntax):
Fixes issue #5669
