### PR TITLE
Added absolute candy limit

### DIFF
--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -46,6 +46,7 @@
           "best_in_family": true,
           "// candy_limit = 0 means no limit, so it will never change current buddy": {},
           "candy_limit": 0,
+          "candy_limit_absolute":0,
           "// force_first_change = true will always change buddy at start removing current one": {},
           "force_first_change": false,
           "buddy_change_wait_min": 3,

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -83,6 +83,7 @@
           "best_in_family": true,
           "// candy_limit = 0 means no limit, so it will never change current buddy": {},
           "candy_limit": 0,
+          "candy_limit_absolute":0,
           "// force_first_change = true will always change buddy at start removing current one": {},
           "force_first_change": false,
           "buddy_change_wait_min": 3,

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -46,6 +46,7 @@
           "best_in_family": true,
           "// candy_limit = 0 means no limit, so it will never change current buddy": {},
           "candy_limit": 0,
+          "candy_limit_absolute":0,
           "// force_first_change = true will always change buddy at start removing current one": {},
           "force_first_change": false,
           "buddy_change_wait_min": 3,

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -46,6 +46,7 @@
           "best_in_family": true,
           "// candy_limit = 0 means no limit, so it will never change current buddy": {},
           "candy_limit": 0,
+          "candy_limit_absolute":0,
           "// force_first_change = true will always change buddy at start removing current one": {},
           "force_first_change": false,
           "buddy_change_wait_min": 3,

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -46,6 +46,7 @@
           "best_in_family": true,
           "// candy_limit = 0 means no limit, so it will never change current buddy": {},
           "candy_limit": 0,
+          "candy_limit_absolute":0,
           "// force_first_change = true will always change buddy at start removing current one": {},
           "force_first_change": false,
           "buddy_change_wait_min": 3,

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -1298,6 +1298,7 @@ After setting a buddy it's not possible to remove it, only change it. So if a bu
 * `buddy_list`: `Default: []`. List of pokemon names that will be used as buddy. If '[]' or 'none', will not use or change buddy.
 * `best_in_family`: `Default: True`. If True, picks best Pokemon in the family (sorted by cp).
 * `candy_limit`: `Default: 0`. Set the candy limit to be rewarded per buddy, when reaching this limit the bot will change the buddy to the next in the list. When candy_limit = 0 or only one buddy in list, it has no limit and never changes buddy.
+* `candy_limit_absolute`: `Default: 0`. Set the absolute candy limit to be rewarded per buddy, when reaching this limit the bot will change the buddy to the next in the list. When candy_limit_absolute = 0 or only one buddy in list, it has no limit and never changes buddy. Use this to stop collecting candy when a candy threshold for your buddy's pokemon family is reached (e.g. 50 for evolving).
 * `force_first_change`: `Default: False`. If True, will try to change buddy at bot start according to the buddy list. If False, will use the buddy already set until candy_limit is reached and then use the buddy list.
 * `buddy_change_wait_min`: `Default: 3`. Minimum time (in seconds) that the buddy change takes.
 * `buddy_change_wait_max`: `Default: 5`. Maximum time (in seconds) that the buddy change takes.
@@ -1314,6 +1315,7 @@ After setting a buddy it's not possible to remove it, only change it. So if a bu
         "best_in_family": true,
         "// candy_limit = 0 means no limit, so it will never change current buddy": {},
         "candy_limit": 0,
+        "candy_limit_absolute": 0,
         "// force_first_change = true will always change buddy at start removing current one": {},
         "force_first_change": false,
         "buddy_change_wait_min": 3,

--- a/pokemongo_bot/cell_workers/buddy_pokemon.py
+++ b/pokemongo_bot/cell_workers/buddy_pokemon.py
@@ -106,13 +106,13 @@ class BuddyPokemon(BaseTask):
 
         if self.buddy_list:
             pokemon = self._get_pokemon_by_name(self._get_pokemon_by_id(self.buddy['id']).name)
-            if self.force_first_change or not self.buddy or pokemon is None or (self.candy_limit != 0 and self.candy_awarded >= self.candy_limit) or (self.candy_limit_absolute != 0 and inventory.candies().get(pokemon.family_id).quantity >= self.candy_limit_absolute):
+            if self.force_first_change or not self.buddy or pokemon is None or (self.candy_limit != 0 and self.candy_awarded >= self.candy_limit) or self._check_candy_limit_absolute(pokemon):
                 self.force_first_change = False
 
                 remaining = []
                 for name in self.buddy_list:
                     pokemon = self._get_pokemon_by_name(name)
-                    if name not in self.cache and pokemon is not None and (self.candy_limit_absolute == 0 or inventory.candies().get(pokemon.family_id).quantity < self.candy_limit_absolute):
+                    if name not in self.cache and pokemon is not None and not self._check_candy_limit_absolute(pokemon):
                         remaining.append(name)
 
                 if not remaining:
@@ -216,6 +216,9 @@ class BuddyPokemon(BaseTask):
                 formatted='Error trying to get candy from buddy.'
             )
             return False
+
+    def _check_candy_limit_absolute(self, pokemon):
+        return self.candy_limit_absolute != 0 and inventory.candies().get(pokemon.family_id).quantity >= self.candy_limit_absolute
 
     def _check_old_reward(self):
         if not self.buddy:

--- a/pokemongo_bot/cell_workers/buddy_pokemon.py
+++ b/pokemongo_bot/cell_workers/buddy_pokemon.py
@@ -106,22 +106,13 @@ class BuddyPokemon(BaseTask):
 
         if self.buddy_list:
             pokemon = self._get_pokemon_by_name(self._get_pokemon_by_id(self.buddy['id']).name)
