### PR TITLE
Load CatchPokemon config in PokemonCatchWorker

### DIFF
--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -255,7 +255,7 @@ class MoveToMapPokemon(BaseTask):
         # If target exists, catch it, otherwise ignore
         if exists:
             self._encountered(pokemon)
-            catch_worker = PokemonCatchWorker(pokemon, self.bot, self.config)
+            catch_worker = PokemonCatchWorker(pokemon, self.bot)
             api_encounter_response = catch_worker.create_encounter_api_call()
             time.sleep(self.config.get('snipe_sleep_sec', 2))
             self._teleport_back(last_position)

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -45,11 +45,11 @@ DEBUG_ON = False
 
 class PokemonCatchWorker(BaseTask):
 
-    def __init__(self, pokemon, bot, config=None):
+    def __init__(self, pokemon, bot, config={}):
         self.pokemon = pokemon
 
         # Load CatchPokemon config if no config supplied  
-        if config is None:
+        if not config:
             for value in bot.workers:
                 if hasattr(value, 'catch_pokemon'):
                     config = value.config

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -45,8 +45,17 @@ DEBUG_ON = False
 
 class PokemonCatchWorker(BaseTask):
 
-    def __init__(self, pokemon, bot, config):
+    def __init__(self, pokemon, bot, config=None):
         self.pokemon = pokemon
+
+        # Load CatchPokemon config if no config supplied  
+        if config is None:
+            for value in bot.workers:
+                if hasattr(value, 'catch_pokemon'):
+                    config = value.config
+                    
+        self.config = config
+
         super(PokemonCatchWorker, self).__init__(bot, config)
         if self.config.get('debug', False): DEBUG_ON = True
 
@@ -61,8 +70,6 @@ class PokemonCatchWorker(BaseTask):
         self.response_status_key = ''
         self.rest_completed = False
         self.caught_last_24 = 0
-
-
 
         #Config
         self.min_ultraball_to_keep = self.config.get('min_ultraball_to_keep', 10)

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -550,7 +550,7 @@ class Sniper(BaseTask):
         self._teleport(position_array[0], position_array[1], self.altitude)
 
     def _teleport_back_and_catch(self, position_array, pokemon):
-        catch_worker = PokemonCatchWorker(pokemon, self.bot, self.config)
+        catch_worker = PokemonCatchWorker(pokemon, self.bot)
         api_encounter_response = catch_worker.create_encounter_api_call()
         self._teleport_back(position_array)
         catch_worker.work(api_encounter_response)


### PR DESCRIPTION
## Short Description:

If PokemonCatchWorker is instantiated from Sniper or MoveToMapPokemon, the config passed is not the correct config for PokemonCatchWorker, which results in defaults being set instead of using the config file values.

This PR loads the CatchPokemon config into PokemonCatchWorker if no config is provided.

This solution is probably not great python, but it works. If anyone can see a better way to grab this config from the already-existing list of workers, please advise.

Fixes issues like those seen in #5696 and #5684 

IMPORTANT NOTE: If the CatchPokemon task is disabled (PR #5591 which completely ignores CatchPokemon task config if the task is disabled), default values will be used instead. 

## Fixes/Resolves/Closes (please use correct syntax):
- #5696
- #5684 