### PR TITLE
Revert "Avoid task init if task is disabled" (#5591)

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -217,7 +217,6 @@ class PokemonGoBot(object):
         self.event_manager.register_event('buddy_pokemon', parameters=('pokemon', 'iv', 'cp'))
         self.event_manager.register_event('buddy_reward', parameters=('pokemon', 'family', 'candy_earned', 'candy'))
         self.event_manager.register_event('buddy_walked', parameters=('pokemon', 'distance_walked', 'distance_needed'))
-        self.event_manager.register_event('task_disabled', parameters=('task_name',))
 
         #  ignore candy above threshold
         self.event_manager.register_event(

--- a/pokemongo_bot/event_handlers/logging_handler.py
+++ b/pokemongo_bot/event_handlers/logging_handler.py
@@ -81,7 +81,6 @@ class LoggingHandler(EventHandler):
         'softban_log':                       'magenta',
         'spin_limit':                        'red',
         'spun_pokestop':                     'cyan',
-        'task_disabled':                     'yellow',
         'threw_berry_failed':                'red',
         'transfer_log':                      'magenta',
         'unknown_spin_result':               'red',

--- a/pokemongo_bot/tree_config_builder.py
+++ b/pokemongo_bot/tree_config_builder.py
@@ -54,17 +54,6 @@ class TreeConfigBuilder(object):
                                         'See config.json.*example for more information.')
                 continue
 
-            if not task_config.get("enabled", True):
-                msg = "Task {task_name} is disabled"
-                self.bot.event_manager.emit(
-                    'task_disabled',
-                    sender=self,
-                    level='info',
-                    formatted=msg,
-                    data={'task_name': task_type}
-                )
-                continue
-
             if self._is_plugin_task(task_type):
                 worker = self.plugin_loader.get_class(task_type)
             else:

--- a/tests/tree_config_builder_test.py
+++ b/tests/tree_config_builder_test.py
@@ -1,7 +1,6 @@
 import unittest
 import json
 import os
-from mock import MagicMock
 from pokemongo_bot import PokemonGoBot, ConfigException, MismatchTaskApiVersion, TreeConfigBuilder, PluginLoader, BaseTask
 from pokemongo_bot.cell_workers import HandleSoftBan, CatchPokemon
 from pokemongo_bot.test.resources.plugin_fixture import FakeTask, UnsupportedApiTask
@@ -11,9 +10,7 @@ def convert_from_json(str):
 
 class TreeConfigBuilderTest(unittest.TestCase):
     def setUp(self):
-        self.bot = MagicMock()
-        self.bot.event_manager = MagicMock()
-        self.bot.event_manager.emit = lambda *args, **kwargs: None
+        self.bot = {}
 
     def test_should_throw_on_no_type_key(self):
         obj = convert_from_json("""[{


### PR DESCRIPTION
As expected, I just came across with the following situation:

_If the user wants to disable catching nearby pokemons **ONLY** and enables Sniper and/or MoveToMapPokemon, the PokemonCatchWorker will never be initialized._ But what's so bad about this? Well, I need to store the `daily_catch_limit` value (PokemonCatchWorker task's config), since it'll be used from both Sniper/MTMP, but if that task is never initialized, I will never have this value.

This is just **ONE MORE** case that proves why we shouldn't handle such logic in the TreeConfigBuilder/BaseTask, like I said, unless you guys can come up with something better (post below).

These are definitely not viable:

- Load up and parse the whole config file and retrieve only the PokemonCatchWorker portion within both Sniper/MTMP tasks if need be
