### PR TITLE
Change websocket URL in example configs

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -324,6 +324,6 @@
     },
 	"websocket": {
 		"start_embedded_server": true,
-		"server_url": "0.0.0.0:4000"
+		"server_url": "127.0.0.1:4000"
 	}
 }

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -482,6 +482,6 @@
     },
 	"websocket": {
 		"start_embedded_server": true,
-		"server_url": "0.0.0.0:4000"
+		"server_url": "127.0.0.1:4000"
 	}
 }

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -669,6 +669,6 @@
     },
 	"websocket": {
 		"start_embedded_server": true,
-		"server_url": "0.0.0.0:4000"
+		"server_url": "127.0.0.1:4000"
 	}
 }

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -307,6 +307,6 @@
     },
 	"websocket": {
 		"start_embedded_server": true,
-		"server_url": "0.0.0.0:4000"
+		"server_url": "127.0.0.1:4000"
 	}
 }

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -556,6 +556,6 @@
     },
 	"websocket": {
 		"start_embedded_server": true,
-		"server_url": "0.0.0.0:4000"
+		"server_url": "127.0.0.1:4000"
 	}
 }


### PR DESCRIPTION
## Short Description:

Current example configs have "server_url": "0.0.0.0:4000" in websocket config. This causes bot to halt at startup as 0.0.0.0 is not a valid IP address. Changed to 127.0.0.1.

## Fixes/Resolves/Closes (please use correct syntax):
- #5745 
- #5737
