### PR TITLE
New walking modes (bicycle, driving and flying) for FollowPath

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -383,6 +383,8 @@
     },
     "walk_max": 4.16,
     "walk_min": 2.16,
+    "fly_max": 222,
+    "fly_min": 202,
     "alt_min": 500,
     "alt_max": 1000,
 

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -79,8 +79,10 @@ Document the configuration options of PokemonGo-Bot.
 | `max_steps`        | 5       | The steps around your initial location (DEFAULT 5 mean 25 cells around your location) that will be explored
 | `forts.avoid_circles`             | False     | Set whether the bot should avoid circles |
 | `forts.max_circle_size`             | 10     | How many forts to keep in ignore list |
-| `walk_max`             | 4.16    | Set the maximum walking speed in m/s (1 is about 3.6km/hr) 4.16m/s = 15km/h
-| `walk_min`             | 2.16    | Set the minimum walking speed in m/s (1 is about 3.6km/hr) 2.16m/s = 7.8km/h
+| `walk_max`             | 4.16    | Set the maximum walking speed in m/s (1 is about 3.6km/h) 4.16m/s = 15km/h
+| `walk_min`             | 2.16    | Set the minimum walking speed in m/s (1 is about 3.6km/h) 2.16m/s = 7.8km/h
+| `fly_max`              |  282    | Set the maximum flying speed in m/s (1 is about 3.6km/h) 282m/s = 1015km/h
+| `fly_min`              |  294    | Set the minimum flying speed in m/s (1 is about 3.6km/h) 294m/s = 1058km/h
 | `action_wait_min`   | 1       | Set the minimum time setting for anti-ban time randomizer
 | `action_wait_max`   | 4       | Set the maximum time setting for anti-ban time randomizer
 | `debug`            | false   | Let the default value here except if you are developer                                                                                                                                      |
@@ -887,6 +889,23 @@ indicated the number of seconds the bot should wander after reaching the point.
 During this time, the next Task in the configuration file is executed, e.g. a
 MoveToFort task. This allows the bot to walk around the waypoint looking for
 forts for a limited time.
