### PR TITLE
pokecli.py: wait_time for every exception randomized

### DIFF
--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -84,7 +84,7 @@ Document the configuration options of PokemonGo-Bot.
 | `action_wait_min`   | 1       | Set the minimum time setting for anti-ban time randomizer
 | `action_wait_max`   | 4       | Set the maximum time setting for anti-ban time randomizer
 | `debug`            | false   | Let the default value here except if you are developer                                                                                                                                      |
-| `test`             | false   | Let the default value here except if you are developer                                                                                                                                      |  
+| `test`             | false   | Let the default value here except if you are developer                                                                                                                                      |
 | `walker_limit_output`             | false   | Reduce output from walker functions                                                                                                                                      |                                                                                       |
 | `location_cache`   | true    | Bot will start at last known location if you do not have location set in the config                                                                                                         |
 | `distance_unit`    | km      | Set the unit to display distance in (km for kilometers, mi for miles, ft for feet)                                                                                                          |
@@ -97,6 +97,7 @@ Document the configuration options of PokemonGo-Bot.
 | `live_config_update.enabled`            | false     | Enable live config update
 | `live_config_update.tasks_only`            | false     | True: quick update for Tasks only (without re-login). False: slower update for entire config file.
 | `enable_social`            | true     | True: to chat with other pokemon go bot users [more information](https://github.com/PokemonGoF/PokemonGo-Bot/pull/4596)
+| `reconnecting_timeout`   |  5      | Set the wait time for the bot between tries, time will be randomized by 40%
 
 ## Logging configuration
 [[back to top](#table-of-contents)]
@@ -163,7 +164,7 @@ The behaviors of the bot are configured via the `tasks` key in the `config.json`
 ### Task Options:
 [[back to top](#table-of-contents)]
 * CatchPokemon
-  * `enabled`: Default "true" | Enable/Disable the task. 
+  * `enabled`: Default "true" | Enable/Disable the task.
   * `treat_unseen_as_vip`: Default `"true"` | If true, treat new to dex as VIP
   * `catch_visible_pokemon`:  Default "true" | If enabled, attempts to catch "visible" pokemon that are reachable
   * `catch_lured_pokemon`: Default "true" | If enabled, attempts to catch "lured" pokemon that are reachable
@@ -201,7 +202,7 @@ The behaviors of the bot are configured via the `tasks` key in the `config.json`
   * `log_interval`: `Default: 120`. Time (in seconds) to periodically print how far you are from having enough pokemon to evolve (more than `min_pokemon_to_be_evolved`)
   * `evolve_list`: Default `all` | Set to all, or specifiy different pokemon seperated by a comma
   * `donot_evolve_list`: Default `none` | Pokemon seperated by comma, will be ignored from evolve_list
-  * `min_evolve_speed`: Default `25` | Minimum seconds to wait between each evolution 
+  * `min_evolve_speed`: Default `25` | Minimum seconds to wait between each evolution
   * `max_evolve_speed`: Default `30` | Maximum seconds to wait between each evolution
   * `min_pokemon_to_be_evolved`: Default: `1` | Minimum pokemon to be evolved
   * `use_lucky_egg`: Default: `False` | Only evolve if we can use a lucky egg
@@ -217,8 +218,8 @@ The behaviors of the bot are configured via the `tasks` key in the `config.json`
 * IncubateEggs
   * `enable`: Disable or enable this task.
   * `longer_eggs_first`: Depreciated
-  * `infinite_longer_eggs_first`:  Default `true` | Prioritize longer eggs in perminent incubators. 
-  * `breakable_longer_eggs_first`:  Default `false` | Prioritize longer eggs in breakable incubators. 
+  * `infinite_longer_eggs_first`:  Default `true` | Prioritize longer eggs in perminent incubators.
+  * `breakable_longer_eggs_first`:  Default `false` | Prioritize longer eggs in breakable incubators.
   * `min_interval`: Default `120` | Minimum number of seconds between incubation updates.
   * `infinite`: Default `[2,5,10]` | Types of eggs to be incubated in permanent incubators.
   * `breakable`: Default `[2,5,10]` | Types of eggs to be incubated in breakable incubators.
@@ -273,10 +274,10 @@ The behaviors of the bot are configured via the `tasks` key in the `config.json`
   * `level_limit`: Default `-1` | Bot will stop automatically after trainer reaches level limit. Set to `-1` to disable.
 * All tasks
   * `log_interval`: Default `0` | Minimum seconds interval before next log of the current task will be printed
-  
-  
+
+
 ### Specify a custom log_interval for specific task
-  
+
   ```
     {
       "type": "MoveToFort",
@@ -289,9 +290,9 @@ The behaviors of the bot are configured via the `tasks` key in the `config.json`
       }
     }
    ```
-      
+
    Result:
-    
+
     2016-08-26 11:43:18,199 [MoveToFort] [INFO] [moving_to_fort] Moving towards pokestop ... - 0.07km
     2016-08-26 11:43:23,641 [MoveToFort] [INFO] [moving_to_fort] Moving towards pokestop ... - 0.06km
     2016-08-26 11:43:28,198 [MoveToFort] [INFO] [moving_to_fort] Moving towards pokestop ... - 0.05km
@@ -900,7 +901,7 @@ forts for a limited time.
 * `path_file` - "/path/to/your/path.json"
 
 ### Notice
-If you use the `single` `path_mode` without e.g. a `MoveToFort` task, your bot 
+If you use the `single` `path_mode` without e.g. a `MoveToFort` task, your bot
 with /not move at all/ when the path is finished. Similarly, if you use the
 `wander` option in your json path file without a following `MoveToFort` or
 similar task, your bot will not move during the wandering period. Please

--- a/pokecli.py
+++ b/pokecli.py
@@ -40,6 +40,7 @@ import string
 import subprocess
 
 from logging import Formatter
+from random import randint
 
 codecs.register(lambda name: codecs.lookup("utf-8") if name == "cp65001" else None)
 
@@ -185,7 +186,7 @@ def main():
         finished = False
 
         while not finished:
-            wait_time = config.reconnecting_timeout * 60
+            wait_time = randint(config.reconnecting_timeout, (config.reconnecting_timeout * 60))
             try:
                 bot = initialize(config)
                 bot = start_bot(bot, config)
@@ -241,9 +242,10 @@ def main():
                     'api_error',
                     sender=bot,
                     level='info',
-                    formatted='Server is throttling, reconnecting in 30 seconds'
+                    formatted='Server is throttling, reconnecting in {:d} seconds'.format(wait_time)
                 )
-                time.sleep(30)
+                time.sleep(wait_time)
+#                 sys.exit()
             except PermaBannedException:
                 bot.event_manager.emit(
                     'api_error',

--- a/pokecli.py
+++ b/pokecli.py
@@ -186,7 +186,7 @@ def main():
         finished = False
 
         while not finished:
-            wait_time = randint(config.reconnecting_timeout, (config.reconnecting_timeout * 60))
+            wait_time = randint((config.reconnecting_timeout * 0.8 * 60), (config.reconnecting_timeout *  1.2 * 60))
             try:
                 bot = initialize(config)
                 bot = start_bot(bot, config)
@@ -234,7 +234,7 @@ def main():
                     'api_error',
                     sender=bot,
                     level='info',
-                    formatted='Server busy or offline'
+                    formatted='Server busy or offline, reconnecting in {:d} seconds'.format(wait_time)
                 )
                 time.sleep(wait_time)
             except ServerSideRequestThrottlingException:
@@ -245,7 +245,6 @@ def main():
                     formatted='Server is throttling, reconnecting in {:d} seconds'.format(wait_time)
                 )
                 time.sleep(wait_time)
-#                 sys.exit()
             except PermaBannedException:
                 bot.event_manager.emit(
                     'api_error',
@@ -259,7 +258,7 @@ def main():
                     'api_error',
                     sender=bot,
                     level='info',
-                    formatted='No player position set'
+                    formatted='No player position set, reconnecting in {:d} seconds'.format(wait_time)
                 )
                 time.sleep(wait_time)
 


### PR DESCRIPTION
Feature Request (https://github.com/PokemonGoF/PokemonGo-Bot/issues/5579)

Short Description:
it's create a random waiting time based on config for all exception (connection lost, throttling, and so on), so no static time span will be used anymore
---

randint(min,max)
config.reconnecting -> min
config.reconnection \* 60 -> max