-            if pokemon is None:
-                self.force_first_change = True
-            else:
-                candies_absolute = inventory.candies().get(pokemon.family_id).quantity
-                
-            if self.force_first_change or not self.buddy or (self.candy_limit != 0 and self.candy_awarded >= self.candy_limit) or (self.candy_limit_absolute != 0 and candies_absolute >= self.candy_limit_absolute):
+            if self.force_first_change or not self.buddy or pokemon is None or (self.candy_limit != 0 and self.candy_awarded >= self.candy_limit) or (self.candy_limit_absolute != 0 and inventory.candies().get(pokemon.family_id).quantity >= self.candy_limit_absolute):
                 self.force_first_change = False
 
                 remaining = []
                 for name in self.buddy_list:
                     pokemon = self._get_pokemon_by_name(name)
-                    if pokemon is None:
-                        continue
-                    elif self.candy_limit_absolute != 0 and inventory.candies().get(pokemon.family_id).quantity >= self.candy_limit_absolute:
-                        continue
-                    if name not in self.cache:
+                    if name not in self.cache and pokemon is not None and (self.candy_limit_absolute == 0 or inventory.candies().get(pokemon.family_id).quantity < self.candy_limit_absolute):
                         remaining.append(name)
 
                 if not remaining:

--- a/pokemongo_bot/cell_workers/buddy_pokemon.py
+++ b/pokemongo_bot/cell_workers/buddy_pokemon.py
@@ -255,7 +255,7 @@ class BuddyPokemon(BaseTask):
                 }
             )
             return None
-        
+
         fam_id = pokemon.family_id
         poke_id = pokemon.pokemon_id
         if self.best_in_family:

--- a/pokemongo_bot/cell_workers/buddy_pokemon.py
+++ b/pokemongo_bot/cell_workers/buddy_pokemon.py
@@ -25,6 +25,7 @@ class BuddyPokemon(BaseTask):
             "best_in_family": true,
             "// candy_limit = 0 means no limit, so it will never change current buddy": {},
             "candy_limit": 0,
+            "candy_limit_absolute": 0,
             "// force_first_change = true will always change buddy at start removing current one": {},
             "force_first_change": false,
             "buddy_change_wait_min": 3,
@@ -42,6 +43,16 @@ class BuddyPokemon(BaseTask):
                              to the next in the list. When candy_limit = 0 or
                              only one buddy in list, it has no limit and never
                              changes buddy.
+    candy_limit_absolute: Default: 0. Set the absolute candy limit to be
+                                      rewarded per buddy, when reaching this
+                                      limit the bot will change the buddy to the
+                                      next in the list. When
+                                      candy_limit_absolute = 0 or only one buddy
+                                      in list, it has no limit and never changes
+                                      buddy. Use this to stop collecting candy
+                                      when a candy threshold for your buddy's
+                                      pokemon family is reached (e.g. 50 for
+                                      evolving).
     force_first_change: Default: False. If True, will try to change buddy at
                         bot start according to the buddy list. If False, will
                         use the buddy already set until candy_limit is reached
@@ -61,6 +72,7 @@ class BuddyPokemon(BaseTask):
         self.buddy_list = self.config.get('buddy_list', [])
         self.best_in_family = self.config.get('best_in_family', True)
         self.candy_limit = self.config.get('candy_limit', 0)  # 0 = No Limit
+        self.candy_limit_absolute = self.config.get('candy_limit_absolute', 0)  # 0 = No Limit
         self.force_first_change = self.config.get('force_first_change', False)
         self.buddy_change_wait_min = self.config.get('buddy_change_wait_min', 3)
         self.buddy_change_wait_max = self.config.get('buddy_change_wait_max', 5)
@@ -93,10 +105,25 @@ class BuddyPokemon(BaseTask):
             return WorkerResult.SUCCESS
 
         if self.buddy_list:
-            if self.force_first_change or not self.buddy or self.candy_limit != 0 and self.candy_awarded >= self.candy_limit:
+            pokemon = self._get_pokemon_by_name(self._get_pokemon_by_id(self.buddy['id']).name)
+            if pokemon is None:
+                self.force_first_change = True
+            else:
+                candies_absolute = inventory.candies().get(pokemon.family_id).quantity
+                
+            if self.force_first_change or not self.buddy or (self.candy_limit != 0 and self.candy_awarded >= self.candy_limit) or (self.candy_limit_absolute != 0 and candies_absolute >= self.candy_limit_absolute):
                 self.force_first_change = False
 
-                remaining = [name for name in self.buddy_list if name not in self.cache]
+                remaining = []
+                for name in self.buddy_list:
+                    pokemon = self._get_pokemon_by_name(name)
+                    if pokemon is None:
+                        continue
+                    elif self.candy_limit_absolute != 0 and inventory.candies().get(pokemon.family_id).quantity >= self.candy_limit_absolute:
+                        continue
+                    if name not in self.cache:
+                        remaining.append(name)
+
                 if not remaining:
                     self.cache = []
                     return WorkerResult.SUCCESS
@@ -215,7 +242,7 @@ class BuddyPokemon(BaseTask):
         pokemons = inventory.pokemons().all()
         pokemon = None
         for p in pokemons:
-            if p.name.lower() == name:
+            if p.name.lower() == name.lower():
                 pokemon = p
                 break
 
@@ -228,7 +255,7 @@ class BuddyPokemon(BaseTask):
                 }
             )
             return None
-
+        
         fam_id = pokemon.family_id
         poke_id = pokemon.pokemon_id
         if self.best_in_family:


### PR DESCRIPTION
In addition to `candy_limit` I've added a new config parameter `candy_limit_absolute`. It should be used to stop collecting candy with your current buddy when a candy threshold for your buddy's pokemon family is reached (e.g. 50 for evolving).
It also should fix a potential crash when your current buddy gets evolved and no other pokemon of the same type is available.