### PR TITLE
Do not try to transfer buddy

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_optimizer.py
+++ b/pokemongo_bot/cell_workers/pokemon_optimizer.py
@@ -34,6 +34,7 @@ class PokemonOptimizer(BaseTask):
         self.evolution_map = {}
         self.ongoing_stardust_count = 0
         self.buddy = None
+        self.buddyid = 0
         self.lock_buddy = True
         self.no_log_until = 0
 
@@ -241,6 +242,7 @@ class PokemonOptimizer(BaseTask):
 
     def check_buddy(self):
         self.buddy = self.bot.player_data.get("buddy_pokemon", {})
+        self.buddyid = self._get_buddyid()
 
         if not self.buddy:
             self.lock_buddy = False
@@ -523,7 +525,7 @@ class PokemonOptimizer(BaseTask):
         # All the rest is crap, for now
         crap = list(family_list)
         crap = [p for p in crap if p not in keep]
-        crap = [p for p in crap if not p.in_fort and not p.is_favorite and not (p.unique_id == self.buddy['id'])]
+        crap = [p for p in crap if not p.in_fort and not p.is_favorite and not (p.unique_id == self.buddyid)]
         crap.sort(key=lambda p: (p.iv, p.cp), reverse=True)
 
         # We will gain a candy whether we choose to transfer or evolve these Pokemon
@@ -858,6 +860,7 @@ class PokemonOptimizer(BaseTask):
 
         if not self.bot.config.test:
             self.buddy = response_dict.get("responses", {}).get("SET_BUDDY_POKEMON", {}).get("updated_buddy", {})
+            self.buddyid = self._get_buddyid()
 
         self.emit_event("buddy_pokemon",
                         formatted="Buddy {pokemon} [IV {iv}] [CP {cp}]",
@@ -908,3 +911,8 @@ class PokemonOptimizer(BaseTask):
             action_delay(self.config_action_wait_min, self.config_action_wait_max)
 
         return True
+        
+    def _get_buddyid(self):
+        if self.buddy and'id' in self.buddy:
+            return self.buddy['id']
+        return 0

--- a/pokemongo_bot/cell_workers/pokemon_optimizer.py
+++ b/pokemongo_bot/cell_workers/pokemon_optimizer.py
@@ -523,7 +523,7 @@ class PokemonOptimizer(BaseTask):
         # All the rest is crap, for now
         crap = list(family_list)
         crap = [p for p in crap if p not in keep]
-        crap = [p for p in crap if not p.in_fort and not p.is_favorite]
+        crap = [p for p in crap if not p.in_fort and not p.is_favorite and not (p.unique_id == self.buddy['id'])]
         crap.sort(key=lambda p: (p.iv, p.cp), reverse=True)
 
         # We will gain a candy whether we choose to transfer or evolve these Pokemon

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -19,6 +19,7 @@ class TransferPokemon(BaseTask):
         self.min_free_slot = self.config.get('min_free_slot', 5)
         self.transfer_wait_min = self.config.get('transfer_wait_min', 1)
         self.transfer_wait_max = self.config.get('transfer_wait_max', 4)
+        self.buddy = self.bot.player_data.get('buddy_pokemon', {})
 
     def work(self):
         if not self._should_work():
@@ -31,17 +32,18 @@ class TransferPokemon(BaseTask):
 
         if self.bot.config.release.get('all'):
             group = [p for p in inventory.pokemons().all()
-                     if p.in_fort is False and p.is_favorite is False]
+                     if not p.in_fort and not p.is_favorite and not (p.unique_id == self.buddy['id'])]
             self._release_pokemon_worst_in_group(group, 'all')
 
     def _should_work(self):
+        return True
         random_number = randrange (0,20,1) 
         return inventory.Pokemons.get_space_left() <= max(1,self.min_free_slot - random_number)
 
     def _release_pokemon_get_groups(self):
         pokemon_groups = {}
         for pokemon in inventory.pokemons().all():
-            if pokemon.in_fort or pokemon.is_favorite:
+            if pokemon.in_fort or pokemon.is_favorite or pokemon.unique_id == self.buddy['id']:
                 continue
 
             group_id = pokemon.pokemon_id

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -36,7 +36,6 @@ class TransferPokemon(BaseTask):
             self._release_pokemon_worst_in_group(group, 'all')
 
     def _should_work(self):
-        return True
         random_number = randrange (0,20,1) 
         return inventory.Pokemons.get_space_left() <= max(1,self.min_free_slot - random_number)
 

--- a/pokemongo_bot/cell_workers/transfer_pokemon.py
+++ b/pokemongo_bot/cell_workers/transfer_pokemon.py
@@ -20,6 +20,7 @@ class TransferPokemon(BaseTask):
         self.transfer_wait_min = self.config.get('transfer_wait_min', 1)
         self.transfer_wait_max = self.config.get('transfer_wait_max', 4)
         self.buddy = self.bot.player_data.get('buddy_pokemon', {})
+        self.buddyid = self._get_buddyid()
 
     def work(self):
         if not self._should_work():
@@ -32,7 +33,7 @@ class TransferPokemon(BaseTask):
 
         if self.bot.config.release.get('all'):
             group = [p for p in inventory.pokemons().all()
-                     if not p.in_fort and not p.is_favorite and not (p.unique_id == self.buddy['id'])]
+                     if not p.in_fort and not p.is_favorite and not (p.unique_id == self.buddyid)]
             self._release_pokemon_worst_in_group(group, 'all')
 
     def _should_work(self):
@@ -42,7 +43,7 @@ class TransferPokemon(BaseTask):
     def _release_pokemon_get_groups(self):
         pokemon_groups = {}
         for pokemon in inventory.pokemons().all():
-            if pokemon.in_fort or pokemon.is_favorite or pokemon.unique_id == self.buddy['id']:
+            if pokemon.in_fort or pokemon.is_favorite or pokemon.unique_id == self.buddyid:
                 continue
 
             group_id = pokemon.pokemon_id
@@ -340,3 +341,8 @@ class TransferPokemon(BaseTask):
                 keep_best = False
                 
         return keep_best, keep_best_cp, keep_best_iv, keep_best_ivcp
+        
+    def _get_buddyid(self):
+        if self.buddy and'id' in self.buddy:
+            return self.buddy['id']
+        return 0


### PR DESCRIPTION
## Short Description:

Transfer attempt of buddy pokemon currently fails and results in endless transfer loop. Added check to both TransferPokemon and PokemonOptimizer to skip trying to transfer buddy pokemon.

## Fixes/Resolves/Closes (please use correct syntax):
- #5723 
