### PR TITLE
API Validation - Killswitch on API Change

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -2,6 +2,7 @@
     "websocket_server": false,
     "heartbeat_threshold": 10,
     "enable_social": false,
+    "check_niantic_api": true,
     "live_config_update": {
       "enabled": false,
       "tasks_only": false

--- a/pokecli.py
+++ b/pokecli.py
@@ -38,6 +38,7 @@ import time
 import signal
 import string
 import subprocess
+import urllib
 
 from logging import Formatter
 from random import randint
@@ -76,6 +77,41 @@ except pkg_resources.DistributionNotFound:
 except ImportError as e:
     print e
     pass
+
+def query_yes_no(question, default="no"):
+    valid = {"yes":"yes",   "y":"yes",  "ye":"yes",
+             "no":"no",     "n":"no"}
+    if default == None:
+        prompt = " [y/n] "
+    elif default == "yes":
+        prompt = " [Y/n] "
+    elif default == "no":
+        prompt = " [y/N] "
+    else:
+        raise ValueError("invalid default answer: '%s'" % default)
+
+    while 1:
+        sys.stdout.write(question + prompt)
+        choice = raw_input().lower()
+        if default is not None and choice == '':
+            return default
+        elif choice in valid.keys():
+            return valid[choice]
+        else:
+            sys.stdout.write("Please respond with 'yes' or 'no' "\
+                             "(or 'y' or 'n').\n")
+capi = '0.43.0'
+link = "https://pgorelease.nianticlabs.com/plfe/version"
+print capi
+f = urllib.urlopen(link)
+myfile = f.read()
+print myfile
+if capi not in myfile:
+    print "Not safe to bot. Official API version is not equal to current version"
+    response = query_yes_no("Do you want to continue?")
+    if response == "no":
+        print "Exiting..."
+        sys.exit(1)
 
 logging.basicConfig(
     level=logging.INFO,

--- a/pokecli.py
+++ b/pokecli.py
@@ -100,7 +100,7 @@ def query_yes_no(question, default="no"):
         else:
             sys.stdout.write("Please respond with 'yes' or 'no' "\
                              "(or 'y' or 'n').\n")
-capi = '0.43.0'
+capi = '0.45.0'
 link = "https://pgorelease.nianticlabs.com/plfe/version"
 print capi
 f = urllib.urlopen(link)

--- a/pokecli.py
+++ b/pokecli.py
@@ -38,7 +38,6 @@ import time
 import signal
 import string
 import subprocess
-import urllib
 
 from logging import Formatter
 from random import randint
@@ -78,40 +77,6 @@ except ImportError as e:
     print e
     pass
 
-def query_yes_no(question, default="no"):
-    valid = {"yes":"yes",   "y":"yes",  "ye":"yes",
-             "no":"no",     "n":"no"}
-    if default == None:
-        prompt = " [y/n] "
-    elif default == "yes":
-        prompt = " [Y/n] "
-    elif default == "no":
-        prompt = " [y/N] "
-    else:
-        raise ValueError("invalid default answer: '%s'" % default)
-
-    while 1:
-        sys.stdout.write(question + prompt)
-        choice = raw_input().lower()
-        if default is not None and choice == '':
-            return default
-        elif choice in valid.keys():
-            return valid[choice]
-        else:
-            sys.stdout.write("Please respond with 'yes' or 'no' "\
-                             "(or 'y' or 'n').\n")
-capi = '0.45.0'
-link = "https://pgorelease.nianticlabs.com/plfe/version"
-print capi
-f = urllib.urlopen(link)
-myfile = f.read()
-print myfile
-if capi not in myfile:
-    print "Not safe to bot. Official API version is not equal to current version"
-    response = query_yes_no("Do you want to continue?")
-    if response == "no":
-        print "Exiting..."
-        sys.exit(1)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -440,6 +405,15 @@ def init_config():
         long_flag="--username",
         help="Username",
         default=None
+    )
+    add_config(
+        parser,
+        load,
+        short_flag="-capi",
+        long_flag="--check_niantic_api",
+        help="Enable killswitch on API Change",
+        type=bool,
+        default=True
     )
     add_config(
         parser,

--- a/pokemongo_bot/api_wrapper.py
+++ b/pokemongo_bot/api_wrapper.py
@@ -4,6 +4,8 @@ import logging
 import random, base64, struct
 import hashlib
 import os
+import urllib
+import sys
 from pgoapi.exceptions import (ServerSideRequestThrottlingException,
                                NotLoggedInException, ServerBusyOrOfflineException,
                                NoPlayerPositionSetException, EmptySubrequestChainException,
@@ -90,6 +92,17 @@ class ApiWrapper(PGoApi, object):
     def login(self, provider, username, password):
         # login needs base class "create_request"
         self.useVanillaRequest = True
+        if self.config.check_niantic_api is True:
+            capi = '0.45.0'
+            link = "https://pgorelease.nianticlabs.com/plfe/version"
+            f = urllib.urlopen(link)
+            myfile = f.read()
+            self.config.check_niantic_api
+            print "Niantic Official API Version:" + myfile
+            if capi not in myfile:
+                print("\033[1;31;40m We have detected a Pokemon API Change. The current API version 0.45.0 is no longer supported. Exiting...")
+                sys.exit(1)
+        
         try:
             PGoApi.set_authentication(
                     self,


### PR DESCRIPTION
## Short Description:
Check if Niantic API is equal to current API. If not, warn and prompt user .
## Fixes/Resolves/Closes (please use correct syntax):
- Running old bot when Niantic force updates version on client

Validate if Official API has changed