+
+For each point in the json file, the optional `mode` field indicates the
+simulated travel model. This is only supported when `walker` is set to
+`PolylineWalker`. When `mode` is set to `driving` or `bicycling`, the
+Google Directions API is used to get the appropriate route.
+
+The supported values for `mode` are:
+* `walking` - walk as usual, using a speed between `walk_min` and `walk_max` 
+  in `config.json`
+* `bicycling` - simulate riding a bicycle. The speed from the Google Directions
+  API is used
+* `driving` - simulate driving a car. The speed from the Google Directions
+  API is used, which depends on the road (e.g. 100 km/h on a highway and 30 km/h 
+  in a suburban area).
+* `flying` - simulate taking an aeroplane. Flies are typical airline cruising
+  speed, configurable with `fly_min` and `fly_max`. During the simulated flight
+  no other actions are taken by the bot.
 
 ### Options
 [[back to top](#table-of-contents)]

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -81,8 +81,8 @@ Document the configuration options of PokemonGo-Bot.
 | `forts.max_circle_size`             | 10     | How many forts to keep in ignore list |
 | `walk_max`             | 4.16    | Set the maximum walking speed in m/s (1 is about 3.6km/h) 4.16m/s = 15km/h
 | `walk_min`             | 2.16    | Set the minimum walking speed in m/s (1 is about 3.6km/h) 2.16m/s = 7.8km/h
-| `fly_max`              |  282    | Set the maximum flying speed in m/s (1 is about 3.6km/h) 282m/s = 1015km/h
-| `fly_min`              |  294    | Set the minimum flying speed in m/s (1 is about 3.6km/h) 294m/s = 1058km/h
+| `fly_max`              |  222    | Set the maximum flying speed in m/s (1 is about 3.6km/h) 222m/s = 800km/h
+| `fly_min`              |  202    | Set the minimum flying speed in m/s (1 is about 3.6km/h) 202m/s = 727km/h
 | `action_wait_min`   | 1       | Set the minimum time setting for anti-ban time randomizer
 | `action_wait_max`   | 4       | Set the maximum time setting for anti-ban time randomizer
 | `debug`            | false   | Let the default value here except if you are developer                                                                                                                                      |

--- a/pokecli.py
+++ b/pokecli.py
@@ -727,6 +727,8 @@ def init_config():
     config.live_config_update_enabled = config.live_config_update.get('enabled', False)
     config.live_config_update_tasks_only = config.live_config_update.get('tasks_only', False)
     config.logging = load.get('logging', {})
+    config.fly_min = load.get('fly_min', 282)
+    config.fly_max = load.get('fly_max', 294)
 
     if config.map_object_cache_time < 0.0:
         parser.error("--map_object_cache_time is out of range! (should be >= 0.0)")

--- a/pokemongo_bot/cell_workers/buddy_pokemon.py
+++ b/pokemongo_bot/cell_workers/buddy_pokemon.py
@@ -58,6 +58,8 @@ class BuddyPokemon(BaseTask):
 
     def initialize(self):
         self.buddy = self.bot.player_data.get('buddy_pokemon', {})
+        if 'last_km_awarded' not in self.buddy:
+            self.buddy['last_km_awarded'] = 0
         self.buddy_list = self.config.get('buddy_list', [])
         self.best_in_family = self.config.get('best_in_family', True)
         self.candy_limit = self.config.get('candy_limit', 0)  # 0 = No Limit

--- a/pokemongo_bot/cell_workers/follow_path.py
+++ b/pokemongo_bot/cell_workers/follow_path.py
@@ -81,8 +81,7 @@ class FollowPath(BaseTask):
             point["lat"] = float(point_tuple[0])
             point["lng"] = float(point_tuple[1])
             point["alt"] = float(point_tuple[2])
-            if "mode" not in point:
-                point["mode"] = "walking"
+            point["mode"] = mode.get("mode", "walking")
         return points
 
     def load_gpx(self):
@@ -160,9 +159,7 @@ class FollowPath(BaseTask):
             alt = uniform(self.bot.config.alt_min, self.bot.config.alt_max)
 
         if self.bot.config.walk_max > 0:
-            mode = "walking"
-            if "mode" in point:
-                mode = point["mode"]
+            mode = point.get("mode", "walking")
             step_walker = walker_factory(self.walker,
                 self.bot,
                 lat,

--- a/pokemongo_bot/cell_workers/follow_path.py
+++ b/pokemongo_bot/cell_workers/follow_path.py
@@ -77,10 +77,12 @@ class FollowPath(BaseTask):
                     'position': point_tuple
                 }
             )
-            # Keep point['location']
+            # Keep point['location'] and other keys
             point["lat"] = float(point_tuple[0])
             point["lng"] = float(point_tuple[1])
             point["alt"] = float(point_tuple[2])
+            if "mode" not in point:
+                point["mode"] = "walking"
         return points
 
     def load_gpx(self):
@@ -158,11 +160,15 @@ class FollowPath(BaseTask):
             alt = uniform(self.bot.config.alt_min, self.bot.config.alt_max)
 
         if self.bot.config.walk_max > 0:
+            mode = "walking"
+            if "mode" in point:
+                mode = point["mode"]
             step_walker = walker_factory(self.walker,
                 self.bot,
                 lat,
                 lng,
-                alt
+                alt,
+                mode=mode
             )
 
             is_at_destination = False
@@ -181,10 +187,10 @@ class FollowPath(BaseTask):
 
         self.emit_event(
             'position_update',
-            formatted="Walking from {last_position} to {current_position}, distance left: ({distance} {distance_unit}) ..",
+            formatted="Moving from {last_position} to {current_position}, distance left: ({distance} {distance_unit}) ..",
             data={
                 'last_position': (last_lat, last_lng, last_alt),
-                'current_position': (lat, lng, alt),
+                'current_position': "{} ({})".format(point["location"], point["mode"]),
                 'distance': format_dist(dist,self.distance_unit,self.append_unit),
                 'distance_unit': self.distance_unit
             }

--- a/pokemongo_bot/event_handlers/social_handler.py
+++ b/pokemongo_bot/event_handlers/social_handler.py
@@ -83,7 +83,11 @@ class MyMQTTClass:
             return
 
     def run(self):
-        self._mqttc.connect("broker.pikabot.org", 1883, 20)
+        try:
+            self._mqttc.connect("broker.pikabot.org", 1883, 20)
+        except Exception as e:
+            print(e)
+            return
         while True:
             try:
                 self._mqttc.loop_forever(timeout=30.0, max_packets=100, retry_first_connection=False)

--- a/pokemongo_bot/walkers/polyline_walker.py
+++ b/pokemongo_bot/walkers/polyline_walker.py
@@ -15,14 +15,7 @@ class PolylineWalker(StepWalker):
         remaining = Geodesic.WGS84.Inverse(origin_lat, origin_lng, self.dest_lat, self.dest_lng)["s12"]
         time_to_sleep = remaining / speed
         sleep(time_to_sleep)
-        self.bot.api.set_position(self.dest_lat, self.dest_lng, self.dest_alt)
-        self.bot.event_manager.emit("position_update",
-                                    sender=self,
-                                    level="debug",
-                                    data={"current_position": (self.dest_lat, self.dest_lng, self.dest_alt),
-                                          "last_position": (origin_lat, origin_lng, origin_alt),
-                                          "distance": remaining,
-                                          "distance_unit": "m"})
+        super(PolylineWalker, self).step(float("inf"))
 
     def step(self, speed=None):
         if speed is None:

--- a/pokemongo_bot/walkers/step_walker.py
+++ b/pokemongo_bot/walkers/step_walker.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 import time
 
 from geographiclib.geodesic import Geodesic
@@ -8,10 +9,12 @@ from pokemongo_bot.human_behaviour import sleep, random_alt_delta
 
 
 class StepWalker(object):
-    def __init__(self, bot, dest_lat, dest_lng, dest_alt=None, precision=0.5):
+    def __init__(self, bot, dest_lat, dest_lng, dest_alt=None, precision=0.5, mode="walking"):
         self.bot = bot
         self.epsilon = 0.01
         self.precision = max(precision, self.epsilon)
+        self.logger = logging.getLogger(type(self).__name__)
+        self.mode = mode
 
         self.dest_lat = dest_lat
         self.dest_lng = dest_lng

--- a/pokemongo_bot/walkers/walker_factory.py
+++ b/pokemongo_bot/walkers/walker_factory.py
@@ -8,8 +8,5 @@ def walker_factory(name, bot, dest_lat, dest_lng, dest_alt=None, *args, **kwargs
     if 'StepWalker' == name:
         ret = StepWalker(bot, dest_lat, dest_lng, dest_alt)
     elif 'PolylineWalker' == name:
-        mode = "walking"
-        if "mode" in kwargs:
-            mode = kwargs["mode"]
-        ret = PolylineWalker(bot, dest_lat, dest_lng, mode=mode)
+        ret = PolylineWalker(bot, dest_lat, dest_lng, mode=kwargs.get("mode", "walking"))
     return ret

--- a/pokemongo_bot/walkers/walker_factory.py
+++ b/pokemongo_bot/walkers/walker_factory.py
@@ -8,5 +8,8 @@ def walker_factory(name, bot, dest_lat, dest_lng, dest_alt=None, *args, **kwargs
     if 'StepWalker' == name:
         ret = StepWalker(bot, dest_lat, dest_lng, dest_alt)
     elif 'PolylineWalker' == name:
-        ret = PolylineWalker(bot, dest_lat, dest_lng)
+        mode = "walking"
+        if "mode" in kwargs:
+            mode = kwargs["mode"]
+        ret = PolylineWalker(bot, dest_lat, dest_lng, mode=mode)
     return ret


### PR DESCRIPTION
## Short Description:

For the `FollowPath` task with `walker` set to `PolylineWalker`, allow `mode` fields in the points in the `path.json`. Simulates `walking`, `bicycling`, `driving` or `flying`.
## Fixes/Resolves/Closes (please use correct syntax):

Fixes: #5620 
