### PR TITLE
issue #5845

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ enum34==1.1.6
 pyyaml==3.11
 haversine==0.4.5
 polyline==1.3.1
+websocket-client==0.37.0
 python-socketio==1.4.2
 flask==0.11.1
 socketIO_client==0.7.0


### PR DESCRIPTION
## Short Description:
User receives the following error on new installs, while wbesocket-client is already at latest version.
'An incompatible websocket library is conflicting with the one we need.
You can remove the incompatible library and install the correct one
by running the following commands:

yes | pip uninstall websocket websocket-client
pip install -U websocket-client'

## Fixes/Resolves/Closes (please use correct syntax):
The error is from socketIO_client which require websocket-client to be 0.37.0




