### PR TITLE
0.51, hashing service and gen2 pokemons support

### DIFF
--- a/configs/auth.json.example
+++ b/configs/auth.json.example
@@ -10,6 +10,7 @@
         }
     ],
     "gmapkey": "GOOGLE_MAPS_API_KEY",
+    "hashkey" : "YOUR_PURCHASED_HASH_KEY",
     "encrypt_location": "",
     "telegram_token": "",
     "discord_token": ""

--- a/data/fast_moves.json
+++ b/data/fast_moves.json
@@ -15,7 +15,7 @@
         "damage": 8,
         "duration": 630,
         "energy": 7,
-        "dps": 12.69
+        "dps": 12.7
     },
     {
         "id": 226,
@@ -77,7 +77,7 @@
         "type": "Fire",
         "damage": 10,
         "duration": 840,
-        "energy": 4,
+        "energy": 8,
         "dps": 11.9
     },
     {
@@ -86,8 +86,8 @@
         "type": "Ghost",
         "damage": 11,
         "duration": 950,
-        "energy": 7,
-        "dps": 11.57
+        "energy": 8,
+        "dps": 11.58
     },
     {
         "id": 238,
@@ -95,8 +95,8 @@
         "type": "Dark",
         "damage": 12,
         "duration": 1040,
-        "energy": 7,
-        "dps": 11.53
+        "energy": 10,
+        "dps": 11.54
     },
     {
         "id": 224,
@@ -104,8 +104,8 @@
         "type": "Poison",
         "damage": 12,
         "duration": 1050,
-        "energy": 7,
-        "dps": 11.42
+        "energy": 10,
+        "dps": 11.43
     },
     {
         "id": 234,
@@ -113,8 +113,8 @@
         "type": "Psychic",
         "damage": 12,
         "duration": 1050,
-        "energy": 4,
-        "dps": 11.42
+        "energy": 9,
+        "dps": 11.43
     },
     {
         "id": 239,
@@ -122,8 +122,8 @@
         "type": "Steel",
         "damage": 15,
         "duration": 1330,
-        "energy": 4,
-        "dps": 11.27
+        "energy": 12,
+        "dps": 11.28
     },
     {
         "id": 201,
@@ -149,7 +149,7 @@
         "type": "Ground",
         "damage": 15,
         "duration": 1350,
-        "energy": 9,
+        "energy": 12,
         "dps": 11.11
     },
     {
@@ -159,7 +159,7 @@
         "damage": 6,
         "duration": 550,
         "energy": 7,
-        "dps": 10.9
+        "dps": 10.91
     },
     {
         "id": 221,
@@ -167,8 +167,8 @@
         "type": "Normal",
         "damage": 12,
         "duration": 1100,
-        "energy": 7,
-        "dps": 10.9
+        "energy": 10,
+        "dps": 10.91
     },
     {
         "id": 237,
@@ -176,8 +176,8 @@
         "type": "Water",
         "damage": 25,
         "duration": 2300,
-        "energy": 15,
-        "dps": 10.86
+        "energy": 25,
+        "dps": 10.87
     },
     {
         "id": 214,
@@ -194,7 +194,7 @@
         "type": "Ice",
         "damage": 15,
         "duration": 1400,
-        "energy": 7,
+        "energy": 12,
         "dps": 10.71
     },
     {
@@ -203,7 +203,7 @@
         "type": "Fighting",
         "damage": 15,
         "duration": 1410,
-        "energy": 7,
+        "energy": 12,
         "dps": 10.63
     },
     {
@@ -212,7 +212,7 @@
         "type": "Normal",
         "damage": 12,
         "duration": 1130,
-        "energy": 7,
+        "energy": 10,
         "dps": 10.61
     },
     {
@@ -221,7 +221,7 @@
         "type": "Poison",
         "damage": 6,
         "duration": 575,
-        "energy": 4,
+        "energy": 8,
         "dps": 10.43
     },
     {
@@ -230,7 +230,7 @@
         "type": "Grass",
         "damage": 15,
         "duration": 1450,
-        "energy": 7,
+        "energy": 12,
         "dps": 10.34
     },
     {
@@ -239,7 +239,7 @@
         "type": "Ghost",
         "damage": 5,
         "duration": 500,
-        "energy": 7,
+        "energy": 6,
         "dps": 10
     },
     {
@@ -248,7 +248,7 @@
         "type": "Electric",
         "damage": 7,
         "duration": 700,
-        "energy": 4,
+        "energy": 8,
         "dps": 10
     },
     {
@@ -257,7 +257,7 @@
         "type": "Dark",
         "damage": 7,
         "duration": 700,
-        "energy": 4,
+        "energy": 9,
         "dps": 10
     },
     {
@@ -266,7 +266,7 @@
         "type": "Psychic",
         "damage": 15,
         "duration": 1510,
-        "energy": 7,
+        "energy": 14,
         "dps": 9.93
     },
     {
@@ -275,7 +275,7 @@
         "type": "Poison",
         "damage": 10,
         "duration": 1050,
-        "energy": 7,
+        "energy": 10,
         "dps": 9.52
     },
     {
@@ -284,7 +284,7 @@
         "type": "Fire",
         "damage": 10,
         "duration": 1050,
-        "energy": 7,
+        "energy": 10,
         "dps": 9.52
     },
     {
@@ -293,7 +293,7 @@
         "type": "Rock",
         "damage": 12,
         "duration": 1360,
-        "energy": 7,
+        "energy": 15,
         "dps": 8.82
     },
     {
@@ -320,7 +320,7 @@
         "type": "Electric",
         "damage": 5,
         "duration": 600,
-        "energy": 7,
+        "energy": 8,
         "dps": 8.33
     },
     {
@@ -329,7 +329,7 @@
         "type": "Steel",
         "damage": 10,
         "duration": 1200,
-        "energy": 7,
+        "energy": 10,
         "dps": 8.33
     },
     {
@@ -338,7 +338,7 @@
         "type": "Normal",
         "damage": 10,
         "duration": 1330,
-        "energy": 7,
+        "energy": 12,
         "dps": 7.51
     },
     {
@@ -347,7 +347,7 @@
         "type": "Bug",
         "damage": 3,
         "duration": 400,
-        "energy": 12,
+        "energy": 6,
         "dps": 7.5
     },
     {
@@ -374,7 +374,7 @@
         "type": "Water",
         "damage": 0,
         "duration": 1230,
-        "energy": 7,
+        "energy": 10,
         "dps": 0
     }
 ]

--- a/data/fast_moves.json
+++ b/data/fast_moves.json
@@ -360,6 +360,15 @@
         "dps": 7.5
     },
     {
+        "id": 242,
+        "name": "Transform",
+        "type": "Normal",
+        "damage": 0,
+        "duration": 1230,
+        "energy": 7,
+        "dps": 0.0
+    },
+    {
         "id": 231,
         "name": "Splash",
         "type": "Water",

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -1838,7 +1838,8 @@
         "Special Attack(s)":  [
                                   "Body Slam",
                                   "Dazzling Gleam",
-                                  "Disarming Voice"
+                                  "Disarming Voice",
+                                  "Play Rough"
                               ],
         "BaseAttack":  80,
         "BaseDefense":  44,
@@ -2403,7 +2404,8 @@
                        ],
         "Fast Attack(s)":  [
                                "Mud Slap",
-                               "Sucker Punch"
+                               "Sucker Punch",
+                               "Mud Shot"
                            ],
         "Weight":  "33.3 kg",
         "Height":  "0.7 m",
@@ -3527,7 +3529,8 @@
                        ],
         "Fast Attack(s)":  [
                                "Mud Slap",
-                               "Rock Throw"
+                               "Rock Throw",
+                               "Mud Shot"
                            ],
         "Weight":  "105.0 kg",
         "Height":  "1.0 m",
@@ -3555,7 +3558,8 @@
         "Special Attack(s)":  [
                                   "Dig",
                                   "Rock Slide",
-                                  "Stone Edge"
+                                  "Stone Edge",
+                                  "Earthquake"
                               ],
         "BaseAttack":  164,
         "BaseDefense":  196,
@@ -4030,7 +4034,9 @@
                        ],
         "Fast Attack(s)":  [
                                "Ice Shard",
-                               "Lick"
+                               "Lick",
+                               "Rock Throw",
+                               "Water Gun"
                            ],
         "Weight":  "90.0 kg",
         "Height":  "1.1 m",
@@ -4052,7 +4058,8 @@
         "Special Attack(s)":  [
                                   "Aqua Jet",
                                   "Aqua Tail",
-                                  "Icy Wind"
+                                  "Icy Wind",
+                                  "Ancient Power"
                               ],
         "BaseAttack":  85,
         "BaseDefense":  128,
@@ -5072,7 +5079,8 @@
                            "Psychic"
                        ],
         "Fast Attack(s)":  [
-                               "Tackle"
+                               "Tackle",
+                               "Acid"
                            ],
         "Weight":  "9.5 kg",
         "Height":  "1.2 m",
@@ -5477,7 +5485,8 @@
                        ],
         "Fast Attack(s)":  [
                                "Tackle",
-                               "Water Gun"
+                               "Water Gun",
+                               "Quick Attack"
                            ],
         "Weight":  "34.5 kg",
         "Height":  "0.8 m",
@@ -5527,7 +5536,8 @@
                        ],
         "Fast Attack(s)":  [
                                "Tackle",
-                               "Water Gun"
+                               "Water Gun",
+                               "Quick Attack"
                            ],
         "Weight":  "80.0 kg",
         "Height":  "1.1 m",
@@ -5544,7 +5554,8 @@
         "Special Attack(s)":  [
                                   "Hydro Pump",
                                   "Power Gem",
-                                  "Psychic"
+                                  "Psychic",
+                                  "Psybeam"
                               ],
         "BaseAttack":  210,
         "BaseDefense":  184,
@@ -6240,7 +6251,8 @@
                        ],
         "Fast Attack(s)":  [
                                "Mud Shot",
-                               "Water Gun"
+                               "Water Gun",
+                               "Rock Throw"
                            ],
         "Weight":  "35.0 kg",
         "Height":  "1.0 m",

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -3588,7 +3588,8 @@
                        ],
         "Fast Attack(s)":  [
                                "Mud Slap",
-                               "Rock Throw"
+                               "Rock Throw",
+                               "Mud Shot"
                            ],
         "Weight":  "300.0 kg",
         "Height":  "1.4 m",
@@ -4942,7 +4943,8 @@
         "Special Attack(s)":  [
                                   "Brick Break",
                                   "Low Sweep",
-                                  "Stone Edge"
+                                  "Stone Edge",
+                                  "Stomp"
                               ],
         "BaseAttack":  224,
         "BaseDefense":  211,

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -1,6069 +1,10490 @@
 [
     {
-        "Number": "001",
-        "Name": "Bulbasaur",
-        "Classification": "Seed Pokemon",
-        "Type I": [
-            "Grass"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Ice",
-            "Flying",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Tackle",
-            "Vine Whip"
-        ],
-        "Weight": "6.9 kg",
-        "Height": "0.7 m",
-        "Next Evolution Requirements": {
-            "Amount": 25,
-            "Family": 1,
-            "Name": "Bulbasaur candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "002",
-                "Name": "Ivysaur"
-            },
-            {
-                "Number": "003",
-                "Name": "Venusaur"
-            }
-        ],
-        "Special Attack(s)": [
-            "Power Whip",
-            "Seed Bomb",
-            "Sludge Bomb"
-        ],
-        "BaseAttack": 126,
-        "BaseDefense": 126,
-        "BaseStamina": 90,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "002",
-        "Name": "Ivysaur",
-        "Classification": "Seed Pokemon",
-        "Type I": [
-            "Grass"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Ice",
-            "Flying",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Razor Leaf",
-            "Vine Whip"
-        ],
-        "Weight": "13.0 kg",
-        "Height": "1.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "001",
-                "Name": "Bulbasaur"
-            }
-        ],
-        "Next Evolution Requirements": {
-            "Amount": 100,
-            "Family": 1,
-            "Name": "Bulbasaur candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "003",
-                "Name": "Venusaur"
-            }
-        ],
-        "Special Attack(s)": [
-            "Power Whip",
-            "Sludge Bomb",
-            "Solar Beam"
-        ],
-        "BaseAttack": 156,
-        "BaseDefense": 158,
-        "BaseStamina": 120,
-        "CaptureRate": 0.08,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "003",
-        "Name": "Venusaur",
-        "Classification": "Seed Pokemon",
-        "Type I": [
-            "Grass"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Ice",
-            "Flying",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Razor Leaf",
-            "Vine Whip"
-        ],
-        "Weight": "100.0 kg",
-        "Height": "2.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "001",
-                "Name": "Bulbasaur"
-            },
-            {
-                "Number": "002",
-                "Name": "Ivysaur"
-            }
-        ],
-        "Special Attack(s)": [
-            "Petal Blizzard",
-            "Sludge Bomb",
-            "Solar Beam"
-        ],
-        "BaseAttack": 198,
-        "BaseDefense": 200,
-        "BaseStamina": 160,
-        "CaptureRate": 0.04,
-        "FleeRate": 0.05,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "004",
-        "Name": "Charmander",
-        "Classification": "Lizard Pokemon",
-        "Type I": [
-            "Fire"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Ground",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Ember",
-            "Scratch"
-        ],
-        "Weight": "8.5 kg",
-        "Height": "0.6 m",
-        "Next Evolution Requirements": {
-            "Amount": 25,
-            "Family": 4,
-            "Name": "Charmander candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "005",
-                "Name": "Charmeleon"
-            },
-            {
-                "Number": "006",
-                "Name": "Charizard"
-            }
-        ],
-        "Special Attack(s)": [
-            "Flame Burst",
-            "Flame Charge",
-            "Flamethrower"
-        ],
-        "BaseAttack": 128,
-        "BaseDefense": 108,
-        "BaseStamina": 78,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "005",
-        "Name": "Charmeleon",
-        "Classification": "Flame Pokemon",
-        "Type I": [
-            "Fire"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Ground",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Ember",
-            "Scratch"
-        ],
-        "Weight": "19.0 kg",
-        "Height": "1.1 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "004",
-                "Name": "Charmander"
-            }
-        ],
-        "Next Evolution Requirements": {
-            "Amount": 100,
-            "Family": 4,
-            "Name": "Charmander candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "006",
-                "Name": "Charizard"
-            }
-        ],
-        "Special Attack(s)": [
-            "Fire Punch",
-            "Flame Burst",
-            "Flamethrower"
-        ],
-        "BaseAttack": 160,
-        "BaseDefense": 140,
-        "BaseStamina": 116,
-        "CaptureRate": 0.08,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "006",
-        "Name": "Charizard",
-        "Classification": "Flame Pokemon",
-        "Type I": [
-            "Fire"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Electric",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Ember",
-            "Wing Attack"
-        ],
-        "Weight": "90.5 kg",
-        "Height": "1.7 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "004",
-                "Name": "Charmander"
-            },
-            {
-                "Number": "005",
-                "Name": "Charmeleon"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dragon Claw",
-            "Fire Blast",
-            "Flamethrower"
-        ],
-        "BaseAttack": 212,
-        "BaseDefense": 182,
-        "BaseStamina": 156,
-        "CaptureRate": 0.04,
-        "FleeRate": 0.05,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "007",
-        "Name": "Squirtle",
-        "Classification": "Tiny Turtle Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Bubble",
-            "Tackle"
-        ],
-        "Weight": "9.0 kg",
-        "Height": "0.5 m",
-        "Next Evolution Requirements": {
-            "Amount": 25,
-            "Family": 7,
-            "Name": "Squirtle candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "008",
-                "Name": "Wartortle"
-            },
-            {
-                "Number": "009",
-                "Name": "Blastoise"
-            }
-        ],
-        "Special Attack(s)": [
-            "Aqua Jet",
-            "Aqua Tail",
-            "Water Pulse"
-        ],
-        "BaseAttack": 112,
-        "BaseDefense": 142,
-        "BaseStamina": 88,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "008",
-        "Name": "Wartortle",
-        "Classification": "Turtle Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Bite",
-            "Water Gun"
-        ],
-        "Weight": "22.5 kg",
-        "Height": "1.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "007",
-                "Name": "Squirtle"
-            }
-        ],
-        "Next Evolution Requirements": {
-            "Amount": 100,
-            "Family": 7,
-            "Name": "Squirtle candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "009",
-                "Name": "Blastoise"
-            }
-        ],
-        "Special Attack(s)": [
-            "Aqua Jet",
-            "Hydro Pump",
-            "Ice Beam"
-        ],
-        "BaseAttack": 144,
-        "BaseDefense": 176,
-        "BaseStamina": 118,
-        "CaptureRate": 0.08,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "009",
-        "Name": "Blastoise",
-        "Classification": "Shellfish Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Bite",
-            "Water Gun"
-        ],
-        "Weight": "85.5 kg",
-        "Height": "1.6 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "007",
-                "Name": "Squirtle"
-            },
-            {
-                "Number": "008",
-                "Name": "Wartortle"
-            }
-        ],
-        "Special Attack(s)": [
-            "Flash Cannon",
-            "Hydro Pump",
-            "Ice Beam"
-        ],
-        "BaseAttack": 186,
-        "BaseDefense": 222,
-        "BaseStamina": 158,
-        "CaptureRate": 0.04,
-        "FleeRate": 0.05,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "010",
-        "Name": "Caterpie",
-        "Classification": "Worm Pokemon",
-        "Type I": [
-            "Bug"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Flying",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Bug Bite",
-            "Tackle"
-        ],
-        "Weight": "2.9 kg",
-        "Height": "0.3 m",
-        "Next Evolution Requirements": {
-            "Amount": 12,
-            "Family": 10,
-            "Name": "Caterpie candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "011",
-                "Name": "Metapod"
-            },
-            {
-                "Number": "012",
-                "Name": "Butterfree"
-            }
-        ],
-        "Special Attack(s)": [
-            "Struggle"
-        ],
-        "BaseAttack": 62,
-        "BaseDefense": 66,
-        "BaseStamina": 90,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.2,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "011",
-        "Name": "Metapod",
-        "Classification": "Cocoon Pokemon",
-        "Type I": [
-            "Bug"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Flying",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Bug Bite",
-            "Tackle"
-        ],
-        "Weight": "9.9 kg",
-        "Height": "0.7 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "010",
-                "Name": "Caterpie"
-            }
-        ],
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 10,
-            "Name": "Caterpie candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "012",
-                "Name": "Butterfree"
-            }
-        ],
-        "Special Attack(s)": [
-            "Struggle"
-        ],
-        "BaseAttack": 56,
-        "BaseDefense": 86,
-        "BaseStamina": 100,
-        "CaptureRate": 0.2,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "012",
-        "Name": "Butterfree",
-        "Classification": "Butterfly Pokemon",
-        "Type I": [
-            "Bug"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Electric",
-            "Ice",
-            "Flying",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Bug Bite",
-            "Confusion"
-        ],
-        "Weight": "32.0 kg",
-        "Height": "1.1 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "010",
-                "Name": "Caterpie"
-            },
-            {
-                "Number": "011",
-                "Name": "Metapod"
-            }
-        ],
-        "Special Attack(s)": [
-            "Bug Buzz",
-            "Psychic",
-            "Signal Beam"
-        ],
-        "BaseAttack": 144,
-        "BaseDefense": 144,
-        "BaseStamina": 120,
-        "CaptureRate": 0.1,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "013",
-        "Name": "Weedle",
-        "Classification": "Hairy Pokemon",
-        "Type I": [
-            "Bug"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Flying",
-            "Psychic",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Bug Bite",
-            "Poison Sting"
-        ],
-        "Weight": "3.2 kg",
-        "Height": "0.3 m",
-        "Next Evolution Requirements": {
-            "Amount": 12,
-            "Family": 13,
-            "Name": "Weedle candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "014",
-                "Name": "Kakuna"
-            },
-            {
-                "Number": "015",
-                "Name": "Beedrill"
-            }
-        ],
-        "Special Attack(s)": [
-            "Struggle"
-        ],
-        "BaseAttack": 68,
-        "BaseDefense": 64,
-        "BaseStamina": 80,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.2,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "014",
-        "Name": "Kakuna",
-        "Classification": "Cocoon Pokemon",
-        "Type I": [
-            "Bug"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Flying",
-            "Psychic",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Bug Bite",
-            "Poison Sting"
-        ],
-        "Weight": "10.0 kg",
-        "Height": "0.6 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "013",
-                "Name": "Weedle"
-            }
-        ],
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 13,
-            "Name": "Weedle candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "015",
-                "Name": "Beedrill"
-            }
-        ],
-        "Special Attack(s)": [
-            "Struggle"
-        ],
-        "BaseAttack": 62,
-        "BaseDefense": 82,
-        "BaseStamina": 90,
-        "CaptureRate": 0.2,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "015",
-        "Name": "Beedrill",
-        "Classification": "Poison Bee Pokemon",
-        "Type I": [
-            "Bug"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Flying",
-            "Psychic",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Bug Bite",
-            "Poison Jab"
-        ],
-        "Weight": "29.5 kg",
-        "Height": "1.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "013",
-                "Name": "Weedle"
-            },
-            {
-                "Number": "014",
-                "Name": "Kakuna"
-            }
-        ],
-        "Special Attack(s)": [
-            "Aerial Ace",
-            "Sludge Bomb",
-            "X Scissor"
-        ],
-        "BaseAttack": 144,
-        "BaseDefense": 130,
-        "BaseStamina": 130,
-        "CaptureRate": 0.1,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "016",
-        "Name": "Pidgey",
-        "Classification": "Tiny Bird Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Quick Attack",
-            "Tackle"
-        ],
-        "Special Attack(s)": [
-            "Aerial Ace",
-            "Air Cutter",
-            "Twister"
-        ],
-        "Weight": "1.8 kg",
-        "Height": "0.3 m",
-        "Next Evolution Requirements": {
-            "Amount": 12,
-            "Family": 16,
-            "Name": "Pidgey candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "017",
-                "Name": "Pidgeotto"
-            },
-            {
-                "Number": "018",
-                "Name": "Pidgeot"
-            }
-        ],
-        "BaseAttack": 94,
-        "BaseDefense": 90,
-        "BaseStamina": 80,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.2,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "017",
-        "Name": "Pidgeotto",
-        "Classification": "Bird Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Steel Wing",
-            "Wing Attack"
-        ],
-        "Special Attack(s)": [
-            "Aerial Ace",
-            "Air Cutter",
-            "Twister"
-        ],
-        "Weight": "30.0 kg",
-        "Height": "1.1 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "016",
-                "Name": "Pidgey"
-            }
-        ],
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 16,
-            "Name": "Pidgey candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "018",
-                "Name": "Pidgeot"
-            }
-        ],
-        "BaseAttack": 126,
-        "BaseDefense": 122,
-        "BaseStamina": 126,
-        "CaptureRate": 0.2,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "018",
-        "Name": "Pidgeot",
-        "Classification": "Bird Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Steel Wing",
-            "Wing Attack"
-        ],
-        "Special Attack(s)": [
-            "Aerial Ace",
-            "Air Cutter",
-            "Hurricane"
-        ],
-        "Weight": "39.5 kg",
-        "Height": "1.5 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "016",
-                "Name": "Pidgey"
-            },
-            {
-                "Number": "017",
-                "Name": "Pidgeotto"
-            }
-        ],
-        "BaseAttack": 170,
-        "BaseDefense": 166,
-        "BaseStamina": 166,
-        "CaptureRate": 0.1,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "019",
-        "Name": "Rattata",
-        "Classification": "Mouse Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Weaknesses": [
-            "Fighting"
-        ],
-        "Fast Attack(s)": [
-            "Quick Attack",
-            "Tackle"
-        ],
-        "Special Attack(s)": [
-            "Body Slam",
-            "Dig",
-            "Hyper Fang"
-        ],
-        "Weight": "3.5 kg",
-        "Height": "0.3 m",
-        "Next Evolution Requirements": {
-            "Amount": 25,
-            "Family": 19,
-            "Name": "Rattata candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "020",
-                "Name": "Raticate"
-            }
-        ],
-        "BaseAttack": 92,
-        "BaseDefense": 86,
-        "BaseStamina": 60,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.2,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "020",
-        "Name": "Raticate",
-        "Classification": "Mouse Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Weaknesses": [
-            "Fighting"
-        ],
-        "Fast Attack(s)": [
-            "Bite",
-            "Quick Attack"
-        ],
-        "Special Attack(s)": [
-            "Dig",
-            "Hyper Beam",
-            "Hyper Fang"
-        ],
-        "Weight": "18.5 kg",
-        "Height": "0.7 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "019",
-                "Name": "Rattata"
-            }
-        ],
-        "BaseAttack": 146,
-        "BaseDefense": 150,
-        "BaseStamina": 110,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "021",
-        "Name": "Spearow",
-        "Classification": "Tiny Bird Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Peck",
-            "Quick Attack"
-        ],
-        "Weight": "2.0 kg",
-        "Height": "0.3 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 21,
-            "Name": "Spearow candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "022",
-                "Name": "Fearow"
-            }
-        ],
-        "Special Attack(s)": [
-            "Aerial Ace",
-            "Drill Peck",
-            "Twister"
-        ],
-        "BaseAttack": 102,
-        "BaseDefense": 78,
-        "BaseStamina": 80,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.15,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "022",
-        "Name": "Fearow",
-        "Classification": "Beak Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Peck",
-            "Steel Wing"
-        ],
-        "Weight": "38.0 kg",
-        "Height": "1.2 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "021",
-                "Name": "Spearow"
-            }
-        ],
-        "Special Attack(s)": [
-            "Aerial Ace",
-            "Drill Run",
-            "Twister"
-        ],
-        "BaseAttack": 168,
-        "BaseDefense": 146,
-        "BaseStamina": 130,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "023",
-        "Name": "Ekans",
-        "Classification": "Snake Pokemon",
-        "Type I": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Ground",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Acid",
-            "Poison Sting"
-        ],
-        "Weight": "6.9 kg",
-        "Height": "2.0 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 23,
-            "Name": "Ekans candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "024",
-                "Name": "Arbok"
-            }
-        ],
-        "Special Attack(s)": [
-            "Gunk Shot",
-            "Sludge Bomb",
-            "Wrap"
-        ],
-        "BaseAttack": 112,
-        "BaseDefense": 112,
-        "BaseStamina": 70,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.15,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "024",
-        "Name": "Arbok",
-        "Classification": "Cobra Pokemon",
-        "Type I": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Ground",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Acid",
-            "Bite"
-        ],
-        "Weight": "65.0 kg",
-        "Height": "3.5 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "023",
-                "Name": "Ekans"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dark Pulse",
-            "Gunk Shot",
-            "Sludge Wave"
-        ],
-        "BaseAttack": 166,
-        "BaseDefense": 166,
-        "BaseStamina": 120,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "025",
-        "Name": "Pikachu",
-        "Classification": "Mouse Pokemon",
-        "Type I": [
-            "Electric"
-        ],
-        "Weaknesses": [
-            "Ground"
-        ],
-        "Fast Attack(s)": [
-            "Quick Attack",
-            "Thunder Shock"
-        ],
-        "Weight": "6.0 kg",
-        "Height": "0.4 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 25,
-            "Name": "Pikachu candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "026",
-                "Name": "Raichu"
-            }
-        ],
-        "Special Attack(s)": [
-            "Discharge",
-            "Thunder",
-            "Thunderbolt"
-        ],
-        "BaseAttack": 124,
-        "BaseDefense": 108,
-        "BaseStamina": 70,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "026",
-        "Name": "Raichu",
-        "Classification": "Mouse Pokemon",
-        "Type I": [
-            "Electric"
-        ],
-        "Weaknesses": [
-            "Ground"
-        ],
-        "Fast Attack(s)": [
-            "Spark",
-            "Thunder Shock"
-        ],
-        "Weight": "30.0 kg",
-        "Height": "0.8 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "025",
-                "Name": "Pikachu"
-            }
-        ],
-        "Special Attack(s)": [
-            "Brick Break",
-            "Thunder",
-            "Thunder Punch"
-        ],
-        "BaseAttack": 200,
-        "BaseDefense": 154,
-        "BaseStamina": 120,
-        "CaptureRate": 0.08,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "027",
-        "Name": "Sandshrew",
-        "Classification": "Mouse Pokemon",
-        "Type I": [
-            "Ground"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Grass",
-            "Ice"
-        ],
-        "Fast Attack(s)": [
-            "Mud Shot",
-            "Scratch"
-        ],
-        "Weight": "12.0 kg",
-        "Height": "0.6 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 27,
-            "Name": "Sandshrew candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "028",
-                "Name": "Sandslash"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dig",
-            "Rock Slide",
-            "Rock Tomb"
-        ],
-        "BaseAttack": 90,
-        "BaseDefense": 114,
-        "BaseStamina": 100,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "028",
-        "Name": "Sandslash",
-        "Classification": "Mouse Pokemon",
-        "Type I": [
-            "Ground"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Grass",
-            "Ice"
-        ],
-        "Fast Attack(s)": [
-            "Metal Claw",
-            "Mud Shot"
-        ],
-        "Weight": "29.5 kg",
-        "Height": "1.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "027",
-                "Name": "Sandshrew"
-            }
-        ],
-        "Special Attack(s)": [
-            "Bulldoze",
-            "Earthquake",
-            "Rock Tomb"
-        ],
-        "BaseAttack": 150,
-        "BaseDefense": 172,
-        "BaseStamina": 150,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "029",
-        "Name": "Nidoran F",
-        "Classification": "Poison Pin Pokemon",
-        "Type I": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Ground",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Bite",
-            "Poison Sting"
-        ],
-        "Weight": "7.0 kg",
-        "Height": "0.4 m",
-        "Next Evolution Requirements": {
-            "Amount": 25,
-            "Family": 29,
-            "Name": "Nidoran F candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "030",
-                "Name": "Nidorina"
-            },
-            {
-                "Number": "031",
-                "Name": "Nidoqueen"
-            }
-        ],
-        "Special Attack(s)": [
-            "Body Slam",
-            "Poison Fang",
-            "Sludge Bomb"
-        ],
-        "BaseAttack": 100,
-        "BaseDefense": 104,
-        "BaseStamina": 110,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.15,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "030",
-        "Name": "Nidorina",
-        "Classification": "Poison Pin Pokemon",
-        "Type I": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Ground",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Bite",
-            "Poison Sting"
-        ],
-        "Weight": "20.0 kg",
-        "Height": "0.8 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "029",
-                "Name": "Nidoran F"
-            }
-        ],
-        "Next Evolution Requirements": {
-            "Amount": 100,
-            "Family": 29,
-            "Name": "Nidoran F candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "031",
-                "Name": "Nidoqueen"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dig",
-            "Poison Fang",
-            "Sludge Bomb"
-        ],
-        "BaseAttack": 132,
-        "BaseDefense": 136,
-        "BaseStamina": 140,
-        "CaptureRate": 0.2,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "031",
-        "Name": "Nidoqueen",
-        "Classification": "Drill Pokemon",
-        "Type I": [
-            "Poison"
-        ],
-        "Type II": [
-            "Ground"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Ice",
-            "Ground",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Bite",
-            "Poison Jab"
-        ],
-        "Weight": "60.0 kg",
-        "Height": "1.3 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "029",
-                "Name": "Nidoran F"
-            },
-            {
-                "Number": "030",
-                "Name": "Nidorina"
-            }
-        ],
-        "Special Attack(s)": [
-            "Earthquake",
-            "Sludge Wave",
-            "Stone Edge"
-        ],
-        "BaseAttack": 184,
-        "BaseDefense": 190,
-        "BaseStamina": 180,
-        "CaptureRate": 0.1,
-        "FleeRate": 0.05,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "032",
-        "Name": "Nidoran M",
-        "Classification": "Poison Pin Pokemon",
-        "Type I": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Ground",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Peck",
-            "Poison Sting"
-        ],
-        "Weight": "9.0 kg",
-        "Height": "0.5 m",
-        "Next Evolution Requirements": {
-            "Amount": 25,
-            "Family": 32,
-            "Name": "Nidoran M candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "033",
-                "Name": "Nidorino"
-            },
-            {
-                "Number": "034",
-                "Name": "Nidoking"
-            }
-        ],
-        "Special Attack(s)": [
-            "Body Slam",
-            "Horn Attack",
-            "Sludge Bomb"
-        ],
-        "BaseAttack": 110,
-        "BaseDefense": 94,
-        "BaseStamina": 92,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.15,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "033",
-        "Name": "Nidorino",
-        "Classification": "Poison Pin Pokemon",
-        "Type I": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Ground",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Poison Jab",
-            "Poison Sting"
-        ],
-        "Weight": "19.5 kg",
-        "Height": "0.9 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "032",
-                "Name": "Nidoran M"
-            }
-        ],
-        "Next Evolution Requirements": {
-            "Amount": 100,
-            "Family": 32,
-            "Name": "Nidoran M candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "034",
-                "Name": "Nidoking"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dig",
-            "Horn Attack",
-            "Sludge Bomb"
-        ],
-        "BaseAttack": 142,
-        "BaseDefense": 128,
-        "BaseStamina": 122,
-        "CaptureRate": 0.2,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "034",
-        "Name": "Nidoking",
-        "Classification": "Drill Pokemon",
-        "Type I": [
-            "Poison"
-        ],
-        "Type II": [
-            "Ground"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Ice",
-            "Ground",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Fury Cutter",
-            "Poison Jab"
-        ],
-        "Weight": "62.0 kg",
-        "Height": "1.4 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "032",
-                "Name": "Nidoran M"
-            },
-            {
-                "Number": "033",
-                "Name": "Nidorino"
-            }
-        ],
-        "Special Attack(s)": [
-            "Earthquake",
-            "Megahorn",
-            "Sludge Wave"
-        ],
-        "BaseAttack": 204,
-        "BaseDefense": 170,
-        "BaseStamina": 162,
-        "CaptureRate": 0.1,
-        "FleeRate": 0.05,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "035",
-        "Name": "Clefairy",
-        "Classification": "Fairy Pokemon",
-        "Type I": [
-            "Fairy"
-        ],
-        "Weaknesses": [
-            "Fighting"
-        ],
-        "Fast Attack(s)": [
-            "Pound",
-            "Zen Headbutt"
-        ],
-        "Weight": "7.5 kg",
-        "Height": "0.6 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 35,
-            "Name": "Clefairy candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "036",
-                "Name": "Clefable"
-            }
-        ],
-        "Special Attack(s)": [
-            "Body Slam",
-            "Disarming Voice",
-            "Moonblast"
-        ],
-        "BaseAttack": 116,
-        "BaseDefense": 124,
-        "BaseStamina": 140,
-        "CaptureRate": 0.24,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "036",
-        "Name": "Clefable",
-        "Classification": "Fairy Pokemon",
-        "Type I": [
-            "Fairy"
-        ],
-        "Weaknesses": [
-            "Fighting"
-        ],
-        "Fast Attack(s)": [
-            "Pound",
-            "Zen Headbutt"
-        ],
-        "Weight": "40.0 kg",
-        "Height": "1.3 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "035",
-                "Name": "Clefairy"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dazzling Gleam",
-            "Moonblast",
-            "Psychic"
-        ],
-        "BaseAttack": 178,
-        "BaseDefense": 178,
-        "BaseStamina": 190,
-        "CaptureRate": 0.08,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "037",
-        "Name": "Vulpix",
-        "Classification": "Fox Pokemon",
-        "Type I": [
-            "Fire"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Ground",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Ember",
-            "Quick Attack"
-        ],
-        "Weight": "9.9 kg",
-        "Height": "0.6 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 37,
-            "Name": "Vulpix candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "038",
-                "Name": "Ninetales"
-            }
-        ],
-        "Special Attack(s)": [
-            "Body Slam",
-            "Flame Charge",
-            "Flamethrower"
-        ],
-        "BaseAttack": 106,
-        "BaseDefense": 118,
-        "BaseStamina": 76,
-        "CaptureRate": 0.24,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "038",
-        "Name": "Ninetales",
-        "Classification": "Fox Pokemon",
-        "Type I": [
-            "Fire"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Ground",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Ember",
-            "Feint Attack"
-        ],
-        "Weight": "19.9 kg",
-        "Height": "1.1 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "037",
-                "Name": "Vulpix"
-            }
-        ],
-        "Special Attack(s)": [
-            "Fire Blast",
-            "Flamethrower",
-            "Heat Wave"
-        ],
-        "BaseAttack": 176,
-        "BaseDefense": 194,
-        "BaseStamina": 146,
-        "CaptureRate": 0.08,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "039",
-        "Name": "Jigglypuff",
-        "Classification": "Balloon Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Type II": [
-            "Fairy"
-        ],
-        "Weaknesses": [
-            "Fighting"
-        ],
-        "Fast Attack(s)": [
-            "Feint Attack",
-            "Pound"
-        ],
-        "Weight": "5.5 kg",
-        "Height": "0.5 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 39,
-            "Name": "Jigglypuff candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "040",
-                "Name": "Wigglytuff"
-            }
-        ],
-        "Special Attack(s)": [
-            "Body Slam",
-            "Dazzling Gleam",
-            "Disarming Voice",
-            "Play Rough",
-            "Dazzling Gleam"
-        ],
-        "BaseAttack": 98,
-        "BaseDefense": 54,
-        "BaseStamina": 230,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "040",
-        "Name": "Wigglytuff",
-        "Classification": "Balloon Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Type II": [
-            "Fairy"
-        ],
-        "Weaknesses": [
-            "Fighting"
-        ],
-        "Fast Attack(s)": [
-            "Feint Attack",
-            "Pound"
-        ],
-        "Weight": "12.0 kg",
-        "Height": "1.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "039",
-                "Name": "Jigglypuff"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dazzling Gleam",
-            "Hyper Beam",
-            "Play Rough"
-        ],
-        "BaseAttack": 168,
-        "BaseDefense": 108,
-        "BaseStamina": 280,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "041",
-        "Name": "Zubat",
-        "Classification": "Bat Pokemon",
-        "Type I": [
-            "Poison"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Ice",
-            "Psychic",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Bite",
-            "Quick Attack"
-        ],
-        "Weight": "7.5 kg",
-        "Height": "0.8 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 41,
-            "Name": "Zubat candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "042",
-                "Name": "Golbat"
-            }
-        ],
-        "Special Attack(s)": [
-            "Air Cutter",
-            "Poison Fang",
-            "Sludge Bomb"
-        ],
-        "BaseAttack": 88,
-        "BaseDefense": 90,
-        "BaseStamina": 80,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.2,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "042",
-        "Name": "Golbat",
-        "Classification": "Bat Pokemon",
-        "Type I": [
-            "Poison"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Ice",
-            "Psychic",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Bite",
-            "Wing Attack"
-        ],
-        "Weight": "55.0 kg",
-        "Height": "1.6 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "041",
-                "Name": "Zubat"
-            }
-        ],
-        "Special Attack(s)": [
-            "Air Cutter",
-            "Ominous Wind",
-            "Poison Fang"
-        ],
-        "BaseAttack": 164,
-        "BaseDefense": 164,
-        "BaseStamina": 150,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "043",
-        "Name": "Oddish",
-        "Classification": "Weed Pokemon",
-        "Type I": [
-            "Grass"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Ice",
-            "Flying",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Acid",
-            "Razor Leaf"
-        ],
-        "Weight": "5.4 kg",
-        "Height": "0.5 m",
-        "Next Evolution Requirements": {
-            "Amount": 25,
-            "Family": 43,
-            "Name": "Oddish candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "044",
-                "Name": "Gloom"
-            },
-            {
-                "Number": "045",
-                "Name": "Vileplume"
-            }
-        ],
-        "Special Attack(s)": [
-            "Moonblast",
-            "Seed Bomb",
-            "Sludge Bomb"
-        ],
-        "BaseAttack": 134,
-        "BaseDefense": 130,
-        "BaseStamina": 90,
-        "CaptureRate": 0.48,
-        "FleeRate": 0.15,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "044",
-        "Name": "Gloom",
-        "Classification": "Weed Pokemon",
-        "Type I": [
-            "Grass"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Ice",
-            "Flying",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Acid",
-            "Razor Leaf"
-        ],
-        "Weight": "8.6 kg",
-        "Height": "0.8 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "043",
-                "Name": "Oddish"
-            }
-        ],
-        "Next Evolution Requirements": {
-            "Amount": 100,
-            "Family": 43,
-            "Name": "Oddish candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "045",
-                "Name": "Vileplume"
-            }
-        ],
-        "Special Attack(s)": [
-            "Moonblast",
-            "Petal Blizzard",
-            "Sludge Bomb"
-        ],
-        "BaseAttack": 162,
-        "BaseDefense": 158,
-        "BaseStamina": 120,
-        "CaptureRate": 0.24,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "045",
-        "Name": "Vileplume",
-        "Classification": "Flower Pokemon",
-        "Type I": [
-            "Grass"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Ice",
-            "Flying",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Acid",
-            "Razor Leaf"
-        ],
-        "Weight": "18.6 kg",
-        "Height": "1.2 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "043",
-                "Name": "Oddish"
-            },
-            {
-                "Number": "044",
-                "Name": "Gloom"
-            }
-        ],
-        "Special Attack(s)": [
-            "Moonblast",
-            "Petal Blizzard",
-            "Solar Beam"
-        ],
-        "BaseAttack": 202,
-        "BaseDefense": 190,
-        "BaseStamina": 150,
-        "CaptureRate": 0.12,
-        "FleeRate": 0.05,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "046",
-        "Name": "Paras",
-        "Classification": "Mushroom Pokemon",
-        "Type I": [
-            "Bug"
-        ],
-        "Type II": [
-            "Grass"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Ice",
-            "Poison",
-            "Flying",
-            "Bug",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Bug Bite",
-            "Scratch"
-        ],
-        "Weight": "5.4 kg",
-        "Height": "0.3 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 46,
-            "Name": "Paras candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "047",
-                "Name": "Parasect"
-            }
-        ],
-        "Special Attack(s)": [
-            "Cross Poison",
-            "Seed Bomb",
-            "X Scissor"
-        ],
-        "BaseAttack": 122,
-        "BaseDefense": 120,
-        "BaseStamina": 70,
-        "CaptureRate": 0.32,
-        "FleeRate": 0.15,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "047",
-        "Name": "Parasect",
-        "Classification": "Mushroom Pokemon",
-        "Type I": [
-            "Bug"
-        ],
-        "Type II": [
-            "Grass"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Ice",
-            "Poison",
-            "Flying",
-            "Bug",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Bug Bite",
-            "Fury Cutter"
-        ],
-        "Weight": "29.5 kg",
-        "Height": "1.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "046",
-                "Name": "Paras"
-            }
-        ],
-        "Special Attack(s)": [
-            "Cross Poison",
-            "Solar Beam",
-            "X Scissor"
-        ],
-        "BaseAttack": 162,
-        "BaseDefense": 170,
-        "BaseStamina": 120,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "048",
-        "Name": "Venonat",
-        "Classification": "Insect Pokemon",
-        "Type I": [
-            "Bug"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Flying",
-            "Psychic",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Bug Bite",
-            "Confusion"
-        ],
-        "Weight": "30.0 kg",
-        "Height": "1.0 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 48,
-            "Name": "Venonat candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "049",
-                "Name": "Venomoth"
-            }
-        ],
-        "Special Attack(s)": [
-            "Poison Fang",
-            "Psybeam",
-            "Signal Beam"
-        ],
-        "BaseAttack": 108,
-        "BaseDefense": 118,
-        "BaseStamina": 120,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.15,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "049",
-        "Name": "Venomoth",
-        "Classification": "Poison Moth Pokemon",
-        "Type I": [
-            "Bug"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Flying",
-            "Psychic",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Bug Bite",
-            "Confusion"
-        ],
-        "Weight": "12.5 kg",
-        "Height": "1.5 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "048",
-                "Name": "Venonat"
-            }
-        ],
-        "Special Attack(s)": [
-            "Bug Buzz",
-            "Poison Fang",
-            "Psychic"
-        ],
-        "BaseAttack": 172,
-        "BaseDefense": 154,
-        "BaseStamina": 140,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "050",
-        "Name": "Diglett",
-        "Classification": "Mole Pokemon",
-        "Type I": [
-            "Ground"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Grass",
-            "Ice"
-        ],
-        "Fast Attack(s)": [
-            "Mud Shot",
-            "Mud Slap",
-            "Scratch"
-        ],
-        "Weight": "0.8 kg",
-        "Height": "0.2 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 50,
-            "Name": "Diglett candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "051",
-                "Name": "Dugtrio"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dig",
-            "Mud Bomb",
-            "Rock Tomb"
-        ],
-        "BaseAttack": 108,
-        "BaseDefense": 86,
-        "BaseStamina": 20,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "051",
-        "Name": "Dugtrio",
-        "Classification": "Mole Pokemon",
-        "Type I": [
-            "Ground"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Grass",
-            "Ice"
-        ],
-        "Fast Attack(s)": [
-            "Mud Shot",
-            "Mud Slap",
-            "Sucker Punch"
-        ],
-        "Weight": "33.3 kg",
-        "Height": "0.7 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "050",
-                "Name": "Diglett"
-            }
-        ],
-        "Special Attack(s)": [
-            "Earthquake",
-            "Mud Bomb",
-            "Stone Edge"
-        ],
-        "BaseAttack": 148,
-        "BaseDefense": 140,
-        "BaseStamina": 70,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "052",
-        "Name": "Meowth",
-        "Classification": "Scratch Cat Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Weaknesses": [
-            "Fighting"
-        ],
-        "Fast Attack(s)": [
-            "Bite",
-            "Scratch"
-        ],
-        "Weight": "4.2 kg",
-        "Height": "0.4 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 52,
-            "Name": "Meowth candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "053",
-                "Name": "Persian"
-            }
-        ],
-        "Special Attack(s)": [
-            "Body Slam",
-            "Dark Pulse",
-            "Night Slash"
-        ],
-        "BaseAttack": 104,
-        "BaseDefense": 94,
-        "BaseStamina": 80,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.15,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "053",
-        "Name": "Persian",
-        "Classification": "Classy Cat Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Weaknesses": [
-            "Fighting"
-        ],
-        "Fast Attack(s)": [
-            "Feint Attack",
-            "Scratch"
-        ],
-        "Weight": "32.0 kg",
-        "Height": "1.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "052",
-                "Name": "Meowth"
-            }
-        ],
-        "Special Attack(s)": [
-            "Night Slash",
-            "Play Rough",
-            "Power Gem"
-        ],
-        "BaseAttack": 156,
-        "BaseDefense": 146,
-        "BaseStamina": 130,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "054",
-        "Name": "Psyduck",
-        "Classification": "Duck Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Water Gun",
-            "Zen Headbutt"
-        ],
-        "Weight": "19.6 kg",
-        "Height": "0.8 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 54,
-            "Name": "Psyduck candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "055",
-                "Name": "Golduck"
-            }
-        ],
-        "Special Attack(s)": [
-            "Aqua Tail",
-            "Cross Chop",
-            "Psybeam"
-        ],
-        "BaseAttack": 132,
-        "BaseDefense": 112,
-        "BaseStamina": 100,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "055",
-        "Name": "Golduck",
-        "Classification": "Duck Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Confusion",
-            "Water Gun"
-        ],
-        "Weight": "76.6 kg",
-        "Height": "1.7 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "054",
-                "Name": "Psyduck"
-            }
-        ],
-        "Special Attack(s)": [
-            "Hydro Pump",
-            "Ice Beam",
-            "Psychic"
-        ],
-        "BaseAttack": 194,
-        "BaseDefense": 176,
-        "BaseStamina": 160,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "056",
-        "Name": "Mankey",
-        "Classification": "Pig Monkey Pokemon",
-        "Type I": [
-            "Fighting"
-        ],
-        "Weaknesses": [
-            "Flying",
-            "Psychic",
-            "Fairy"
-        ],
-        "Fast Attack(s)": [
-            "Karate Chop",
-            "Scratch"
-        ],
-        "Weight": "28.0 kg",
-        "Height": "0.5 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 56,
-            "Name": "Mankey candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "057",
-                "Name": "Primeape"
-            }
-        ],
-        "Special Attack(s)": [
-            "Brick Break",
-            "Cross Chop",
-            "Low Sweep"
-        ],
-        "BaseAttack": 122,
-        "BaseDefense": 96,
-        "BaseStamina": 80,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "057",
-        "Name": "Primeape",
-        "Classification": "Pig Monkey Pokemon",
-        "Type I": [
-            "Fighting"
-        ],
-        "Weaknesses": [
-            "Flying",
-            "Psychic",
-            "Fairy"
-        ],
-        "Fast Attack(s)": [
-            "Karate Chop",
-            "Low Kick"
-        ],
-        "Weight": "32.0 kg",
-        "Height": "1.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "056",
-                "Name": "Mankey"
-            }
-        ],
-        "Special Attack(s)": [
-            "Cross Chop",
-            "Low Sweep",
-            "Night Slash"
-        ],
-        "BaseAttack": 178,
-        "BaseDefense": 150,
-        "BaseStamina": 130,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "058",
-        "Name": "Growlithe",
-        "Classification": "Puppy Pokemon",
-        "Type I": [
-            "Fire"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Ground",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Bite",
-            "Ember"
-        ],
-        "Weight": "19.0 kg",
-        "Height": "0.7 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 58,
-            "Name": "Growlithe candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "059",
-                "Name": "Arcanine"
-            }
-        ],
-        "Special Attack(s)": [
-            "Body Slam",
-            "Flame Wheel",
-            "Flamethrower"
-        ],
-        "BaseAttack": 156,
-        "BaseDefense": 110,
-        "BaseStamina": 110,
-        "CaptureRate": 0.24,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "059",
-        "Name": "Arcanine",
-        "Classification": "Legendary Pokemon",
-        "Type I": [
-            "Fire"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Ground",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Bite",
-            "Fire Fang"
-        ],
-        "Weight": "155.0 kg",
-        "Height": "1.9 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "058",
-                "Name": "Growlithe"
-            }
-        ],
-        "Special Attack(s)": [
-            "Bulldoze",
-            "Fire Blast",
-            "Flamethrower"
-        ],
-        "BaseAttack": 230,
-        "BaseDefense": 180,
-        "BaseStamina": 180,
-        "CaptureRate": 0.08,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "060",
-        "Name": "Poliwag",
-        "Classification": "Tadpole Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Bubble",
-            "Mud Shot"
-        ],
-        "Weight": "12.4 kg",
-        "Height": "0.6 m",
-        "Next Evolution Requirements": {
-            "Amount": 25,
-            "Family": 60,
-            "Name": "Poliwag candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "061",
-                "Name": "Poliwhirl"
-            },
-            {
-                "Number": "062",
-                "Name": "Poliwrath"
-            }
-        ],
-        "Special Attack(s)": [
-            "Body Slam",
-            "Bubble Beam",
-            "Mud Bomb"
-        ],
-        "BaseAttack": 108,
-        "BaseDefense": 98,
-        "BaseStamina": 80,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.15,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "061",
-        "Name": "Poliwhirl",
-        "Classification": "Tadpole Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Bubble",
-            "Mud Shot"
-        ],
-        "Weight": "20.0 kg",
-        "Height": "1.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "060",
-                "Name": "Poliwag"
-            }
-        ],
-        "Next Evolution Requirements": {
-            "Amount": 100,
-            "Family": 60,
-            "Name": "Poliwag candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "062",
-                "Name": "Poliwrath"
-            }
-        ],
-        "Special Attack(s)": [
-            "Bubble Beam",
-            "Mud Bomb",
-            "Scald"
-        ],
-        "BaseAttack": 132,
-        "BaseDefense": 132,
-        "BaseStamina": 130,
-        "CaptureRate": 0.2,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "062",
-        "Name": "Poliwrath",
-        "Classification": "Tadpole Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Type II": [
-            "Fighting"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass",
-            "Flying",
-            "Psychic",
-            "Fairy"
-        ],
-        "Fast Attack(s)": [
-            "Bubble",
-            "Mud Shot"
-        ],
-        "Weight": "54.0 kg",
-        "Height": "1.3 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "060",
-                "Name": "Poliwag"
-            },
-            {
-                "Number": "061",
-                "Name": "Poliwhirl"
-            }
-        ],
-        "Special Attack(s)": [
-            "Hydro Pump",
-            "Ice Punch",
-            "Submission"
-        ],
-        "BaseAttack": 180,
-        "BaseDefense": 202,
-        "BaseStamina": 180,
-        "CaptureRate": 0.1,
-        "FleeRate": 0.05,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "063",
-        "Name": "Abra",
-        "Classification": "Psi Pokemon",
-        "Type I": [
-            "Psychic"
-        ],
-        "Weaknesses": [
-            "Bug",
-            "Ghost",
-            "Dark"
-        ],
-        "Fast Attack(s)": [
-            "Zen Headbutt"
-        ],
-        "Weight": "19.5 kg",
-        "Height": "0.9 m",
-        "Next Evolution Requirements": {
-            "Amount": 25,
-            "Family": 63,
-            "Name": "Abra candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "064",
-                "Name": "Kadabra"
-            },
-            {
-                "Number": "065",
-                "Name": "Alakazam"
-            }
-        ],
-        "Special Attack(s)": [
-            "Psyshock",
-            "Shadow Ball",
-            "Signal Beam"
-        ],
-        "BaseAttack": 110,
-        "BaseDefense": 76,
-        "BaseStamina": 50,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.99,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "064",
-        "Name": "Kadabra",
-        "Classification": "Psi Pokemon",
-        "Type I": [
-            "Psychic"
-        ],
-        "Weaknesses": [
-            "Bug",
-            "Ghost",
-            "Dark"
-        ],
-        "Fast Attack(s)": [
-            "Confusion",
-            "Psycho Cut"
-        ],
-        "Weight": "56.5 kg",
-        "Height": "1.3 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "063",
-                "Name": "Abra"
-            }
-        ],
-        "Next Evolution Requirements": {
-            "Amount": 100,
-            "Family": 63,
-            "Name": "Abra candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "065",
-                "Name": "Alakazam"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dazzling Gleam",
-            "Psybeam",
-            "Shadow Ball"
-        ],
-        "BaseAttack": 150,
-        "BaseDefense": 112,
-        "BaseStamina": 80,
-        "CaptureRate": 0.2,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "065",
-        "Name": "Alakazam",
-        "Classification": "Psi Pokemon",
-        "Type I": [
-            "Psychic"
-        ],
-        "Weaknesses": [
-            "Bug",
-            "Ghost",
-            "Dark"
-        ],
-        "Fast Attack(s)": [
-            "Confusion",
-            "Psycho Cut"
-        ],
-        "Weight": "48.0 kg",
-        "Height": "1.5 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "063",
-                "Name": "Abra"
-            },
-            {
-                "Number": "064",
-                "Name": "Kadabra"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dazzling Gleam",
-            "Psychic",
-            "Shadow Ball"
-        ],
-        "BaseAttack": 186,
-        "BaseDefense": 152,
-        "BaseStamina": 110,
-        "CaptureRate": 0.1,
-        "FleeRate": 0.05,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "066",
-        "Name": "Machop",
-        "Classification": "Superpower Pokemon",
-        "Type I": [
-            "Fighting"
-        ],
-        "Weaknesses": [
-            "Flying",
-            "Psychic",
-            "Fairy"
-        ],
-        "Fast Attack(s)": [
-            "Karate Chop",
-            "Low Kick"
-        ],
-        "Weight": "19.5 kg",
-        "Height": "0.8 m",
-        "Next Evolution Requirements": {
-            "Amount": 25,
-            "Family": 66,
-            "Name": "Machop candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "067",
-                "Name": "Machoke"
-            },
-            {
-                "Number": "068",
-                "Name": "Machamp"
-            }
-        ],
-        "Special Attack(s)": [
-            "Brick Break",
-            "Cross Chop",
-            "Low Sweep"
-        ],
-        "BaseAttack": 118,
-        "BaseDefense": 96,
-        "BaseStamina": 140,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "067",
-        "Name": "Machoke",
-        "Classification": "Superpower Pokemon",
-        "Type I": [
-            "Fighting"
-        ],
-        "Weaknesses": [
-            "Flying",
-            "Psychic",
-            "Fairy"
-        ],
-        "Fast Attack(s)": [
-            "Karate Chop",
-            "Low Kick"
-        ],
-        "Weight": "70.5 kg",
-        "Height": "1.5 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "066",
-                "Name": "Machop"
-            }
-        ],
-        "Next Evolution Requirements": {
-            "Amount": 100,
-            "Family": 66,
-            "Name": "Machop candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "068",
-                "Name": "Machamp"
-            }
-        ],
-        "Special Attack(s)": [
-            "Brick Break",
-            "Cross Chop",
-            "Submission"
-        ],
-        "BaseAttack": 154,
-        "BaseDefense": 144,
-        "BaseStamina": 160,
-        "CaptureRate": 0.2,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "068",
-        "Name": "Machamp",
-        "Classification": "Superpower Pokemon",
-        "Type I": [
-            "Fighting"
-        ],
-        "Weaknesses": [
-            "Flying",
-            "Psychic",
-            "Fairy"
-        ],
-        "Fast Attack(s)": [
-            "Bullet Punch",
-            "Karate Chop"
-        ],
-        "Weight": "130.0 kg",
-        "Height": "1.6 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "066",
-                "Name": "Machop"
-            },
-            {
-                "Number": "067",
-                "Name": "Machoke"
-            }
-        ],
-        "Special Attack(s)": [
-            "Cross Chop",
-            "Stone Edge",
-            "Submission"
-        ],
-        "BaseAttack": 198,
-        "BaseDefense": 180,
-        "BaseStamina": 180,
-        "CaptureRate": 0.1,
-        "FleeRate": 0.05,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "069",
-        "Name": "Bellsprout",
-        "Classification": "Flower Pokemon",
-        "Type I": [
-            "Grass"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Ice",
-            "Flying",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Acid",
-            "Vine Whip"
-        ],
-        "Weight": "4.0 kg",
-        "Height": "0.7 m",
-        "Next Evolution Requirements": {
-            "Amount": 25,
-            "Family": 69,
-            "Name": "Bellsprout candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "070",
-                "Name": "Weepinbell"
-            },
-            {
-                "Number": "071",
-                "Name": "Victreebel"
-            }
-        ],
-        "Special Attack(s)": [
-            "Power Whip",
-            "Sludge Bomb",
-            "Wrap"
-        ],
-        "BaseAttack": 158,
-        "BaseDefense": 78,
-        "BaseStamina": 100,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.15,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "070",
-        "Name": "Weepinbell",
-        "Classification": "Flycatcher Pokemon",
-        "Type I": [
-            "Grass"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Ice",
-            "Flying",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Acid",
-            "Razor Leaf"
-        ],
-        "Weight": "6.4 kg",
-        "Height": "1.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "069",
-                "Name": "Bellsprout"
-            }
-        ],
-        "Next Evolution Requirements": {
-            "Amount": 100,
-            "Family": 69,
-            "Name": "Bellsprout candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "071",
-                "Name": "Victreebel"
-            }
-        ],
-        "Special Attack(s)": [
-            "Power Whip",
-            "Seed Bomb",
-            "Sludge Bomb"
-        ],
-        "BaseAttack": 190,
-        "BaseDefense": 110,
-        "BaseStamina": 130,
-        "CaptureRate": 0.2,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "071",
-        "Name": "Victreebel",
-        "Classification": "Flycatcher Pokemon",
-        "Type I": [
-            "Grass"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Ice",
-            "Flying",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Acid",
-            "Razor Leaf"
-        ],
-        "Weight": "15.5 kg",
-        "Height": "1.7 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "069",
-                "Name": "Bellsprout"
-            },
-            {
-                "Number": "070",
-                "Name": "Weepinbell"
-            }
-        ],
-        "Special Attack(s)": [
-            "Leaf Blade",
-            "Sludge Bomb",
-            "Solar Beam"
-        ],
-        "BaseAttack": 222,
-        "BaseDefense": 152,
-        "BaseStamina": 160,
-        "CaptureRate": 0.1,
-        "FleeRate": 0.05,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "072",
-        "Name": "Tentacool",
-        "Classification": "Jellyfish Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Ground",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Bubble",
-            "Poison Sting"
-        ],
-        "Weight": "45.5 kg",
-        "Height": "0.9 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 72,
-            "Name": "Tentacool candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "073",
-                "Name": "Tentacruel"
-            }
-        ],
-        "Special Attack(s)": [
-            "Bubble Beam",
-            "Water Pulse",
-            "Wrap"
-        ],
-        "BaseAttack": 106,
-        "BaseDefense": 136,
-        "BaseStamina": 80,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.15,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "073",
-        "Name": "Tentacruel",
-        "Classification": "Jellyfish Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Ground",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Acid",
-            "Poison Jab"
-        ],
-        "Weight": "55.0 kg",
-        "Height": "1.6 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "072",
-                "Name": "Tentacool"
-            }
-        ],
-        "Special Attack(s)": [
-            "Blizzard",
-            "Hydro Pump",
-            "Sludge Wave"
-        ],
-        "BaseAttack": 170,
-        "BaseDefense": 196,
-        "BaseStamina": 160,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "074",
-        "Name": "Geodude",
-        "Classification": "Rock Pokemon",
-        "Type I": [
-            "Rock"
-        ],
-        "Type II": [
-            "Ground"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Grass",
-            "Ice",
-            "Fighting",
-            "Ground",
-            "Steel"
-        ],
-        "Fast Attack(s)": [
-            "Rock Throw",
-            "Tackle"
-        ],
-        "Weight": "20.0 kg",
-        "Height": "0.4 m",
-        "Next Evolution Requirements": {
-            "Amount": 25,
-            "Family": 74,
-            "Name": "Geodude candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "075",
-                "Name": "Graveler"
-            },
-            {
-                "Number": "076",
-                "Name": "Golem"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dig",
-            "Rock Slide",
-            "Rock Tomb"
-        ],
-        "BaseAttack": 106,
-        "BaseDefense": 118,
-        "BaseStamina": 80,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "075",
-        "Name": "Graveler",
-        "Classification": "Rock Pokemon",
-        "Type I": [
-            "Rock"
-        ],
-        "Type II": [
-            "Ground"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Grass",
-            "Ice",
-            "Fighting",
-            "Ground",
-            "Steel"
-        ],
-        "Fast Attack(s)": [
-            "Mud Shot",
-            "Mud Slap",
-            "Rock Throw"
-        ],
-        "Weight": "105.0 kg",
-        "Height": "1.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "074",
-                "Name": "Geodude"
-            }
-        ],
-        "Next Evolution Requirements": {
-            "Amount": 100,
-            "Family": 74,
-            "Name": "Geodude candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "076",
-                "Name": "Golem"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dig",
-            "Rock Slide",
-            "Stone Edge"
-        ],
-        "BaseAttack": 142,
-        "BaseDefense": 156,
-        "BaseStamina": 110,
-        "CaptureRate": 0.2,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "076",
-        "Name": "Golem",
-        "Classification": "Megaton Pokemon",
-        "Type I": [
-            "Rock"
-        ],
-        "Type II": [
-            "Ground"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Grass",
-            "Ice",
-            "Fighting",
-            "Ground",
-            "Steel"
-        ],
-        "Fast Attack(s)": [
-            "Mud Shot",
-            "Mud Slap",
-            "Rock Throw"
-        ],
-        "Weight": "300.0 kg",
-        "Height": "1.4 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "074",
-                "Name": "Geodude"
-            },
-            {
-                "Number": "075",
-                "Name": "Graveler"
-            }
-        ],
-        "Special Attack(s)": [
-            "Ancient Power",
-            "Earthquake",
-            "Stone Edge"
-        ],
-        "BaseAttack": 176,
-        "BaseDefense": 198,
-        "BaseStamina": 160,
-        "CaptureRate": 0.1,
-        "FleeRate": 0.05,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "077",
-        "Name": "Ponyta",
-        "Classification": "Fire Horse Pokemon",
-        "Type I": [
-            "Fire"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Ground",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Ember",
-            "Tackle"
-        ],
-        "Weight": "30.0 kg",
-        "Height": "1.0 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 77,
-            "Name": "Ponyta candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "078",
-                "Name": "Rapidash"
-            }
-        ],
-        "Special Attack(s)": [
-            "Fire Blast",
-            "Flame Charge",
-            "Flame Wheel"
-        ],
-        "BaseAttack": 168,
-        "BaseDefense": 138,
-        "BaseStamina": 100,
-        "CaptureRate": 0.32,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "078",
-        "Name": "Rapidash",
-        "Classification": "Fire Horse Pokemon",
-        "Type I": [
-            "Fire"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Ground",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Ember",
-            "Low Kick"
-        ],
-        "Weight": "95.0 kg",
-        "Height": "1.7 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "077",
-                "Name": "Ponyta"
-            }
-        ],
-        "Special Attack(s)": [
-            "Drill Run",
-            "Fire Blast",
-            "Heat Wave"
-        ],
-        "BaseAttack": 200,
-        "BaseDefense": 170,
-        "BaseStamina": 130,
-        "CaptureRate": 0.12,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "079",
-        "Name": "Slowpoke",
-        "Classification": "Dopey Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Type II": [
-            "Psychic"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass",
-            "Bug",
-            "Ghost",
-            "Dark"
-        ],
-        "Fast Attack(s)": [
-            "Confusion",
-            "Water Gun"
-        ],
-        "Weight": "36.0 kg",
-        "Height": "1.2 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 79,
-            "Name": "Slowpoke candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "080",
-                "Name": "Slowbro"
-            }
-        ],
-        "Special Attack(s)": [
-            "Psychic",
-            "Psyshock",
-            "Water Pulse"
-        ],
-        "BaseAttack": 110,
-        "BaseDefense": 110,
-        "BaseStamina": 180,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "080",
-        "Name": "Slowbro",
-        "Classification": "Hermit Crab Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Type II": [
-            "Psychic"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass",
-            "Bug",
-            "Ghost",
-            "Dark"
-        ],
-        "Fast Attack(s)": [
-            "Confusion",
-            "Water Gun"
-        ],
-        "Weight": "78.5 kg",
-        "Height": "1.6 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "079",
-                "Name": "Slowpoke"
-            }
-        ],
-        "Special Attack(s)": [
-            "Ice Beam",
-            "Psychic",
-            "Water Pulse"
-        ],
-        "BaseAttack": 184,
-        "BaseDefense": 198,
-        "BaseStamina": 190,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "081",
-        "Name": "Magnemite",
-        "Classification": "Magnet Pokemon",
-        "Type I": [
-            "Electric"
-        ],
-        "Type II": [
-            "Steel"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Water",
-            "Ground"
-        ],
-        "Fast Attack(s)": [
-            "Spark",
-            "Thunder Shock"
-        ],
-        "Weight": "6.0 kg",
-        "Height": "0.3 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 81,
-            "Name": "Magnemite candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "082",
-                "Name": "Magneton"
-            }
-        ],
-        "Special Attack(s)": [
-            "Discharge",
-            "Magnet Bomb",
-            "Thunderbolt"
-        ],
-        "BaseAttack": 128,
-        "BaseDefense": 138,
-        "BaseStamina": 50,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "082",
-        "Name": "Magneton",
-        "Classification": "Magnet Pokemon",
-        "Type I": [
-            "Electric"
-        ],
-        "Type II": [
-            "Steel"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Water",
-            "Ground"
-        ],
-        "Fast Attack(s)": [
-            "Spark",
-            "Thunder Shock"
-        ],
-        "Weight": "60.0 kg",
-        "Height": "1.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "081",
-                "Name": "Magnemite"
-            }
-        ],
-        "Special Attack(s)": [
-            "Discharge",
-            "Flash Cannon",
-            "Magnet Bomb"
-        ],
-        "BaseAttack": 186,
-        "BaseDefense": 180,
-        "BaseStamina": 100,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "083",
-        "Name": "Farfetch'd",
-        "Classification": "Wild Duck Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Cut",
-            "Fury Cutter"
-        ],
-        "Special Attack(s)": [
-            "Aerial Ace",
-            "Air Cutter",
-            "Leaf Blade"
-        ],
-        "Weight": "15.0 kg",
-        "Height": "0.8 m",
-        "BaseAttack": 138,
-        "BaseDefense": 132,
-        "BaseStamina": 104,
-        "CaptureRate": 0.24,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "084",
-        "Name": "Doduo",
-        "Classification": "Twin Bird Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Peck",
-            "Quick Attack"
-        ],
-        "Weight": "39.2 kg",
-        "Height": "1.4 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 84,
-            "Name": "Doduo candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "085",
-                "Name": "Dodrio"
-            }
-        ],
-        "Special Attack(s)": [
-            "Aerial Ace",
-            "Drill Peck",
-            "Swift"
-        ],
-        "BaseAttack": 126,
-        "BaseDefense": 96,
-        "BaseStamina": 70,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "085",
-        "Name": "Dodrio",
-        "Classification": "Triple Bird Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Feint Attack",
-            "Steel Wing"
-        ],
-        "Weight": "85.2 kg",
-        "Height": "1.8 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "084",
-                "Name": "Doduo"
-            }
-        ],
-        "Special Attack(s)": [
-            "Aerial Ace",
-            "Air Cutter",
-            "Drill Peck"
-        ],
-        "BaseAttack": 182,
-        "BaseDefense": 150,
-        "BaseStamina": 120,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "086",
-        "Name": "Seel",
-        "Classification": "Sea Lion Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Ice Shard",
-            "Lick",
-            "Water Gun"
-        ],
-        "Weight": "90.0 kg",
-        "Height": "1.1 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 86,
-            "Name": "Seel candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "087",
-                "Name": "Dewgong"
-            }
-        ],
-        "Special Attack(s)": [
-            "Aqua Jet",
-            "Aqua Tail",
-            "Icy Wind"
-        ],
-        "BaseAttack": 104,
-        "BaseDefense": 138,
-        "BaseStamina": 130,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "087",
-        "Name": "Dewgong",
-        "Classification": "Sea Lion Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Type II": [
-            "Ice"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass",
-            "Fighting",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Frost Breath",
-            "Ice Shard"
-        ],
-        "Weight": "120.0 kg",
-        "Height": "1.7 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "086",
-                "Name": "Seel"
-            }
-        ],
-        "Special Attack(s)": [
-            "Aqua Jet",
-            "Blizzard",
-            "Icy Wind"
-        ],
-        "BaseAttack": 156,
-        "BaseDefense": 192,
-        "BaseStamina": 180,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "088",
-        "Name": "Grimer",
-        "Classification": "Sludge Pokemon",
-        "Type I": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Ground",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Acid",
-            "Mud Slap",
-            "Poison Jab"
-        ],
-        "Weight": "30.0 kg",
-        "Height": "0.9 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 88,
-            "Name": "Grimer candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "089",
-                "Name": "Muk"
-            }
-        ],
-        "Special Attack(s)": [
-            "Mud Bomb",
-            "Sludge",
-            "Sludge Bomb"
-        ],
-        "BaseAttack": 124,
-        "BaseDefense": 110,
-        "BaseStamina": 160,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "089",
-        "Name": "Muk",
-        "Classification": "Sludge Pokemon",
-        "Type I": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Ground",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Acid",
-            "Lick",
-            "Poison Jab"
-        ],
-        "Weight": "30.0 kg",
-        "Height": "1.2 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "088",
-                "Name": "Grimer"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dark Pulse",
-            "Gunk Shot",
-            "Sludge Wave"
-        ],
-        "BaseAttack": 180,
-        "BaseDefense": 188,
-        "BaseStamina": 210,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "090",
-        "Name": "Shellder",
-        "Classification": "Bivalve Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Ice Shard",
-            "Tackle"
-        ],
-        "Weight": "4.0 kg",
-        "Height": "0.3 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 90,
-            "Name": "Shellder candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "091",
-                "Name": "Cloyster"
-            }
-        ],
-        "Special Attack(s)": [
-            "Bubble Beam",
-            "Icy Wind",
-            "Water Pulse"
-        ],
-        "BaseAttack": 120,
-        "BaseDefense": 112,
-        "BaseStamina": 60,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "091",
-        "Name": "Cloyster",
-        "Classification": "Bivalve Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Type II": [
-            "Ice"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass",
-            "Fighting",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Frost Breath",
-            "Ice Shard"
-        ],
-        "Weight": "132.5 kg",
-        "Height": "1.5 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "090",
-                "Name": "Shellder"
-            }
-        ],
-        "Special Attack(s)": [
-            "Blizzard",
-            "Hydro Pump",
-            "Icy Wind"
-        ],
-        "BaseAttack": 196,
-        "BaseDefense": 196,
-        "BaseStamina": 100,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "092",
-        "Name": "Gastly",
-        "Classification": "Gas Pokemon",
-        "Type I": [
-            "Ghost"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Ground",
-            "Psychic",
-            "Ghost",
-            "Dark"
-        ],
-        "Fast Attack(s)": [
-            "Lick",
-            "Sucker Punch"
-        ],
-        "Weight": "0.1 kg",
-        "Height": "1.3 m",
-        "Next Evolution Requirements": {
-            "Amount": 25,
-            "Family": 92,
-            "Name": "Gastly candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "093",
-                "Name": "Haunter"
-            },
-            {
-                "Number": "094",
-                "Name": "Gengar"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dark Pulse",
-            "Ominous Wind",
-            "Sludge Bomb"
-        ],
-        "BaseAttack": 136,
-        "BaseDefense": 82,
-        "BaseStamina": 60,
-        "CaptureRate": 0.32,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "093",
-        "Name": "Haunter",
-        "Classification": "Gas Pokemon",
-        "Type I": [
-            "Ghost"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Ground",
-            "Psychic",
-            "Ghost",
-            "Dark"
-        ],
-        "Fast Attack(s)": [
-            "Lick",
-            "Shadow Claw"
-        ],
-        "Weight": "0.1 kg",
-        "Height": "1.6 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "092",
-                "Name": "Gastly"
-            }
-        ],
-        "Next Evolution Requirements": {
-            "Amount": 100,
-            "Family": 92,
-            "Name": "Gastly candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "094",
-                "Name": "Gengar"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dark Pulse",
-            "Shadow Ball",
-            "Sludge Bomb"
-        ],
-        "BaseAttack": 172,
-        "BaseDefense": 118,
-        "BaseStamina": 90,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "094",
-        "Name": "Gengar",
-        "Classification": "Shadow Pokemon",
-        "Type I": [
-            "Ghost"
-        ],
-        "Type II": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Ground",
-            "Psychic",
-            "Ghost",
-            "Dark"
-        ],
-        "Fast Attack(s)": [
-            "Shadow Claw",
-            "Sucker Punch"
-        ],
-        "Weight": "40.5 kg",
-        "Height": "1.5 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "092",
-                "Name": "Gastly"
-            },
-            {
-                "Number": "093",
-                "Name": "Haunter"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dark Pulse",
-            "Shadow Ball",
-            "Sludge Bomb",
-            "Sludge Wave"
-        ],
-        "BaseAttack": 204,
-        "BaseDefense": 156,
-        "BaseStamina": 120,
-        "CaptureRate": 0.08,
-        "FleeRate": 0.05,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "095",
-        "Name": "Onix",
-        "Classification": "Rock Snake Pokemon",
-        "Type I": [
-            "Rock"
-        ],
-        "Type II": [
-            "Ground"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Grass",
-            "Ice",
-            "Fighting",
-            "Ground",
-            "Steel"
-        ],
-        "Fast Attack(s)": [
-            "Rock Throw",
-            "Tackle"
-        ],
-        "Weight": "210.0 kg",
-        "Height": "8.8 m",
-        "Special Attack(s)": [
-            "Iron Head",
-            "Rock Slide",
-            "Stone Edge"
-        ],
-        "BaseAttack": 90,
-        "BaseDefense": 186,
-        "BaseStamina": 70,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "096",
-        "Name": "Drowzee",
-        "Classification": "Hypnosis Pokemon",
-        "Type I": [
-            "Psychic"
-        ],
-        "Weaknesses": [
-            "Bug",
-            "Ghost",
-            "Dark"
-        ],
-        "Fast Attack(s)": [
-            "Confusion",
-            "Pound"
-        ],
-        "Weight": "32.4 kg",
-        "Height": "1.0 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 96,
-            "Name": "Drowzee candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "097",
-                "Name": "Hypno"
-            }
-        ],
-        "Special Attack(s)": [
-            "Psybeam",
-            "Psychic",
-            "Psyshock"
-        ],
-        "BaseAttack": 104,
-        "BaseDefense": 140,
-        "BaseStamina": 120,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "097",
-        "Name": "Hypno",
-        "Classification": "Hypnosis Pokemon",
-        "Type I": [
-            "Psychic"
-        ],
-        "Weaknesses": [
-            "Bug",
-            "Ghost",
-            "Dark"
-        ],
-        "Fast Attack(s)": [
-            "Confusion",
-            "Zen Headbutt"
-        ],
-        "Weight": "75.6 kg",
-        "Height": "1.6 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "096",
-                "Name": "Drowzee"
-            }
-        ],
-        "Special Attack(s)": [
-            "Psychic",
-            "Psyshock",
-            "Shadow Ball"
-        ],
-        "BaseAttack": 162,
-        "BaseDefense": 196,
-        "BaseStamina": 170,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "098",
-        "Name": "Krabby",
-        "Classification": "River Crab Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Bubble",
-            "Mud Shot"
-        ],
-        "Weight": "6.5 kg",
-        "Height": "0.4 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 98,
-            "Name": "Krabby candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "099",
-                "Name": "Kingler"
-            }
-        ],
-        "Special Attack(s)": [
-            "Bubble Beam",
-            "Vice Grip",
-            "Water Pulse"
-        ],
-        "BaseAttack": 116,
-        "BaseDefense": 110,
-        "BaseStamina": 60,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.15,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "099",
-        "Name": "Kingler",
-        "Classification": "Pincer Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Metal Claw",
-            "Mud Shot"
-        ],
-        "Weight": "60.0 kg",
-        "Height": "1.3 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "098",
-                "Name": "Krabby"
-            }
-        ],
-        "Special Attack(s)": [
-            "Vice Grip",
-            "Water Pulse",
-            "X Scissor"
-        ],
-        "BaseAttack": 178,
-        "BaseDefense": 168,
-        "BaseStamina": 110,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "100",
-        "Name": "Voltorb",
-        "Classification": "Ball Pokemon",
-        "Type I": [
-            "Electric"
-        ],
-        "Weaknesses": [
-            "Ground"
-        ],
-        "Fast Attack(s)": [
-            "Spark",
-            "Tackle"
-        ],
-        "Weight": "10.4 kg",
-        "Height": "0.5 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 100,
-            "Name": "Voltorb candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "101",
-                "Name": "Electrode"
-            }
-        ],
-        "Special Attack(s)": [
-            "Discharge",
-            "Signal Beam",
-            "Thunderbolt"
-        ],
-        "BaseAttack": 102,
-        "BaseDefense": 124,
-        "BaseStamina": 80,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "101",
-        "Name": "Electrode",
-        "Classification": "Ball Pokemon",
-        "Type I": [
-            "Electric"
-        ],
-        "Weaknesses": [
-            "Ground"
-        ],
-        "Fast Attack(s)": [
-            "Spark",
-            "Tackle"
-        ],
-        "Weight": "66.6 kg",
-        "Height": "1.2 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "100",
-                "Name": "Voltorb"
-            }
-        ],
-        "Special Attack(s)": [
-            "Discharge",
-            "Hyper Beam",
-            "Thunderbolt"
-        ],
-        "BaseAttack": 150,
-        "BaseDefense": 174,
-        "BaseStamina": 120,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "102",
-        "Name": "Exeggcute",
-        "Classification": "Egg Pokemon",
-        "Type I": [
-            "Grass"
-        ],
-        "Type II": [
-            "Psychic"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Ice",
-            "Poison",
-            "Flying",
-            "Bug",
-            "Ghost",
-            "Dark"
-        ],
-        "Fast Attack(s)": [
-            "Confusion"
-        ],
-        "Weight": "2.5 kg",
-        "Height": "0.4 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 102,
-            "Name": "Exeggcute candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "103",
-                "Name": "Exeggutor"
-            }
-        ],
-        "Special Attack(s)": [
-            "Ancient Power",
-            "Psychic",
-            "Seed Bomb"
-        ],
-        "BaseAttack": 110,
-        "BaseDefense": 132,
-        "BaseStamina": 120,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "103",
-        "Name": "Exeggutor",
-        "Classification": "Coconut Pokemon",
-        "Type I": [
-            "Grass"
-        ],
-        "Type II": [
-            "Psychic"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Ice",
-            "Poison",
-            "Flying",
-            "Bug",
-            "Ghost",
-            "Dark"
-        ],
-        "Fast Attack(s)": [
-            "Confusion",
-            "Zen Headbutt"
-        ],
-        "Weight": "120.0 kg",
-        "Height": "2.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "102",
-                "Name": "Exeggcute"
-            }
-        ],
-        "Special Attack(s)": [
-            "Psychic",
-            "Seed Bomb",
-            "Solar Beam"
-        ],
-        "BaseAttack": 232,
-        "BaseDefense": 164,
-        "BaseStamina": 190,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "104",
-        "Name": "Cubone",
-        "Classification": "Lonely Pokemon",
-        "Type I": [
-            "Ground"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Grass",
-            "Ice"
-        ],
-        "Fast Attack(s)": [
-            "Mud Slap",
-            "Rock Smash"
-        ],
-        "Weight": "6.5 kg",
-        "Height": "0.4 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 104,
-            "Name": "Cubone candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "105",
-                "Name": "Marowak"
-            }
-        ],
-        "Special Attack(s)": [
-            "Bone Club",
-            "Bulldoze",
-            "Dig"
-        ],
-        "BaseAttack": 102,
-        "BaseDefense": 150,
-        "BaseStamina": 100,
-        "CaptureRate": 0.32,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "105",
-        "Name": "Marowak",
-        "Classification": "Bone Keeper Pokemon",
-        "Type I": [
-            "Ground"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Grass",
-            "Ice"
-        ],
-        "Fast Attack(s)": [
-            "Mud Slap",
-            "Rock Smash"
-        ],
-        "Weight": "45.0 kg",
-        "Height": "1.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "104",
-                "Name": "Cubone"
-            }
-        ],
-        "Special Attack(s)": [
-            "Bone Club",
-            "Dig",
-            "Earthquake"
-        ],
-        "BaseAttack": 140,
-        "BaseDefense": 202,
-        "BaseStamina": 120,
-        "CaptureRate": 0.12,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "106",
-        "Name": "Hitmonlee",
-        "Classification": "Kicking Pokemon",
-        "Type I": [
-            "Fighting"
-        ],
-        "Weaknesses": [
-            "Flying",
-            "Psychic",
-            "Fairy"
-        ],
-        "Fast Attack(s)": [
-            "Low Kick",
-            "Rock Smash"
-        ],
-        "Weight": "49.8 kg",
-        "Height": "1.5 m",
-        "Special Attack(s)": [
-            "Brick Break",
-            "Low Sweep",
-            "Stomp",
-            "Stone Edge"
-        ],
-        "BaseAttack": 148,
-        "BaseDefense": 172,
-        "BaseStamina": 100,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "107",
-        "Name": "Hitmonchan",
-        "Classification": "Punching Pokemon",
-        "Type I": [
-            "Fighting"
-        ],
-        "Weaknesses": [
-            "Flying",
-            "Psychic",
-            "Fairy"
-        ],
-        "Fast Attack(s)": [
-            "Bullet Punch",
-            "Rock Smash"
-        ],
-        "Weight": "50.2 kg",
-        "Height": "1.4 m",
-        "Special Attack(s)": [
-            "Brick Break",
-            "Fire Punch",
-            "Ice Punch",
-            "Thunder Punch"
-        ],
-        "BaseAttack": 138,
-        "BaseDefense": 204,
-        "BaseStamina": 100,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "108",
-        "Name": "Lickitung",
-        "Classification": "Licking Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Weaknesses": [
-            "Fighting"
-        ],
-        "Fast Attack(s)": [
-            "Lick",
-            "Zen Headbutt"
-        ],
-        "Weight": "65.5 kg",
-        "Height": "1.2 m",
-        "Special Attack(s)": [
-            "Hyper Beam",
-            "Power Whip",
-            "Stomp"
-        ],
-        "BaseAttack": 126,
-        "BaseDefense": 160,
-        "BaseStamina": 180,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "109",
-        "Name": "Koffing",
-        "Classification": "Poison Gas Pokemon",
-        "Type I": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Ground",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Acid",
-            "Tackle"
-        ],
-        "Weight": "1.0 kg",
-        "Height": "0.6 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 109,
-            "Name": "Koffing candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "110",
-                "Name": "Weezing"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dark Pulse",
-            "Sludge",
-            "Sludge Bomb"
-        ],
-        "BaseAttack": 136,
-        "BaseDefense": 142,
-        "BaseStamina": 80,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "110",
-        "Name": "Weezing",
-        "Classification": "Poison Gas Pokemon",
-        "Type I": [
-            "Poison"
-        ],
-        "Weaknesses": [
-            "Ground",
-            "Psychic"
-        ],
-        "Fast Attack(s)": [
-            "Acid",
-            "Tackle"
-        ],
-        "Weight": "9.5 kg",
-        "Height": "1.2 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "109",
-                "Name": "Koffing"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dark Pulse",
-            "Shadow Ball",
-            "Sludge Bomb"
-        ],
-        "BaseAttack": 190,
-        "BaseDefense": 198,
-        "BaseStamina": 130,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "111",
-        "Name": "Rhyhorn",
-        "Classification": "Spikes Pokemon",
-        "Type I": [
-            "Ground"
-        ],
-        "Type II": [
-            "Rock"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Grass",
-            "Ice",
-            "Fighting",
-            "Ground",
-            "Steel"
-        ],
-        "Fast Attack(s)": [
-            "Mud Slap",
-            "Rock Smash"
-        ],
-        "Weight": "115.0 kg",
-        "Height": "1.0 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 111,
-            "Name": "Rhyhorn candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "112",
-                "Name": "Rhydon"
-            }
-        ],
-        "Special Attack(s)": [
-            "Bulldoze",
-            "Horn Attack",
-            "Stomp"
-        ],
-        "BaseAttack": 110,
-        "BaseDefense": 116,
-        "BaseStamina": 160,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "112",
-        "Name": "Rhydon",
-        "Classification": "Drill Pokemon",
-        "Type I": [
-            "Ground"
-        ],
-        "Type II": [
-            "Rock"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Grass",
-            "Ice",
-            "Fighting",
-            "Ground",
-            "Steel"
-        ],
-        "Fast Attack(s)": [
-            "Mud Slap",
-            "Rock Smash"
-        ],
-        "Weight": "120.0 kg",
-        "Height": "1.9 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "111",
-                "Name": "Rhyhorn"
-            }
-        ],
-        "Special Attack(s)": [
-            "Earthquake",
-            "Megahorn",
-            "Stone Edge"
-        ],
-        "BaseAttack": 166,
-        "BaseDefense": 160,
-        "BaseStamina": 210,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "113",
-        "Name": "Chansey",
-        "Classification": "Egg Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Weaknesses": [
-            "Fighting"
-        ],
-        "Fast Attack(s)": [
-            "Pound",
-            "Zen Headbutt"
-        ],
-        "Weight": "34.6 kg",
-        "Height": "1.1 m",
-        "Special Attack(s)": [
-            "Dazzling Gleam",
-            "Hyper Beam",
-            "Psybeam",
-            "Psychic"
-        ],
-        "BaseAttack": 40,
-        "BaseDefense": 60,
-        "BaseStamina": 500,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "114",
-        "Name": "Tangela",
-        "Classification": "Vine Pokemon",
-        "Type I": [
-            "Grass"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Ice",
-            "Poison",
-            "Flying",
-            "Bug"
-        ],
-        "Fast Attack(s)": [
-            "Vine Whip"
-        ],
-        "Weight": "35.0 kg",
-        "Height": "1.0 m",
-        "Special Attack(s)": [
-            "Power Whip",
-            "Sludge Bomb",
-            "Solar Beam"
-        ],
-        "BaseAttack": 164,
-        "BaseDefense": 152,
-        "BaseStamina": 130,
-        "CaptureRate": 0.32,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "115",
-        "Name": "Kangaskhan",
-        "Classification": "Parent Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Weaknesses": [
-            "Fighting"
-        ],
-        "Fast Attack(s)": [
-            "Low Kick",
-            "Mud Slap"
-        ],
-        "Weight": "80.0 kg",
-        "Height": "2.2 m",
-        "Special Attack(s)": [
-            "Brick Break",
-            "Earthquake",
-            "Stomp"
-        ],
-        "BaseAttack": 142,
-        "BaseDefense": 178,
-        "BaseStamina": 210,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "116",
-        "Name": "Horsea",
-        "Classification": "Dragon Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Bubble",
-            "Water Gun"
-        ],
-        "Weight": "8.0 kg",
-        "Height": "0.4 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 116,
-            "Name": "Horsea candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "117",
-                "Name": "Seadra"
-            }
-        ],
-        "Special Attack(s)": [
-            "Bubble Beam",
-            "Dragon Pulse",
-            "Flash Cannon"
-        ],
-        "BaseAttack": 122,
-        "BaseDefense": 100,
-        "BaseStamina": 60,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "117",
-        "Name": "Seadra",
-        "Classification": "Dragon Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Dragon Breath",
-            "Water Gun"
-        ],
-        "Weight": "25.0 kg",
-        "Height": "1.2 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "116",
-                "Name": "Horsea"
-            }
-        ],
-        "Special Attack(s)": [
-            "Blizzard",
-            "Dragon Pulse",
-            "Hydro Pump"
-        ],
-        "BaseAttack": 176,
-        "BaseDefense": 150,
-        "BaseStamina": 110,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "118",
-        "Name": "Goldeen",
-        "Classification": "Goldfish Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Mud Shot",
-            "Peck"
-        ],
-        "Weight": "15.0 kg",
-        "Height": "0.6 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 118,
-            "Name": "Goldeen candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "119",
-                "Name": "Seaking"
-            }
-        ],
-        "Special Attack(s)": [
-            "Aqua Tail",
-            "Horn Attack",
-            "Water Pulse"
-        ],
-        "BaseAttack": 112,
-        "BaseDefense": 126,
-        "BaseStamina": 90,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.15,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "119",
-        "Name": "Seaking",
-        "Classification": "Goldfish Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Peck",
-            "Poison Jab"
-        ],
-        "Weight": "39.0 kg",
-        "Height": "1.3 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "118",
-                "Name": "Goldeen"
-            }
-        ],
-        "Special Attack(s)": [
-            "Drill Run",
-            "Icy Wind",
-            "Megahorn"
-        ],
-        "BaseAttack": 172,
-        "BaseDefense": 160,
-        "BaseStamina": 160,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "120",
-        "Name": "Staryu",
-        "Classification": "Starshape Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Quick Attack",
-            "Tackle",
-            "Water Gun"
-        ],
-        "Weight": "34.5 kg",
-        "Height": "0.8 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 120,
-            "Name": "Staryu candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "121",
-                "Name": "Starmie"
-            }
-        ],
-        "Special Attack(s)": [
-            "Bubble Beam",
-            "Power Gem",
-            "Swift"
-        ],
-        "BaseAttack": 130,
-        "BaseDefense": 128,
-        "BaseStamina": 60,
-        "CaptureRate": 0.4,
-        "FleeRate": 0.15,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "121",
-        "Name": "Starmie",
-        "Classification": "Mysterious Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Type II": [
-            "Psychic"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass",
-            "Bug",
-            "Ghost",
-            "Dark"
-        ],
-        "Fast Attack(s)": [
-            "Quick Attack",
-            "Tackle",
-            "Water Gun"
-        ],
-        "Weight": "80.0 kg",
-        "Height": "1.1 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "120",
-                "Name": "Staryu"
-            }
-        ],
-        "Special Attack(s)": [
-            "Hydro Pump",
-            "Power Gem",
-            "Psybeam",
-            "Psychic"
-        ],
-        "BaseAttack": 194,
-        "BaseDefense": 192,
-        "BaseStamina": 120,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "122",
-        "Name": "Mr. Mime",
-        "Classification": "Barrier Pokemon",
-        "Type I": [
-            "Psychic"
-        ],
-        "Type II": [
-            "Fairy"
-        ],
-        "Weaknesses": [
-            "Bug",
-            "Ghost",
-            "Dark"
-        ],
-        "Fast Attack(s)": [
-            "Confusion",
-            "Zen Headbutt"
-        ],
-        "Weight": "54.5 kg",
-        "Height": "1.3 m",
-        "Special Attack(s)": [
-            "Psybeam",
-            "Psychic",
-            "Shadow Ball"
-        ],
-        "BaseAttack": 154,
-        "BaseDefense": 196,
-        "BaseStamina": 80,
-        "CaptureRate": 0.24,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "123",
-        "Name": "Scyther",
-        "Classification": "Mantis Pokemon",
-        "Type I": [
-            "Bug"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Electric",
-            "Ice",
-            "Flying",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Fury Cutter",
-            "Steel Wing"
-        ],
-        "Weight": "56.0 kg",
-        "Height": "1.5 m",
-        "Special Attack(s)": [
-            "Bug Buzz",
-            "Night Slash",
-            "X Scissor"
-        ],
-        "BaseAttack": 176,
-        "BaseDefense": 180,
-        "BaseStamina": 140,
-        "CaptureRate": 0.24,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "124",
-        "Name": "Jynx",
-        "Classification": "Humanshape Pokemon",
-        "Type I": [
-            "Ice"
-        ],
-        "Type II": [
-            "Psychic"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Bug",
-            "Rock",
-            "Ghost",
-            "Dark",
-            "Steel"
-        ],
-        "Fast Attack(s)": [
-            "Frost Breath",
-            "Pound"
-        ],
-        "Weight": "40.6 kg",
-        "Height": "1.4 m",
-        "Special Attack(s)": [
-            "Draining Kiss",
-            "Ice Punch",
-            "Psyshock"
-        ],
-        "BaseAttack": 172,
-        "BaseDefense": 134,
-        "BaseStamina": 130,
-        "CaptureRate": 0.24,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "125",
-        "Name": "Electabuzz",
-        "Classification": "Electric Pokemon",
-        "Type I": [
-            "Electric"
-        ],
-        "Weaknesses": [
-            "Ground"
-        ],
-        "Fast Attack(s)": [
-            "Low Kick",
-            "Thunder Shock"
-        ],
-        "Weight": "30.0 kg",
-        "Height": "1.1 m",
-        "Special Attack(s)": [
-            "Thunder",
-            "Thunder Punch",
-            "Thunderbolt"
-        ],
-        "BaseAttack": 198,
-        "BaseDefense": 160,
-        "BaseStamina": 130,
-        "CaptureRate": 0.24,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "126",
-        "Name": "Magmar",
-        "Classification": "Spitfire Pokemon",
-        "Type I": [
-            "Fire"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Ground",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Ember",
-            "Karate Chop"
-        ],
-        "Weight": "44.5 kg",
-        "Height": "1.3 m",
-        "Special Attack(s)": [
-            "Fire Blast",
-            "Fire Punch",
-            "Flamethrower"
-        ],
-        "BaseAttack": 214,
-        "BaseDefense": 158,
-        "BaseStamina": 130,
-        "CaptureRate": 0.24,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "127",
-        "Name": "Pinsir",
-        "Classification": "Stagbeetle Pokemon",
-        "Type I": [
-            "Bug"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Flying",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Fury Cutter",
-            "Rock Smash"
-        ],
-        "Weight": "55.0 kg",
-        "Height": "1.5 m",
-        "Special Attack(s)": [
-            "Submission",
-            "Vice Grip",
-            "X Scissor"
-        ],
-        "BaseAttack": 184,
-        "BaseDefense": 186,
-        "BaseStamina": 130,
-        "CaptureRate": 0.24,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "128",
-        "Name": "Tauros",
-        "Classification": "Wild Bull Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Weaknesses": [
-            "Fighting"
-        ],
-        "Fast Attack(s)": [
-            "Tackle",
-            "Zen Headbutt"
-        ],
-        "Weight": "88.4 kg",
-        "Height": "1.4 m",
-        "Special Attack(s)": [
-            "Earthquake",
-            "Horn Attack",
-            "Iron Head"
-        ],
-        "BaseAttack": 148,
-        "BaseDefense": 184,
-        "BaseStamina": 150,
-        "CaptureRate": 0.24,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "129",
-        "Name": "Magikarp",
-        "Classification": "Fish Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Splash"
-        ],
-        "Weight": "10.0 kg",
-        "Height": "0.9 m",
-        "Next Evolution Requirements": {
-            "Amount": 400,
-            "Family": 129,
-            "Name": "Magikarp candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "130",
-                "Name": "Gyarados"
-            }
-        ],
-        "Special Attack(s)": [
-            "Struggle"
-        ],
-        "BaseAttack": 42,
-        "BaseDefense": 84,
-        "BaseStamina": 40,
-        "CaptureRate": 0.56,
-        "FleeRate": 0.15,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "130",
-        "Name": "Gyarados",
-        "Classification": "Atrocious Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Bite",
-            "Dragon Breath"
-        ],
-        "Weight": "235.0 kg",
-        "Height": "6.5 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "129",
-                "Name": "Magikarp"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dragon Pulse",
-            "Hydro Pump",
-            "Twister"
-        ],
-        "BaseAttack": 192,
-        "BaseDefense": 196,
-        "BaseStamina": 190,
-        "CaptureRate": 0.08,
-        "FleeRate": 0.07,
-        "BuddyDistanceNeeded": 1
-    },
-    {
-        "Number": "131",
-        "Name": "Lapras",
-        "Classification": "Transport Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Type II": [
-            "Ice"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass",
-            "Fighting",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Frost Breath",
-            "Ice Shard"
-        ],
-        "Weight": "220.0 kg",
-        "Height": "2.5 m",
-        "Special Attack(s)": [
-            "Blizzard",
-            "Dragon Pulse",
-            "Ice Beam"
-        ],
-        "BaseAttack": 186,
-        "BaseDefense": 190,
-        "BaseStamina": 260,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "132",
-        "Name": "Ditto",
-        "Classification": "Transform Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Weaknesses": [
-            "Fighting"
-        ],
-        "Fast Attack(s)": [
-            "Pound"
-        ],
-        "Special Attack(s)": [
-            "Struggle"
-        ],
-        "Weight": "4.0 kg",
-        "Height": "0.3 m",
-        "BaseAttack": 110,
-        "BaseDefense": 110,
-        "BaseStamina": 96,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "133",
-        "Name": "Eevee",
-        "Classification": "Evolution Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Weaknesses": [
-            "Fighting"
-        ],
-        "Fast Attack(s)": [
-            "Quick Attack",
-            "Tackle"
-        ],
-        "Weight": "6.5 kg",
-        "Height": "0.3 m",
-        "Next Evolution Requirements": {
-            "Amount": 25,
-            "Family": 133,
-            "Name": "Eevee candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "134",
-                "Name": "Vaporeon"
-            },
-            {
-                "Number": "135",
-                "Name": "Jolteon"
-            },
-            {
-                "Number": "136",
-                "Name": "Flareon"
-            }
-        ],
-        "Special Attack(s)": [
-            "Body Slam",
-            "Dig",
-            "Swift"
-        ],
-        "BaseAttack": 114,
-        "BaseDefense": 128,
-        "BaseStamina": 110,
-        "CaptureRate": 0.32,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "134",
-        "Name": "Vaporeon",
-        "Classification": "Bubble Jet Pokemon",
-        "Type I": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass"
-        ],
-        "Fast Attack(s)": [
-            "Water Gun"
-        ],
-        "Weight": "29.0 kg",
-        "Height": "1.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "133",
-                "Name": "Eevee"
-            }
-        ],
-        "Special Attack(s)": [
-            "Aqua Tail",
-            "Hydro Pump",
-            "Water Pulse"
-        ],
-        "BaseAttack": 186,
-        "BaseDefense": 168,
-        "BaseStamina": 260,
-        "CaptureRate": 0.12,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "135",
-        "Name": "Jolteon",
-        "Classification": "Lightning Pokemon",
-        "Type I": [
-            "Electric"
-        ],
-        "Weaknesses": [
-            "Ground"
-        ],
-        "Fast Attack(s)": [
-            "Thunder Shock"
-        ],
-        "Weight": "24.5 kg",
-        "Height": "0.8 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "133",
-                "Name": "Eevee"
-            }
-        ],
-        "Special Attack(s)": [
-            "Discharge",
-            "Thunder",
-            "Thunderbolt"
-        ],
-        "BaseAttack": 192,
-        "BaseDefense": 174,
-        "BaseStamina": 130,
-        "CaptureRate": 0.12,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "136",
-        "Name": "Flareon",
-        "Classification": "Flame Pokemon",
-        "Type I": [
-            "Fire"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Ground",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Ember"
-        ],
-        "Weight": "25.0 kg",
-        "Height": "0.9 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "133",
-                "Name": "Eevee"
-            }
-        ],
-        "Special Attack(s)": [
-            "Fire Blast",
-            "Flamethrower",
-            "Heat Wave"
-        ],
-        "BaseAttack": 238,
-        "BaseDefense": 178,
-        "BaseStamina": 130,
-        "CaptureRate": 0.12,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "137",
-        "Name": "Porygon",
-        "Classification": "Virtual Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Weaknesses": [
-            "Fighting"
-        ],
-        "Fast Attack(s)": [
-            "Quick Attack",
-            "Tackle",
-            "Zen Headbutt"
-        ],
-        "Weight": "36.5 kg",
-        "Height": "0.8 m",
-        "Special Attack(s)": [
-            "Discharge",
-            "Psybeam",
-            "Signal Beam"
-        ],
-        "BaseAttack": 156,
-        "BaseDefense": 158,
-        "BaseStamina": 130,
-        "CaptureRate": 0.32,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 3
-    },
-    {
-        "Number": "138",
-        "Name": "Omanyte",
-        "Classification": "Spiral Pokemon",
-        "Type I": [
-            "Rock"
-        ],
-        "Type II": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass",
-            "Fighting",
-            "Ground"
-        ],
-        "Fast Attack(s)": [
-            "Mud Shot",
-            "Water Gun"
-        ],
-        "Weight": "7.5 kg",
-        "Height": "0.4 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 138,
-            "Name": "Omanyte candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "139",
-                "Name": "Omastar"
-            }
-        ],
-        "Special Attack(s)": [
-            "Ancient Power",
-            "Brine",
-            "Rock Tomb"
-        ],
-        "BaseAttack": 132,
-        "BaseDefense": 160,
-        "BaseStamina": 70,
-        "CaptureRate": 0.32,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "139",
-        "Name": "Omastar",
-        "Classification": "Spiral Pokemon",
-        "Type I": [
-            "Rock"
-        ],
-        "Type II": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass",
-            "Fighting",
-            "Ground"
-        ],
-        "Fast Attack(s)": [
-            "Mud Shot",
-            "Rock Throw",
-            "Water Gun"
-        ],
-        "Weight": "35.0 kg",
-        "Height": "1.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "138",
-                "Name": "Omanyte"
-            }
-        ],
-        "Special Attack(s)": [
-            "Ancient Power",
-            "Hydro Pump",
-            "Rock Slide"
-        ],
-        "BaseAttack": 180,
-        "BaseDefense": 202,
-        "BaseStamina": 140,
-        "CaptureRate": 0.12,
-        "FleeRate": 0.05,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "140",
-        "Name": "Kabuto",
-        "Classification": "Shellfish Pokemon",
-        "Type I": [
-            "Rock"
-        ],
-        "Type II": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass",
-            "Fighting",
-            "Ground"
-        ],
-        "Fast Attack(s)": [
-            "Mud Shot",
-            "Scratch"
-        ],
-        "Weight": "11.5 kg",
-        "Height": "0.5 m",
-        "Next Evolution Requirements": {
-            "Amount": 50,
-            "Family": 140,
-            "Name": "Kabuto candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "141",
-                "Name": "Kabutops"
-            }
-        ],
-        "Special Attack(s)": [
-            "Ancient Power",
-            "Aqua Jet",
-            "Rock Tomb"
-        ],
-        "BaseAttack": 148,
-        "BaseDefense": 142,
-        "BaseStamina": 60,
-        "CaptureRate": 0.32,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "141",
-        "Name": "Kabutops",
-        "Classification": "Shellfish Pokemon",
-        "Type I": [
-            "Rock"
-        ],
-        "Type II": [
-            "Water"
-        ],
-        "Weaknesses": [
-            "Electric",
-            "Grass",
-            "Fighting",
-            "Ground"
-        ],
-        "Fast Attack(s)": [
-            "Fury Cutter",
-            "Mud Shot"
-        ],
-        "Weight": "40.5 kg",
-        "Height": "1.3 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "140",
-                "Name": "Kabuto"
-            }
-        ],
-        "Special Attack(s)": [
-            "Ancient Power",
-            "Stone Edge",
-            "Water Pulse"
-        ],
-        "BaseAttack": 190,
-        "BaseDefense": 190,
-        "BaseStamina": 120,
-        "CaptureRate": 0.12,
-        "FleeRate": 0.05,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "142",
-        "Name": "Aerodactyl",
-        "Classification": "Fossil Pokemon",
-        "Type I": [
-            "Rock"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Electric",
-            "Ice",
-            "Rock",
-            "Steel"
-        ],
-        "Fast Attack(s)": [
-            "Bite",
-            "Steel Wing"
-        ],
-        "Weight": "59.0 kg",
-        "Height": "1.8 m",
-        "Special Attack(s)": [
-            "Ancient Power",
-            "Hyper Beam",
-            "Iron Head"
-        ],
-        "BaseAttack": 182,
-        "BaseDefense": 162,
-        "BaseStamina": 160,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "143",
-        "Name": "Snorlax",
-        "Classification": "Sleeping Pokemon",
-        "Type I": [
-            "Normal"
-        ],
-        "Weaknesses": [
-            "Fighting"
-        ],
-        "Fast Attack(s)": [
-            "Lick",
-            "Zen Headbutt"
-        ],
-        "Weight": "460.0 kg",
-        "Height": "2.1 m",
-        "Special Attack(s)": [
-            "Body Slam",
-            "Earthquake",
-            "Hyper Beam"
-        ],
-        "BaseAttack": 180,
-        "BaseDefense": 180,
-        "BaseStamina": 320,
-        "CaptureRate": 0.16,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "144",
-        "Name": "Articuno",
-        "Classification": "Freeze Pokemon",
-        "Type I": [
-            "Ice"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Fire",
-            "Electric",
-            "Rock",
-            "Steel"
-        ],
-        "Fast Attack(s)": [
-            "Frost Breath"
-        ],
-        "Special Attack(s)": [
-            "Blizzard",
-            "Ice Beam",
-            "Icy Wind"
-        ],
-        "Weight": "55.4 kg",
-        "Height": "1.7 m",
-        "BaseAttack": 198,
-        "BaseDefense": 242,
-        "BaseStamina": 180,
-        "CaptureRate": 0,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "145",
-        "Name": "Zapdos",
-        "Classification": "Electric Pokemon",
-        "Type I": [
-            "Electric"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Ice",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Thunder Shock"
-        ],
-        "Special Attack(s)": [
-            "Discharge",
-            "Thunder",
-            "Thunderbolt"
-        ],
-        "Weight": "52.6 kg",
-        "Height": "1.6 m",
-        "BaseAttack": 232,
-        "BaseDefense": 194,
-        "BaseStamina": 180,
-        "CaptureRate": 0,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "146",
-        "Name": "Moltres",
-        "Classification": "Flame Pokemon",
-        "Type I": [
-            "Fire"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Water",
-            "Electric",
-            "Rock"
-        ],
-        "Fast Attack(s)": [
-            "Ember"
-        ],
-        "Special Attack(s)": [
-            "Fire Blast",
-            "Flamethrower",
-            "Heat Wave"
-        ],
-        "Weight": "60.0 kg",
-        "Height": "2.0 m",
-        "BaseAttack": 242,
-        "BaseDefense": 194,
-        "BaseStamina": 180,
-        "CaptureRate": 0,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "147",
-        "Name": "Dratini",
-        "Classification": "Dragon Pokemon",
-        "Type I": [
-            "Dragon"
-        ],
-        "Weaknesses": [
-            "Ice",
-            "Dragon",
-            "Fairy"
-        ],
-        "Fast Attack(s)": [
-            "Dragon Breath"
-        ],
-        "Weight": "3.3 kg",
-        "Height": "1.8 m",
-        "Next Evolution Requirements": {
-            "Amount": 25,
-            "Family": 147,
-            "Name": "Dratini candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "148",
-                "Name": "Dragonair"
-            },
-            {
-                "Number": "149",
-                "Name": "Dragonite"
-            }
-        ],
-        "Special Attack(s)": [
-            "Aqua Tail",
-            "Twister",
-            "Wrap"
-        ],
-        "BaseAttack": 128,
-        "BaseDefense": 110,
-        "BaseStamina": 82,
-        "CaptureRate": 0.32,
-        "FleeRate": 0.09,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "148",
-        "Name": "Dragonair",
-        "Classification": "Dragon Pokemon",
-        "Type I": [
-            "Dragon"
-        ],
-        "Weaknesses": [
-            "Ice",
-            "Dragon",
-            "Fairy"
-        ],
-        "Fast Attack(s)": [
-            "Dragon Breath"
-        ],
-        "Weight": "16.5 kg",
-        "Height": "4.0 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "147",
-                "Name": "Dratini"
-            }
-        ],
-        "Next Evolution Requirements": {
-            "Amount": 100,
-            "Family": 147,
-            "Name": "Dratini candies"
-        },
-        "Next evolution(s)": [
-            {
-                "Number": "149",
-                "Name": "Dragonite"
-            }
-        ],
-        "Special Attack(s)": [
-            "Aqua Tail",
-            "Dragon Pulse",
-            "Wrap"
-        ],
-        "BaseAttack": 170,
-        "BaseDefense": 152,
-        "BaseStamina": 122,
-        "CaptureRate": 0.08,
-        "FleeRate": 0.06,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "149",
-        "Name": "Dragonite",
-        "Classification": "Dragon Pokemon",
-        "Type I": [
-            "Dragon"
-        ],
-        "Type II": [
-            "Flying"
-        ],
-        "Weaknesses": [
-            "Ice",
-            "Rock",
-            "Dragon",
-            "Fairy"
-        ],
-        "Fast Attack(s)": [
-            "Dragon Breath",
-            "Steel Wing"
-        ],
-        "Weight": "210.0 kg",
-        "Height": "2.2 m",
-        "Previous evolution(s)": [
-            {
-                "Number": "147",
-                "Name": "Dratini"
-            },
-            {
-                "Number": "148",
-                "Name": "Dragonair"
-            }
-        ],
-        "Special Attack(s)": [
-            "Dragon Claw",
-            "Dragon Pulse",
-            "Hyper Beam"
-        ],
-        "BaseAttack": 250,
-        "BaseDefense": 212,
-        "BaseStamina": 182,
-        "CaptureRate": 0.04,
-        "FleeRate": 0.05,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "150",
-        "Name": "Mewtwo",
-        "Classification": "Genetic Pokemon",
-        "Type I": [
-            "Psychic"
-        ],
-        "Weaknesses": [
-            "Bug",
-            "Ghost",
-            "Dark"
-        ],
-        "Fast Attack(s)": [
-            "Confusion",
-            "Psycho Cut"
-        ],
-        "Special Attack(s)": [
-            "Hyper Beam",
-            "Psychic",
-            "Shadow Ball"
-        ],
-        "Weight": "122.0 kg",
-        "Height": "2.0 m",
-        "BaseAttack": 284,
-        "BaseDefense": 202,
-        "BaseStamina": 212,
-        "CaptureRate": 0,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 5
-    },
-    {
-        "Number": "151",
-        "Name": "Mew",
-        "Classification": "New Species Pokemon",
-        "Type I": [
-            "Psychic"
-        ],
-        "Weaknesses": [
-            "Bug",
-            "Ghost",
-            "Dark"
-        ],
-        "Fast Attack(s)": [
-            "Pound"
-        ],
-        "Special Attack(s)": [
-            "Blizzard",
-            "Dragon Pulse",
-            "Earthquake",
-            "Fire Blast",
-            "Hurricane",
-            "Hyper Beam",
-            "Moonblast",
-            "Psychic",
-            "Solar Beam",
-            "Thunder"
-        ],
-        "Weight": "4.0 kg",
-        "Height": "0.4 m",
-        "BaseAttack": 220,
-        "BaseDefense": 220,
-        "BaseStamina": 200,
-        "CaptureRate": 0,
-        "FleeRate": 0.1,
-        "BuddyDistanceNeeded": 5
+        "Number":  "001",
+        "Name":  "Bulbasaur",
+        "Classification":  "Seed Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Flying",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle",
+                               "Vine Whip"
+                           ],
+        "Weight":  "6.9 kg",
+        "Height":  "0.7 m",
+        "Candy":  {
+                      "Name":  "Bulbasaur candies",
+                      "FamilyID":  1
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  1,
+                                            "Name":  "Bulbasaur candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "002",
+                                      "Name":  "Ivysaur"
+                                  },
+                                  {
+                                      "Number":  "003",
+                                      "Name":  "Venusaur"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Power Whip",
+                                  "Seed Bomb",
+                                  "Sludge Bomb"
+                              ],
+        "BaseAttack":  118,
+        "BaseDefense":  118,
+        "BaseStamina":  90,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "002",
+        "Name":  "Ivysaur",
+        "Classification":  "Seed Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Flying",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Razor Leaf",
+                               "Vine Whip"
+                           ],
+        "Weight":  "13.0 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Bulbasaur candies",
+                      "FamilyID":  1
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  100,
+                                            "Family":  1,
+                                            "Name":  "Bulbasaur candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "003",
+                                      "Name":  "Venusaur"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "001",
+                                          "Name":  "Bulbasaur"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Power Whip",
+                                  "Sludge Bomb",
+                                  "Solar Beam"
+                              ],
+        "BaseAttack":  151,
+        "BaseDefense":  151,
+        "BaseStamina":  120,
+        "CaptureRate":  0.08,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "003",
+        "Name":  "Venusaur",
+        "Classification":  "Seed Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Flying",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Razor Leaf",
+                               "Vine Whip"
+                           ],
+        "Weight":  "100.0 kg",
+        "Height":  "2.0 m",
+        "Candy":  {
+                      "Name":  "Bulbasaur candies",
+                      "FamilyID":  1
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "001",
+                                          "Name":  "Bulbasaur"
+                                      },
+                                      {
+                                          "Number":  "002",
+                                          "Name":  "Ivysaur"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Petal Blizzard",
+                                  "Sludge Bomb",
+                                  "Solar Beam"
+                              ],
+        "BaseAttack":  198,
+        "BaseDefense":  198,
+        "BaseStamina":  160,
+        "CaptureRate":  0.04,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "004",
+        "Name":  "Charmander",
+        "Classification":  "Lizard Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Ember",
+                               "Scratch"
+                           ],
+        "Weight":  "8.5 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "Charmander candies",
+                      "FamilyID":  4
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  4,
+                                            "Name":  "Charmander candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "005",
+                                      "Name":  "Charmeleon"
+                                  },
+                                  {
+                                      "Number":  "006",
+                                      "Name":  "Charizard"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Flame Burst",
+                                  "Flame Charge",
+                                  "Flamethrower"
+                              ],
+        "BaseAttack":  116,
+        "BaseDefense":  96,
+        "BaseStamina":  78,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "005",
+        "Name":  "Charmeleon",
+        "Classification":  "Flame Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Ember",
+                               "Scratch"
+                           ],
+        "Weight":  "19.0 kg",
+        "Height":  "1.1 m",
+        "Candy":  {
+                      "Name":  "Charmander candies",
+                      "FamilyID":  4
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  100,
+                                            "Family":  4,
+                                            "Name":  "Charmander candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "006",
+                                      "Name":  "Charizard"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "004",
+                                          "Name":  "Charmander"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Fire Punch",
+                                  "Flame Burst",
+                                  "Flamethrower"
+                              ],
+        "BaseAttack":  158,
+        "BaseDefense":  129,
+        "BaseStamina":  116,
+        "CaptureRate":  0.08,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "006",
+        "Name":  "Charizard",
+        "Classification":  "Flame Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Electric",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Ember",
+                               "Wing Attack"
+                           ],
+        "Weight":  "90.5 kg",
+        "Height":  "1.7 m",
+        "Candy":  {
+                      "Name":  "Charmander candies",
+                      "FamilyID":  4
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "004",
+                                          "Name":  "Charmander"
+                                      },
+                                      {
+                                          "Number":  "005",
+                                          "Name":  "Charmeleon"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Dragon Claw",
+                                  "Fire Blast",
+                                  "Flamethrower"
+                              ],
+        "BaseAttack":  223,
+        "BaseDefense":  176,
+        "BaseStamina":  156,
+        "CaptureRate":  0.04,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "007",
+        "Name":  "Squirtle",
+        "Classification":  "Tiny Turtle Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bubble",
+                               "Tackle"
+                           ],
+        "Weight":  "9.0 kg",
+        "Height":  "0.5 m",
+        "Candy":  {
+                      "Name":  "Squirtle candies",
+                      "FamilyID":  7
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  7,
+                                            "Name":  "Squirtle candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "008",
+                                      "Name":  "Wartortle"
+                                  },
+                                  {
+                                      "Number":  "009",
+                                      "Name":  "Blastoise"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Aqua Jet",
+                                  "Aqua Tail",
+                                  "Water Pulse"
+                              ],
+        "BaseAttack":  94,
+        "BaseDefense":  122,
+        "BaseStamina":  88,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "008",
+        "Name":  "Wartortle",
+        "Classification":  "Turtle Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bite",
+                               "Water Gun"
+                           ],
+        "Weight":  "22.5 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Squirtle candies",
+                      "FamilyID":  7
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  100,
+                                            "Family":  7,
+                                            "Name":  "Squirtle candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "009",
+                                      "Name":  "Blastoise"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "007",
+                                          "Name":  "Squirtle"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Aqua Jet",
+                                  "Hydro Pump",
+                                  "Ice Beam"
+                              ],
+        "BaseAttack":  126,
+        "BaseDefense":  155,
+        "BaseStamina":  118,
+        "CaptureRate":  0.08,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "009",
+        "Name":  "Blastoise",
+        "Classification":  "Shellfish Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bite",
+                               "Water Gun"
+                           ],
+        "Weight":  "85.5 kg",
+        "Height":  "1.6 m",
+        "Candy":  {
+                      "Name":  "Squirtle candies",
+                      "FamilyID":  7
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "007",
+                                          "Name":  "Squirtle"
+                                      },
+                                      {
+                                          "Number":  "008",
+                                          "Name":  "Wartortle"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Flash Cannon",
+                                  "Hydro Pump",
+                                  "Ice Beam"
+                              ],
+        "BaseAttack":  171,
+        "BaseDefense":  210,
+        "BaseStamina":  158,
+        "CaptureRate":  0.04,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "010",
+        "Name":  "Caterpie",
+        "Classification":  "Worm Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Flying",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bug Bite",
+                               "Tackle"
+                           ],
+        "Weight":  "2.9 kg",
+        "Height":  "0.3 m",
+        "Candy":  {
+                      "Name":  "Caterpie candies",
+                      "FamilyID":  10
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  12,
+                                            "Family":  10,
+                                            "Name":  "Caterpie candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "011",
+                                      "Name":  "Metapod"
+                                  },
+                                  {
+                                      "Number":  "012",
+                                      "Name":  "Butterfree"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  55,
+        "BaseDefense":  62,
+        "BaseStamina":  90,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.2,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "011",
+        "Name":  "Metapod",
+        "Classification":  "Cocoon Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Flying",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bug Bite",
+                               "Tackle"
+                           ],
+        "Weight":  "9.9 kg",
+        "Height":  "0.7 m",
+        "Candy":  {
+                      "Name":  "Caterpie candies",
+                      "FamilyID":  10
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  10,
+                                            "Name":  "Caterpie candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "012",
+                                      "Name":  "Butterfree"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "010",
+                                          "Name":  "Caterpie"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  45,
+        "BaseDefense":  94,
+        "BaseStamina":  100,
+        "CaptureRate":  0.2,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "012",
+        "Name":  "Butterfree",
+        "Classification":  "Butterfly Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Electric",
+                           "Ice",
+                           "Flying",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bug Bite",
+                               "Confusion"
+                           ],
+        "Weight":  "32.0 kg",
+        "Height":  "1.1 m",
+        "Candy":  {
+                      "Name":  "Caterpie candies",
+                      "FamilyID":  10
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "010",
+                                          "Name":  "Caterpie"
+                                      },
+                                      {
+                                          "Number":  "011",
+                                          "Name":  "Metapod"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Bug Buzz",
+                                  "Psychic",
+                                  "Signal Beam"
+                              ],
+        "BaseAttack":  167,
+        "BaseDefense":  151,
+        "BaseStamina":  120,
+        "CaptureRate":  0.1,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "013",
+        "Name":  "Weedle",
+        "Classification":  "Hairy Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Flying",
+                           "Psychic",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bug Bite",
+                               "Poison Sting"
+                           ],
+        "Weight":  "3.2 kg",
+        "Height":  "0.3 m",
+        "Candy":  {
+                      "Name":  "Weedle candies",
+                      "FamilyID":  13
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  12,
+                                            "Family":  13,
+                                            "Name":  "Weedle candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "014",
+                                      "Name":  "Kakuna"
+                                  },
+                                  {
+                                      "Number":  "015",
+                                      "Name":  "Beedrill"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  63,
+        "BaseDefense":  55,
+        "BaseStamina":  80,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.2,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "014",
+        "Name":  "Kakuna",
+        "Classification":  "Cocoon Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Flying",
+                           "Psychic",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bug Bite",
+                               "Poison Sting"
+                           ],
+        "Weight":  "10.0 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "Weedle candies",
+                      "FamilyID":  13
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  13,
+                                            "Name":  "Weedle candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "015",
+                                      "Name":  "Beedrill"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "013",
+                                          "Name":  "Weedle"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  46,
+        "BaseDefense":  86,
+        "BaseStamina":  90,
+        "CaptureRate":  0.2,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "015",
+        "Name":  "Beedrill",
+        "Classification":  "Poison Bee Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Flying",
+                           "Psychic",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bug Bite",
+                               "Poison Jab"
+                           ],
+        "Weight":  "29.5 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Weedle candies",
+                      "FamilyID":  13
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "013",
+                                          "Name":  "Weedle"
+                                      },
+                                      {
+                                          "Number":  "014",
+                                          "Name":  "Kakuna"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Aerial Ace",
+                                  "Sludge Bomb",
+                                  "X Scissor"
+                              ],
+        "BaseAttack":  169,
+        "BaseDefense":  150,
+        "BaseStamina":  130,
+        "CaptureRate":  0.1,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "016",
+        "Name":  "Pidgey",
+        "Classification":  "Tiny Bird Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Quick Attack",
+                               "Tackle"
+                           ],
+        "Weight":  "1.8 kg",
+        "Height":  "0.3 m",
+        "Candy":  {
+                      "Name":  "Pidgey candies",
+                      "FamilyID":  16
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  12,
+                                            "Family":  16,
+                                            "Name":  "Pidgey candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "017",
+                                      "Name":  "Pidgeotto"
+                                  },
+                                  {
+                                      "Number":  "018",
+                                      "Name":  "Pidgeot"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Aerial Ace",
+                                  "Air Cutter",
+                                  "Twister"
+                              ],
+        "BaseAttack":  85,
+        "BaseDefense":  76,
+        "BaseStamina":  80,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.2,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "017",
+        "Name":  "Pidgeotto",
+        "Classification":  "Bird Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Steel Wing",
+                               "Wing Attack"
+                           ],
+        "Weight":  "30.0 kg",
+        "Height":  "1.1 m",
+        "Candy":  {
+                      "Name":  "Pidgey candies",
+                      "FamilyID":  16
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  16,
+                                            "Name":  "Pidgey candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "018",
+                                      "Name":  "Pidgeot"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "016",
+                                          "Name":  "Pidgey"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Aerial Ace",
+                                  "Air Cutter",
+                                  "Twister"
+                              ],
+        "BaseAttack":  117,
+        "BaseDefense":  108,
+        "BaseStamina":  126,
+        "CaptureRate":  0.2,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "018",
+        "Name":  "Pidgeot",
+        "Classification":  "Bird Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Steel Wing",
+                               "Wing Attack"
+                           ],
+        "Weight":  "39.5 kg",
+        "Height":  "1.5 m",
+        "Candy":  {
+                      "Name":  "Pidgey candies",
+                      "FamilyID":  16
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "016",
+                                          "Name":  "Pidgey"
+                                      },
+                                      {
+                                          "Number":  "017",
+                                          "Name":  "Pidgeotto"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Aerial Ace",
+                                  "Air Cutter",
+                                  "Hurricane"
+                              ],
+        "BaseAttack":  166,
+        "BaseDefense":  157,
+        "BaseStamina":  166,
+        "CaptureRate":  0.1,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "019",
+        "Name":  "Rattata",
+        "Classification":  "Mouse Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Quick Attack",
+                               "Tackle"
+                           ],
+        "Weight":  "3.5 kg",
+        "Height":  "0.3 m",
+        "Candy":  {
+                      "Name":  "Rattata candies",
+                      "FamilyID":  19
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  19,
+                                            "Name":  "Rattata candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "020",
+                                      "Name":  "Raticate"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Body Slam",
+                                  "Dig",
+                                  "Hyper Fang"
+                              ],
+        "BaseAttack":  103,
+        "BaseDefense":  70,
+        "BaseStamina":  60,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.2,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "020",
+        "Name":  "Raticate",
+        "Classification":  "Mouse Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bite",
+                               "Quick Attack"
+                           ],
+        "Weight":  "18.5 kg",
+        "Height":  "0.7 m",
+        "Candy":  {
+                      "Name":  "Rattata candies",
+                      "FamilyID":  19
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "019",
+                                          "Name":  "Rattata"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Dig",
+                                  "Hyper Beam",
+                                  "Hyper Fang"
+                              ],
+        "BaseAttack":  161,
+        "BaseDefense":  144,
+        "BaseStamina":  110,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "021",
+        "Name":  "Spearow",
+        "Classification":  "Tiny Bird Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Peck",
+                               "Quick Attack"
+                           ],
+        "Weight":  "2.0 kg",
+        "Height":  "0.3 m",
+        "Candy":  {
+                      "Name":  "Spearow candies",
+                      "FamilyID":  21
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  21,
+                                            "Name":  "Spearow candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "022",
+                                      "Name":  "Fearow"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Aerial Ace",
+                                  "Drill Peck",
+                                  "Twister"
+                              ],
+        "BaseAttack":  112,
+        "BaseDefense":  61,
+        "BaseStamina":  80,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.15,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "022",
+        "Name":  "Fearow",
+        "Classification":  "Beak Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Peck",
+                               "Steel Wing"
+                           ],
+        "Weight":  "38.0 kg",
+        "Height":  "1.2 m",
+        "Candy":  {
+                      "Name":  "Spearow candies",
+                      "FamilyID":  21
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "021",
+                                          "Name":  "Spearow"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Aerial Ace",
+                                  "Drill Run",
+                                  "Twister"
+                              ],
+        "BaseAttack":  182,
+        "BaseDefense":  135,
+        "BaseStamina":  130,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "023",
+        "Name":  "Ekans",
+        "Classification":  "Snake Pokemon",
+        "Type I":  [
+                       "Poison"
+                   ],
+        "Weaknesses":  [
+                           "Ground",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Acid",
+                               "Poison Sting"
+                           ],
+        "Weight":  "6.9 kg",
+        "Height":  "2.0 m",
+        "Candy":  {
+                      "Name":  "Ekans candies",
+                      "FamilyID":  23
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  23,
+                                            "Name":  "Ekans candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "024",
+                                      "Name":  "Arbok"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Gunk Shot",
+                                  "Sludge Bomb",
+                                  "Wrap"
+                              ],
+        "BaseAttack":  110,
+        "BaseDefense":  102,
+        "BaseStamina":  70,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.15,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "024",
+        "Name":  "Arbok",
+        "Classification":  "Cobra Pokemon",
+        "Type I":  [
+                       "Poison"
+                   ],
+        "Weaknesses":  [
+                           "Ground",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Acid",
+                               "Bite"
+                           ],
+        "Weight":  "65.0 kg",
+        "Height":  "3.5 m",
+        "Candy":  {
+                      "Name":  "Ekans candies",
+                      "FamilyID":  23
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "023",
+                                          "Name":  "Ekans"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Dark Pulse",
+                                  "Gunk Shot",
+                                  "Sludge Wave"
+                              ],
+        "BaseAttack":  167,
+        "BaseDefense":  158,
+        "BaseStamina":  120,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "025",
+        "Name":  "Pikachu",
+        "Classification":  "Mouse Pokemon",
+        "Type I":  [
+                       "Electric"
+                   ],
+        "Weaknesses":  [
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Quick Attack",
+                               "Thunder Shock"
+                           ],
+        "Weight":  "6.0 kg",
+        "Height":  "0.4 m",
+        "Candy":  {
+                      "Name":  "Pikachu candies",
+                      "FamilyID":  25
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  25,
+                                            "Name":  "Pikachu candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "026",
+                                      "Name":  "Raichu"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "172",
+                                          "Name":  "Pichu"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Discharge",
+                                  "Thunder",
+                                  "Thunderbolt"
+                              ],
+        "BaseAttack":  112,
+        "BaseDefense":  101,
+        "BaseStamina":  70,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "026",
+        "Name":  "Raichu",
+        "Classification":  "Mouse Pokemon",
+        "Type I":  [
+                       "Electric"
+                   ],
+        "Weaknesses":  [
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Spark",
+                               "Thunder Shock"
+                           ],
+        "Weight":  "30.0 kg",
+        "Height":  "0.8 m",
+        "Candy":  {
+                      "Name":  "Pikachu candies",
+                      "FamilyID":  25
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "172",
+                                          "Name":  "Pichu"
+                                      },
+                                      {
+                                          "Number":  "025",
+                                          "Name":  "Pikachu"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Brick Break",
+                                  "Thunder",
+                                  "Thunder Punch"
+                              ],
+        "BaseAttack":  193,
+        "BaseDefense":  165,
+        "BaseStamina":  120,
+        "CaptureRate":  0.08,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "027",
+        "Name":  "Sandshrew",
+        "Classification":  "Mouse Pokemon",
+        "Type I":  [
+                       "Ground"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Ice"
+                       ],
+        "Fast Attack(s)":  [
+                               "Mud Shot",
+                               "Scratch"
+                           ],
+        "Weight":  "12.0 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "Sandshrew candies",
+                      "FamilyID":  27
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  27,
+                                            "Name":  "Sandshrew candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "028",
+                                      "Name":  "Sandslash"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Dig",
+                                  "Rock Slide",
+                                  "Rock Tomb"
+                              ],
+        "BaseAttack":  126,
+        "BaseDefense":  145,
+        "BaseStamina":  100,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "028",
+        "Name":  "Sandslash",
+        "Classification":  "Mouse Pokemon",
+        "Type I":  [
+                       "Ground"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Ice"
+                       ],
+        "Fast Attack(s)":  [
+                               "Metal Claw",
+                               "Mud Shot"
+                           ],
+        "Weight":  "29.5 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Sandshrew candies",
+                      "FamilyID":  27
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "027",
+                                          "Name":  "Sandshrew"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Bulldoze",
+                                  "Earthquake",
+                                  "Rock Tomb"
+                              ],
+        "BaseAttack":  182,
+        "BaseDefense":  202,
+        "BaseStamina":  150,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "029",
+        "Name":  "Nidoran",
+        "Classification":  "Poison Pin Pokemon",
+        "Type I":  [
+                       "Poison"
+                   ],
+        "Weaknesses":  [
+                           "Ground",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bite",
+                               "Poison Sting"
+                           ],
+        "Weight":  "7.0 kg",
+        "Height":  "0.4 m",
+        "Candy":  {
+                      "Name":  "Nidoran Female candies",
+                      "FamilyID":  29
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  29,
+                                            "Name":  "Nidoran Female candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "030",
+                                      "Name":  "Nidorina"
+                                  },
+                                  {
+                                      "Number":  "031",
+                                      "Name":  "Nidoqueen"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Body Slam",
+                                  "Poison Fang",
+                                  "Sludge Bomb"
+                              ],
+        "BaseAttack":  86,
+        "BaseDefense":  94,
+        "BaseStamina":  110,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.15,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "030",
+        "Name":  "Nidorina",
+        "Classification":  "Poison Pin Pokemon",
+        "Type I":  [
+                       "Poison"
+                   ],
+        "Weaknesses":  [
+                           "Ground",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bite",
+                               "Poison Sting"
+                           ],
+        "Weight":  "20.0 kg",
+        "Height":  "0.8 m",
+        "Candy":  {
+                      "Name":  "Nidoran Female candies",
+                      "FamilyID":  29
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  100,
+                                            "Family":  29,
+                                            "Name":  "Nidoran Female candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "031",
+                                      "Name":  "Nidoqueen"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "029",
+                                          "Name":  "Nidoran"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Dig",
+                                  "Poison Fang",
+                                  "Sludge Bomb"
+                              ],
+        "BaseAttack":  117,
+        "BaseDefense":  126,
+        "BaseStamina":  140,
+        "CaptureRate":  0.2,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "031",
+        "Name":  "Nidoqueen",
+        "Classification":  "Drill Pokemon",
+        "Type I":  [
+                       "Poison"
+                   ],
+        "Type II":  [
+                        "Ground"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ice",
+                           "Ground",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bite",
+                               "Poison Jab"
+                           ],
+        "Weight":  "60.0 kg",
+        "Height":  "1.3 m",
+        "Candy":  {
+                      "Name":  "Nidoran Female candies",
+                      "FamilyID":  29
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "029",
+                                          "Name":  "Nidoran"
+                                      },
+                                      {
+                                          "Number":  "030",
+                                          "Name":  "Nidorina"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Earthquake",
+                                  "Sludge Wave",
+                                  "Stone Edge"
+                              ],
+        "BaseAttack":  180,
+        "BaseDefense":  174,
+        "BaseStamina":  180,
+        "CaptureRate":  0.1,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "032",
+        "Name":  "Nidoran",
+        "Classification":  "Poison Pin Pokemon",
+        "Type I":  [
+                       "Poison"
+                   ],
+        "Weaknesses":  [
+                           "Ground",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Peck",
+                               "Poison Sting"
+                           ],
+        "Weight":  "9.0 kg",
+        "Height":  "0.5 m",
+        "Candy":  {
+                      "Name":  "Nidoran Male candies",
+                      "FamilyID":  32
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  32,
+                                            "Name":  "Nidoran Male candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "033",
+                                      "Name":  "Nidorino"
+                                  },
+                                  {
+                                      "Number":  "034",
+                                      "Name":  "Nidoking"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Body Slam",
+                                  "Horn Attack",
+                                  "Sludge Bomb"
+                              ],
+        "BaseAttack":  105,
+        "BaseDefense":  76,
+        "BaseStamina":  92,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.15,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "033",
+        "Name":  "Nidorino",
+        "Classification":  "Poison Pin Pokemon",
+        "Type I":  [
+                       "Poison"
+                   ],
+        "Weaknesses":  [
+                           "Ground",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Poison Jab",
+                               "Poison Sting"
+                           ],
+        "Weight":  "19.5 kg",
+        "Height":  "0.9 m",
+        "Candy":  {
+                      "Name":  "Nidoran Male candies",
+                      "FamilyID":  32
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  100,
+                                            "Family":  32,
+                                            "Name":  "Nidoran Male candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "034",
+                                      "Name":  "Nidoking"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "032",
+                                          "Name":  "Nidoran"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Dig",
+                                  "Horn Attack",
+                                  "Sludge Bomb"
+                              ],
+        "BaseAttack":  137,
+        "BaseDefense":  112,
+        "BaseStamina":  122,
+        "CaptureRate":  0.2,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "034",
+        "Name":  "Nidoking",
+        "Classification":  "Drill Pokemon",
+        "Type I":  [
+                       "Poison"
+                   ],
+        "Type II":  [
+                        "Ground"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ice",
+                           "Ground",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Fury Cutter",
+                               "Poison Jab"
+                           ],
+        "Weight":  "62.0 kg",
+        "Height":  "1.4 m",
+        "Candy":  {
+                      "Name":  "Nidoran Male candies",
+                      "FamilyID":  32
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "032",
+                                          "Name":  "Nidoran"
+                                      },
+                                      {
+                                          "Number":  "033",
+                                          "Name":  "Nidorino"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Earthquake",
+                                  "Megahorn",
+                                  "Sludge Wave"
+                              ],
+        "BaseAttack":  204,
+        "BaseDefense":  157,
+        "BaseStamina":  162,
+        "CaptureRate":  0.1,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "035",
+        "Name":  "Clefairy",
+        "Classification":  "Fairy Pokemon",
+        "Type I":  [
+                       "Fairy"
+                   ],
+        "Weaknesses":  [
+                           "Poison",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Pound",
+                               "Zen Headbutt"
+                           ],
+        "Weight":  "7.5 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "Clefairy candies",
+                      "FamilyID":  35
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  35,
+                                            "Name":  "Clefairy candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "036",
+                                      "Name":  "Clefable"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "173",
+                                          "Name":  "Cleffa"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Body Slam",
+                                  "Disarming Voice",
+                                  "Moonblast"
+                              ],
+        "BaseAttack":  107,
+        "BaseDefense":  116,
+        "BaseStamina":  140,
+        "CaptureRate":  0.24,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "036",
+        "Name":  "Clefable",
+        "Classification":  "Fairy Pokemon",
+        "Type I":  [
+                       "Fairy"
+                   ],
+        "Weaknesses":  [
+                           "Poison",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Pound",
+                               "Zen Headbutt"
+                           ],
+        "Weight":  "40.0 kg",
+        "Height":  "1.3 m",
+        "Candy":  {
+                      "Name":  "Clefairy candies",
+                      "FamilyID":  35
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "173",
+                                          "Name":  "Cleffa"
+                                      },
+                                      {
+                                          "Number":  "035",
+                                          "Name":  "Clefairy"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Dazzling Gleam",
+                                  "Moonblast",
+                                  "Psychic"
+                              ],
+        "BaseAttack":  178,
+        "BaseDefense":  171,
+        "BaseStamina":  190,
+        "CaptureRate":  0.08,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "037",
+        "Name":  "Vulpix",
+        "Classification":  "Fox Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Ember",
+                               "Quick Attack"
+                           ],
+        "Weight":  "9.9 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "Vulpix candies",
+                      "FamilyID":  37
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  37,
+                                            "Name":  "Vulpix candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "038",
+                                      "Name":  "Ninetales"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Body Slam",
+                                  "Flame Charge",
+                                  "Flamethrower"
+                              ],
+        "BaseAttack":  96,
+        "BaseDefense":  122,
+        "BaseStamina":  76,
+        "CaptureRate":  0.24,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "038",
+        "Name":  "Ninetales",
+        "Classification":  "Fox Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Ember",
+                               "Feint Attack"
+                           ],
+        "Weight":  "19.9 kg",
+        "Height":  "1.1 m",
+        "Candy":  {
+                      "Name":  "Vulpix candies",
+                      "FamilyID":  37
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "037",
+                                          "Name":  "Vulpix"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Fire Blast",
+                                  "Flamethrower",
+                                  "Heat Wave"
+                              ],
+        "BaseAttack":  169,
+        "BaseDefense":  204,
+        "BaseStamina":  146,
+        "CaptureRate":  0.08,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "039",
+        "Name":  "Jigglypuff",
+        "Classification":  "Balloon Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Type II":  [
+                        "Fairy"
+                    ],
+        "Weaknesses":  [
+                           "Poison",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Feint Attack",
+                               "Pound"
+                           ],
+        "Weight":  "5.5 kg",
+        "Height":  "0.5 m",
+        "Candy":  {
+                      "Name":  "Jigglypuff candies",
+                      "FamilyID":  39
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  39,
+                                            "Name":  "Jigglypuff candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "040",
+                                      "Name":  "Wigglytuff"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "174",
+                                          "Name":  "Igglybuff"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Body Slam",
+                                  "Dazzling Gleam",
+                                  "Disarming Voice"
+                              ],
+        "BaseAttack":  80,
+        "BaseDefense":  44,
+        "BaseStamina":  230,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "040",
+        "Name":  "Wigglytuff",
+        "Classification":  "Balloon Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Type II":  [
+                        "Fairy"
+                    ],
+        "Weaknesses":  [
+                           "Poison",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Feint Attack",
+                               "Pound"
+                           ],
+        "Weight":  "12.0 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Jigglypuff candies",
+                      "FamilyID":  39
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "174",
+                                          "Name":  "Igglybuff"
+                                      },
+                                      {
+                                          "Number":  "039",
+                                          "Name":  "Jigglypuff"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Dazzling Gleam",
+                                  "Hyper Beam",
+                                  "Play Rough"
+                              ],
+        "BaseAttack":  156,
+        "BaseDefense":  93,
+        "BaseStamina":  280,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "041",
+        "Name":  "Zubat",
+        "Classification":  "Bat Pokemon",
+        "Type I":  [
+                       "Poison"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Psychic",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bite",
+                               "Quick Attack"
+                           ],
+        "Weight":  "7.5 kg",
+        "Height":  "0.8 m",
+        "Candy":  {
+                      "Name":  "Zubat candies",
+                      "FamilyID":  41
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  41,
+                                            "Name":  "Zubat candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "042",
+                                      "Name":  "Golbat"
+                                  },
+                                  {
+                                      "Number":  "169",
+                                      "Name":  "Crobat"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Air Cutter",
+                                  "Poison Fang",
+                                  "Sludge Bomb"
+                              ],
+        "BaseAttack":  83,
+        "BaseDefense":  76,
+        "BaseStamina":  80,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.2,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "042",
+        "Name":  "Golbat",
+        "Classification":  "Bat Pokemon",
+        "Type I":  [
+                       "Poison"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Psychic",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bite",
+                               "Wing Attack"
+                           ],
+        "Weight":  "55.0 kg",
+        "Height":  "1.6 m",
+        "Candy":  {
+                      "Name":  "Zubat candies",
+                      "FamilyID":  41
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "041",
+                                          "Name":  "Zubat"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Air Cutter",
+                                  "Ominous Wind",
+                                  "Poison Fang"
+                              ],
+        "BaseAttack":  161,
+        "BaseDefense":  153,
+        "BaseStamina":  150,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "043",
+        "Name":  "Oddish",
+        "Classification":  "Weed Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Flying",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Acid",
+                               "Razor Leaf"
+                           ],
+        "Weight":  "5.4 kg",
+        "Height":  "0.5 m",
+        "Candy":  {
+                      "Name":  "Oddish candies",
+                      "FamilyID":  43
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  43,
+                                            "Name":  "Oddish candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "044",
+                                      "Name":  "Gloom"
+                                  },
+                                  {
+                                      "Number":  "045",
+                                      "Name":  "Vileplume"
+                                  },
+                                  {
+                                      "Number":  "182",
+                                      "Name":  "Bellossom"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Moonblast",
+                                  "Seed Bomb",
+                                  "Sludge Bomb"
+                              ],
+        "BaseAttack":  131,
+        "BaseDefense":  116,
+        "BaseStamina":  90,
+        "CaptureRate":  0.48,
+        "FleeRate":  0.15,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "044",
+        "Name":  "Gloom",
+        "Classification":  "Weed Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Flying",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Acid",
+                               "Razor Leaf"
+                           ],
+        "Weight":  "8.6 kg",
+        "Height":  "0.8 m",
+        "Candy":  {
+                      "Name":  "Oddish candies",
+                      "FamilyID":  43
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  100,
+                                            "Family":  43,
+                                            "Name":  "Oddish candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "045",
+                                      "Name":  "Vileplume"
+                                  },
+                                  {
+                                      "Number":  "182",
+                                      "Name":  "Bellossom"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "043",
+                                          "Name":  "Oddish"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Moonblast",
+                                  "Petal Blizzard",
+                                  "Sludge Bomb"
+                              ],
+        "BaseAttack":  153,
+        "BaseDefense":  139,
+        "BaseStamina":  120,
+        "CaptureRate":  0.24,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "045",
+        "Name":  "Vileplume",
+        "Classification":  "Flower Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Flying",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Acid",
+                               "Razor Leaf"
+                           ],
+        "Weight":  "18.6 kg",
+        "Height":  "1.2 m",
+        "Candy":  {
+                      "Name":  "Oddish candies",
+                      "FamilyID":  43
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "043",
+                                          "Name":  "Oddish"
+                                      },
+                                      {
+                                          "Number":  "044",
+                                          "Name":  "Gloom"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Moonblast",
+                                  "Petal Blizzard",
+                                  "Solar Beam"
+                              ],
+        "BaseAttack":  202,
+        "BaseDefense":  170,
+        "BaseStamina":  150,
+        "CaptureRate":  0.12,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "046",
+        "Name":  "Paras",
+        "Classification":  "Mushroom Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Grass"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Poison",
+                           "Flying",
+                           "Bug",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bug Bite",
+                               "Scratch"
+                           ],
+        "Weight":  "5.4 kg",
+        "Height":  "0.3 m",
+        "Candy":  {
+                      "Name":  "Paras candies",
+                      "FamilyID":  46
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  46,
+                                            "Name":  "Paras candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "047",
+                                      "Name":  "Parasect"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Cross Poison",
+                                  "Seed Bomb",
+                                  "X Scissor"
+                              ],
+        "BaseAttack":  121,
+        "BaseDefense":  99,
+        "BaseStamina":  70,
+        "CaptureRate":  0.32,
+        "FleeRate":  0.15,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "047",
+        "Name":  "Parasect",
+        "Classification":  "Mushroom Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Grass"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Poison",
+                           "Flying",
+                           "Bug",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bug Bite",
+                               "Fury Cutter"
+                           ],
+        "Weight":  "29.5 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Paras candies",
+                      "FamilyID":  46
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "046",
+                                          "Name":  "Paras"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Cross Poison",
+                                  "Solar Beam",
+                                  "X Scissor"
+                              ],
+        "BaseAttack":  165,
+        "BaseDefense":  146,
+        "BaseStamina":  120,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "048",
+        "Name":  "Venonat",
+        "Classification":  "Insect Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Flying",
+                           "Psychic",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bug Bite",
+                               "Confusion"
+                           ],
+        "Weight":  "30.0 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Venonat candies",
+                      "FamilyID":  48
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  48,
+                                            "Name":  "Venonat candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "049",
+                                      "Name":  "Venomoth"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Poison Fang",
+                                  "Psybeam",
+                                  "Signal Beam"
+                              ],
+        "BaseAttack":  100,
+        "BaseDefense":  102,
+        "BaseStamina":  120,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.15,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "049",
+        "Name":  "Venomoth",
+        "Classification":  "Poison Moth Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Flying",
+                           "Psychic",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bug Bite",
+                               "Confusion"
+                           ],
+        "Weight":  "12.5 kg",
+        "Height":  "1.5 m",
+        "Candy":  {
+                      "Name":  "Venonat candies",
+                      "FamilyID":  48
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "048",
+                                          "Name":  "Venonat"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Bug Buzz",
+                                  "Poison Fang",
+                                  "Psychic"
+                              ],
+        "BaseAttack":  179,
+        "BaseDefense":  150,
+        "BaseStamina":  140,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "050",
+        "Name":  "Diglett",
+        "Classification":  "Mole Pokemon",
+        "Type I":  [
+                       "Ground"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Ice"
+                       ],
+        "Fast Attack(s)":  [
+                               "Mud Slap",
+                               "Scratch"
+                           ],
+        "Weight":  "0.8 kg",
+        "Height":  "0.2 m",
+        "Candy":  {
+                      "Name":  "Diglett candies",
+                      "FamilyID":  50
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  50,
+                                            "Name":  "Diglett candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "051",
+                                      "Name":  "Dugtrio"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Dig",
+                                  "Mud Bomb",
+                                  "Rock Tomb"
+                              ],
+        "BaseAttack":  109,
+        "BaseDefense":  88,
+        "BaseStamina":  20,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "051",
+        "Name":  "Dugtrio",
+        "Classification":  "Mole Pokemon",
+        "Type I":  [
+                       "Ground"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Ice"
+                       ],
+        "Fast Attack(s)":  [
+                               "Mud Slap",
+                               "Sucker Punch"
+                           ],
+        "Weight":  "33.3 kg",
+        "Height":  "0.7 m",
+        "Candy":  {
+                      "Name":  "Diglett candies",
+                      "FamilyID":  50
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "050",
+                                          "Name":  "Diglett"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Earthquake",
+                                  "Mud Bomb",
+                                  "Stone Edge"
+                              ],
+        "BaseAttack":  167,
+        "BaseDefense":  147,
+        "BaseStamina":  70,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "052",
+        "Name":  "Meowth",
+        "Classification":  "Scratch Cat Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bite",
+                               "Scratch"
+                           ],
+        "Weight":  "4.2 kg",
+        "Height":  "0.4 m",
+        "Candy":  {
+                      "Name":  "Meowth candies",
+                      "FamilyID":  52
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  52,
+                                            "Name":  "Meowth candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "053",
+                                      "Name":  "Persian"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Body Slam",
+                                  "Dark Pulse",
+                                  "Night Slash"
+                              ],
+        "BaseAttack":  92,
+        "BaseDefense":  81,
+        "BaseStamina":  80,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.15,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "053",
+        "Name":  "Persian",
+        "Classification":  "Classy Cat Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Feint Attack",
+                               "Scratch"
+                           ],
+        "Weight":  "32.0 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Meowth candies",
+                      "FamilyID":  52
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "052",
+                                          "Name":  "Meowth"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Night Slash",
+                                  "Play Rough",
+                                  "Power Gem"
+                              ],
+        "BaseAttack":  150,
+        "BaseDefense":  139,
+        "BaseStamina":  130,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "054",
+        "Name":  "Psyduck",
+        "Classification":  "Duck Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Water Gun",
+                               "Zen Headbutt"
+                           ],
+        "Weight":  "19.6 kg",
+        "Height":  "0.8 m",
+        "Candy":  {
+                      "Name":  "Psyduck candies",
+                      "FamilyID":  54
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  54,
+                                            "Name":  "Psyduck candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "055",
+                                      "Name":  "Golduck"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Aqua Tail",
+                                  "Cross Chop",
+                                  "Psybeam"
+                              ],
+        "BaseAttack":  122,
+        "BaseDefense":  96,
+        "BaseStamina":  100,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "055",
+        "Name":  "Golduck",
+        "Classification":  "Duck Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Confusion",
+                               "Water Gun"
+                           ],
+        "Weight":  "76.6 kg",
+        "Height":  "1.7 m",
+        "Candy":  {
+                      "Name":  "Psyduck candies",
+                      "FamilyID":  54
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "054",
+                                          "Name":  "Psyduck"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Hydro Pump",
+                                  "Ice Beam",
+                                  "Psychic"
+                              ],
+        "BaseAttack":  191,
+        "BaseDefense":  163,
+        "BaseStamina":  160,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "056",
+        "Name":  "Mankey",
+        "Classification":  "Pig Monkey Pokemon",
+        "Type I":  [
+                       "Fighting"
+                   ],
+        "Weaknesses":  [
+                           "Flying",
+                           "Psychic",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Karate Chop",
+                               "Scratch"
+                           ],
+        "Weight":  "28.0 kg",
+        "Height":  "0.5 m",
+        "Candy":  {
+                      "Name":  "Mankey candies",
+                      "FamilyID":  56
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  56,
+                                            "Name":  "Mankey candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "057",
+                                      "Name":  "Primeape"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Brick Break",
+                                  "Cross Chop",
+                                  "Low Sweep"
+                              ],
+        "BaseAttack":  148,
+        "BaseDefense":  87,
+        "BaseStamina":  80,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "057",
+        "Name":  "Primeape",
+        "Classification":  "Pig Monkey Pokemon",
+        "Type I":  [
+                       "Fighting"
+                   ],
+        "Weaknesses":  [
+                           "Flying",
+                           "Psychic",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Karate Chop",
+                               "Low Kick"
+                           ],
+        "Weight":  "32.0 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Mankey candies",
+                      "FamilyID":  56
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "056",
+                                          "Name":  "Mankey"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Cross Chop",
+                                  "Low Sweep",
+                                  "Night Slash"
+                              ],
+        "BaseAttack":  207,
+        "BaseDefense":  144,
+        "BaseStamina":  130,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "058",
+        "Name":  "Growlithe",
+        "Classification":  "Puppy Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bite",
+                               "Ember"
+                           ],
+        "Weight":  "19.0 kg",
+        "Height":  "0.7 m",
+        "Candy":  {
+                      "Name":  "Growlithe candies",
+                      "FamilyID":  58
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  58,
+                                            "Name":  "Growlithe candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "059",
+                                      "Name":  "Arcanine"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Body Slam",
+                                  "Flame Wheel",
+                                  "Flamethrower"
+                              ],
+        "BaseAttack":  136,
+        "BaseDefense":  96,
+        "BaseStamina":  110,
+        "CaptureRate":  0.24,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "059",
+        "Name":  "Arcanine",
+        "Classification":  "Legendary Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bite",
+                               "Fire Fang"
+                           ],
+        "Weight":  "155.0 kg",
+        "Height":  "1.9 m",
+        "Candy":  {
+                      "Name":  "Growlithe candies",
+                      "FamilyID":  58
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "058",
+                                          "Name":  "Growlithe"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Bulldoze",
+                                  "Fire Blast",
+                                  "Flamethrower"
+                              ],
+        "BaseAttack":  227,
+        "BaseDefense":  166,
+        "BaseStamina":  180,
+        "CaptureRate":  0.08,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "060",
+        "Name":  "Poliwag",
+        "Classification":  "Tadpole Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bubble",
+                               "Mud Shot"
+                           ],
+        "Weight":  "12.4 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "Poliwag candies",
+                      "FamilyID":  60
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  60,
+                                            "Name":  "Poliwag candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "061",
+                                      "Name":  "Poliwhirl"
+                                  },
+                                  {
+                                      "Number":  "062",
+                                      "Name":  "Poliwrath"
+                                  },
+                                  {
+                                      "Number":  "186",
+                                      "Name":  "Politoed"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Body Slam",
+                                  "Bubble Beam",
+                                  "Mud Bomb"
+                              ],
+        "BaseAttack":  101,
+        "BaseDefense":  82,
+        "BaseStamina":  80,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.15,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "061",
+        "Name":  "Poliwhirl",
+        "Classification":  "Tadpole Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bubble",
+                               "Mud Shot"
+                           ],
+        "Weight":  "20.0 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Poliwag candies",
+                      "FamilyID":  60
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  100,
+                                            "Family":  60,
+                                            "Name":  "Poliwag candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "062",
+                                      "Name":  "Poliwrath"
+                                  },
+                                  {
+                                      "Number":  "186",
+                                      "Name":  "Politoed"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "060",
+                                          "Name":  "Poliwag"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Bubble Beam",
+                                  "Mud Bomb",
+                                  "Scald"
+                              ],
+        "BaseAttack":  130,
+        "BaseDefense":  130,
+        "BaseStamina":  130,
+        "CaptureRate":  0.2,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "062",
+        "Name":  "Poliwrath",
+        "Classification":  "Tadpole Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Fighting"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass",
+                           "Flying",
+                           "Psychic",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bubble",
+                               "Mud Shot"
+                           ],
+        "Weight":  "54.0 kg",
+        "Height":  "1.3 m",
+        "Candy":  {
+                      "Name":  "Poliwag candies",
+                      "FamilyID":  60
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "060",
+                                          "Name":  "Poliwag"
+                                      },
+                                      {
+                                          "Number":  "061",
+                                          "Name":  "Poliwhirl"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Hydro Pump",
+                                  "Ice Punch",
+                                  "Submission"
+                              ],
+        "BaseAttack":  182,
+        "BaseDefense":  187,
+        "BaseStamina":  180,
+        "CaptureRate":  0.1,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "063",
+        "Name":  "Abra",
+        "Classification":  "Psi Pokemon",
+        "Type I":  [
+                       "Psychic"
+                   ],
+        "Weaknesses":  [
+                           "Bug",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Zen Headbutt"
+                           ],
+        "Weight":  "19.5 kg",
+        "Height":  "0.9 m",
+        "Candy":  {
+                      "Name":  "Abra candies",
+                      "FamilyID":  63
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  63,
+                                            "Name":  "Abra candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "064",
+                                      "Name":  "Kadabra"
+                                  },
+                                  {
+                                      "Number":  "065",
+                                      "Name":  "Alakazam"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Psyshock",
+                                  "Shadow Ball",
+                                  "Signal Beam"
+                              ],
+        "BaseAttack":  195,
+        "BaseDefense":  103,
+        "BaseStamina":  50,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.99,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "064",
+        "Name":  "Kadabra",
+        "Classification":  "Psi Pokemon",
+        "Type I":  [
+                       "Psychic"
+                   ],
+        "Weaknesses":  [
+                           "Bug",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Confusion",
+                               "Psycho Cut"
+                           ],
+        "Weight":  "56.5 kg",
+        "Height":  "1.3 m",
+        "Candy":  {
+                      "Name":  "Abra candies",
+                      "FamilyID":  63
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  100,
+                                            "Family":  63,
+                                            "Name":  "Abra candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "065",
+                                      "Name":  "Alakazam"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "063",
+                                          "Name":  "Abra"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Dazzling Gleam",
+                                  "Psybeam",
+                                  "Shadow Ball"
+                              ],
+        "BaseAttack":  232,
+        "BaseDefense":  138,
+        "BaseStamina":  80,
+        "CaptureRate":  0.2,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "065",
+        "Name":  "Alakazam",
+        "Classification":  "Psi Pokemon",
+        "Type I":  [
+                       "Psychic"
+                   ],
+        "Weaknesses":  [
+                           "Bug",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Confusion",
+                               "Psycho Cut"
+                           ],
+        "Weight":  "48.0 kg",
+        "Height":  "1.5 m",
+        "Candy":  {
+                      "Name":  "Abra candies",
+                      "FamilyID":  63
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "063",
+                                          "Name":  "Abra"
+                                      },
+                                      {
+                                          "Number":  "064",
+                                          "Name":  "Kadabra"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Dazzling Gleam",
+                                  "Psychic",
+                                  "Shadow Ball"
+                              ],
+        "BaseAttack":  271,
+        "BaseDefense":  194,
+        "BaseStamina":  110,
+        "CaptureRate":  0.1,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "066",
+        "Name":  "Machop",
+        "Classification":  "Superpower Pokemon",
+        "Type I":  [
+                       "Fighting"
+                   ],
+        "Weaknesses":  [
+                           "Flying",
+                           "Psychic",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Karate Chop",
+                               "Low Kick"
+                           ],
+        "Weight":  "19.5 kg",
+        "Height":  "0.8 m",
+        "Candy":  {
+                      "Name":  "Machop candies",
+                      "FamilyID":  66
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  66,
+                                            "Name":  "Machop candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "067",
+                                      "Name":  "Machoke"
+                                  },
+                                  {
+                                      "Number":  "068",
+                                      "Name":  "Machamp"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Brick Break",
+                                  "Cross Chop",
+                                  "Low Sweep"
+                              ],
+        "BaseAttack":  137,
+        "BaseDefense":  88,
+        "BaseStamina":  140,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "067",
+        "Name":  "Machoke",
+        "Classification":  "Superpower Pokemon",
+        "Type I":  [
+                       "Fighting"
+                   ],
+        "Weaknesses":  [
+                           "Flying",
+                           "Psychic",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Karate Chop",
+                               "Low Kick"
+                           ],
+        "Weight":  "70.5 kg",
+        "Height":  "1.5 m",
+        "Candy":  {
+                      "Name":  "Machop candies",
+                      "FamilyID":  66
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  100,
+                                            "Family":  66,
+                                            "Name":  "Machop candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "068",
+                                      "Name":  "Machamp"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "066",
+                                          "Name":  "Machop"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Brick Break",
+                                  "Cross Chop",
+                                  "Submission"
+                              ],
+        "BaseAttack":  177,
+        "BaseDefense":  130,
+        "BaseStamina":  160,
+        "CaptureRate":  0.2,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "068",
+        "Name":  "Machamp",
+        "Classification":  "Superpower Pokemon",
+        "Type I":  [
+                       "Fighting"
+                   ],
+        "Weaknesses":  [
+                           "Flying",
+                           "Psychic",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bullet Punch",
+                               "Karate Chop"
+                           ],
+        "Weight":  "130.0 kg",
+        "Height":  "1.6 m",
+        "Candy":  {
+                      "Name":  "Machop candies",
+                      "FamilyID":  66
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "066",
+                                          "Name":  "Machop"
+                                      },
+                                      {
+                                          "Number":  "067",
+                                          "Name":  "Machoke"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Cross Chop",
+                                  "Stone Edge",
+                                  "Submission"
+                              ],
+        "BaseAttack":  234,
+        "BaseDefense":  162,
+        "BaseStamina":  180,
+        "CaptureRate":  0.1,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "069",
+        "Name":  "Bellsprout",
+        "Classification":  "Flower Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Flying",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Acid",
+                               "Vine Whip"
+                           ],
+        "Weight":  "4.0 kg",
+        "Height":  "0.7 m",
+        "Candy":  {
+                      "Name":  "Bellsprout candies",
+                      "FamilyID":  69
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  69,
+                                            "Name":  "Bellsprout candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "070",
+                                      "Name":  "Weepinbell"
+                                  },
+                                  {
+                                      "Number":  "071",
+                                      "Name":  "Victreebel"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Power Whip",
+                                  "Sludge Bomb",
+                                  "Wrap"
+                              ],
+        "BaseAttack":  139,
+        "BaseDefense":  64,
+        "BaseStamina":  100,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.15,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "070",
+        "Name":  "Weepinbell",
+        "Classification":  "Flycatcher Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Flying",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Acid",
+                               "Razor Leaf"
+                           ],
+        "Weight":  "6.4 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Bellsprout candies",
+                      "FamilyID":  69
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  100,
+                                            "Family":  69,
+                                            "Name":  "Bellsprout candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "071",
+                                      "Name":  "Victreebel"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "069",
+                                          "Name":  "Bellsprout"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Power Whip",
+                                  "Seed Bomb",
+                                  "Sludge Bomb"
+                              ],
+        "BaseAttack":  172,
+        "BaseDefense":  95,
+        "BaseStamina":  130,
+        "CaptureRate":  0.2,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "071",
+        "Name":  "Victreebel",
+        "Classification":  "Flycatcher Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Flying",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Acid",
+                               "Razor Leaf"
+                           ],
+        "Weight":  "15.5 kg",
+        "Height":  "1.7 m",
+        "Candy":  {
+                      "Name":  "Bellsprout candies",
+                      "FamilyID":  69
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "069",
+                                          "Name":  "Bellsprout"
+                                      },
+                                      {
+                                          "Number":  "070",
+                                          "Name":  "Weepinbell"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Leaf Blade",
+                                  "Sludge Bomb",
+                                  "Solar Beam"
+                              ],
+        "BaseAttack":  207,
+        "BaseDefense":  138,
+        "BaseStamina":  160,
+        "CaptureRate":  0.1,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "072",
+        "Name":  "Tentacool",
+        "Classification":  "Jellyfish Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ground",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bubble",
+                               "Poison Sting"
+                           ],
+        "Weight":  "45.5 kg",
+        "Height":  "0.9 m",
+        "Candy":  {
+                      "Name":  "Tentacool candies",
+                      "FamilyID":  72
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  72,
+                                            "Name":  "Tentacool candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "073",
+                                      "Name":  "Tentacruel"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Bubble Beam",
+                                  "Water Pulse",
+                                  "Wrap"
+                              ],
+        "BaseAttack":  97,
+        "BaseDefense":  182,
+        "BaseStamina":  80,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.15,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "073",
+        "Name":  "Tentacruel",
+        "Classification":  "Jellyfish Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ground",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Acid",
+                               "Poison Jab"
+                           ],
+        "Weight":  "55.0 kg",
+        "Height":  "1.6 m",
+        "Candy":  {
+                      "Name":  "Tentacool candies",
+                      "FamilyID":  72
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "072",
+                                          "Name":  "Tentacool"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Blizzard",
+                                  "Hydro Pump",
+                                  "Sludge Wave"
+                              ],
+        "BaseAttack":  166,
+        "BaseDefense":  237,
+        "BaseStamina":  160,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "074",
+        "Name":  "Geodude",
+        "Classification":  "Rock Pokemon",
+        "Type I":  [
+                       "Rock"
+                   ],
+        "Type II":  [
+                        "Ground"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Ice",
+                           "Fighting",
+                           "Ground",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Rock Throw",
+                               "Tackle"
+                           ],
+        "Weight":  "20.0 kg",
+        "Height":  "0.4 m",
+        "Candy":  {
+                      "Name":  "Geodude candies",
+                      "FamilyID":  74
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  74,
+                                            "Name":  "Geodude candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "075",
+                                      "Name":  "Graveler"
+                                  },
+                                  {
+                                      "Number":  "076",
+                                      "Name":  "Golem"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Dig",
+                                  "Rock Slide",
+                                  "Rock Tomb"
+                              ],
+        "BaseAttack":  132,
+        "BaseDefense":  163,
+        "BaseStamina":  80,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "075",
+        "Name":  "Graveler",
+        "Classification":  "Rock Pokemon",
+        "Type I":  [
+                       "Rock"
+                   ],
+        "Type II":  [
+                        "Ground"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Ice",
+                           "Fighting",
+                           "Ground",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Mud Slap",
+                               "Rock Throw"
+                           ],
+        "Weight":  "105.0 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Geodude candies",
+                      "FamilyID":  74
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  100,
+                                            "Family":  74,
+                                            "Name":  "Geodude candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "076",
+                                      "Name":  "Golem"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "074",
+                                          "Name":  "Geodude"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Dig",
+                                  "Rock Slide",
+                                  "Stone Edge"
+                              ],
+        "BaseAttack":  164,
+        "BaseDefense":  196,
+        "BaseStamina":  110,
+        "CaptureRate":  0.2,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "076",
+        "Name":  "Golem",
+        "Classification":  "Megaton Pokemon",
+        "Type I":  [
+                       "Rock"
+                   ],
+        "Type II":  [
+                        "Ground"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Ice",
+                           "Fighting",
+                           "Ground",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Mud Slap",
+                               "Rock Throw"
+                           ],
+        "Weight":  "300.0 kg",
+        "Height":  "1.4 m",
+        "Candy":  {
+                      "Name":  "Geodude candies",
+                      "FamilyID":  74
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "074",
+                                          "Name":  "Geodude"
+                                      },
+                                      {
+                                          "Number":  "075",
+                                          "Name":  "Graveler"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Ancient Power",
+                                  "Earthquake",
+                                  "Stone Edge"
+                              ],
+        "BaseAttack":  211,
+        "BaseDefense":  229,
+        "BaseStamina":  160,
+        "CaptureRate":  0.1,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "077",
+        "Name":  "Ponyta",
+        "Classification":  "Fire Horse Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Ember",
+                               "Tackle"
+                           ],
+        "Weight":  "30.0 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Ponyta candies",
+                      "FamilyID":  77
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  77,
+                                            "Name":  "Ponyta candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "078",
+                                      "Name":  "Rapidash"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Fire Blast",
+                                  "Flame Charge",
+                                  "Flame Wheel"
+                              ],
+        "BaseAttack":  170,
+        "BaseDefense":  132,
+        "BaseStamina":  100,
+        "CaptureRate":  0.32,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "078",
+        "Name":  "Rapidash",
+        "Classification":  "Fire Horse Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Ember",
+                               "Low Kick"
+                           ],
+        "Weight":  "95.0 kg",
+        "Height":  "1.7 m",
+        "Candy":  {
+                      "Name":  "Ponyta candies",
+                      "FamilyID":  77
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "077",
+                                          "Name":  "Ponyta"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Drill Run",
+                                  "Fire Blast",
+                                  "Heat Wave"
+                              ],
+        "BaseAttack":  207,
+        "BaseDefense":  167,
+        "BaseStamina":  130,
+        "CaptureRate":  0.12,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "079",
+        "Name":  "Slowpoke",
+        "Classification":  "Dopey Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Psychic"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass",
+                           "Bug",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Confusion",
+                               "Water Gun"
+                           ],
+        "Weight":  "36.0 kg",
+        "Height":  "1.2 m",
+        "Candy":  {
+                      "Name":  "Slowpoke candies",
+                      "FamilyID":  79
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  79,
+                                            "Name":  "Slowpoke candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "080",
+                                      "Name":  "Slowbro"
+                                  },
+                                  {
+                                      "Number":  "199",
+                                      "Name":  "Slowking"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Psychic",
+                                  "Psyshock",
+                                  "Water Pulse"
+                              ],
+        "BaseAttack":  109,
+        "BaseDefense":  109,
+        "BaseStamina":  180,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "080",
+        "Name":  "Slowbro",
+        "Classification":  "Hermit Crab Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Psychic"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass",
+                           "Bug",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Confusion",
+                               "Water Gun"
+                           ],
+        "Weight":  "78.5 kg",
+        "Height":  "1.6 m",
+        "Candy":  {
+                      "Name":  "Slowpoke candies",
+                      "FamilyID":  79
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "079",
+                                          "Name":  "Slowpoke"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Ice Beam",
+                                  "Psychic",
+                                  "Water Pulse"
+                              ],
+        "BaseAttack":  177,
+        "BaseDefense":  194,
+        "BaseStamina":  190,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "081",
+        "Name":  "Magnemite",
+        "Classification":  "Magnet Pokemon",
+        "Type I":  [
+                       "Electric"
+                   ],
+        "Type II":  [
+                        "Steel"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Fighting",
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Spark",
+                               "Thunder Shock"
+                           ],
+        "Weight":  "6.0 kg",
+        "Height":  "0.3 m",
+        "Candy":  {
+                      "Name":  "Magnemite candies",
+                      "FamilyID":  81
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  81,
+                                            "Name":  "Magnemite candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "082",
+                                      "Name":  "Magneton"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Discharge",
+                                  "Magnet Bomb",
+                                  "Thunderbolt"
+                              ],
+        "BaseAttack":  165,
+        "BaseDefense":  128,
+        "BaseStamina":  50,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "082",
+        "Name":  "Magneton",
+        "Classification":  "Magnet Pokemon",
+        "Type I":  [
+                       "Electric"
+                   ],
+        "Type II":  [
+                        "Steel"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Fighting",
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Spark",
+                               "Thunder Shock"
+                           ],
+        "Weight":  "60.0 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Magnemite candies",
+                      "FamilyID":  81
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "081",
+                                          "Name":  "Magnemite"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Discharge",
+                                  "Flash Cannon",
+                                  "Magnet Bomb"
+                              ],
+        "BaseAttack":  223,
+        "BaseDefense":  182,
+        "BaseStamina":  100,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "083",
+        "Name":  "Farfetchd",
+        "Classification":  "Wild Duck Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Cut",
+                               "Fury Cutter"
+                           ],
+        "Weight":  "15.0 kg",
+        "Height":  "0.8 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  83
+                  },
+        "Special Attack(s)":  [
+                                  "Aerial Ace",
+                                  "Air Cutter",
+                                  "Leaf Blade"
+                              ],
+        "BaseAttack":  124,
+        "BaseDefense":  118,
+        "BaseStamina":  104,
+        "CaptureRate":  0.24,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "084",
+        "Name":  "Doduo",
+        "Classification":  "Twin Bird Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Peck",
+                               "Quick Attack"
+                           ],
+        "Weight":  "39.2 kg",
+        "Height":  "1.4 m",
+        "Candy":  {
+                      "Name":  "Doduo candies",
+                      "FamilyID":  84
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  84,
+                                            "Name":  "Doduo candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "085",
+                                      "Name":  "Dodrio"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Aerial Ace",
+                                  "Drill Peck",
+                                  "Swift"
+                              ],
+        "BaseAttack":  158,
+        "BaseDefense":  88,
+        "BaseStamina":  70,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "085",
+        "Name":  "Dodrio",
+        "Classification":  "Triple Bird Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Feint Attack",
+                               "Steel Wing"
+                           ],
+        "Weight":  "85.2 kg",
+        "Height":  "1.8 m",
+        "Candy":  {
+                      "Name":  "Doduo candies",
+                      "FamilyID":  84
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "084",
+                                          "Name":  "Doduo"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Aerial Ace",
+                                  "Air Cutter",
+                                  "Drill Peck"
+                              ],
+        "BaseAttack":  218,
+        "BaseDefense":  145,
+        "BaseStamina":  120,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "086",
+        "Name":  "Seel",
+        "Classification":  "Sea Lion Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Ice Shard",
+                               "Lick"
+                           ],
+        "Weight":  "90.0 kg",
+        "Height":  "1.1 m",
+        "Candy":  {
+                      "Name":  "Seel candies",
+                      "FamilyID":  86
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  86,
+                                            "Name":  "Seel candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "087",
+                                      "Name":  "Dewgong"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Aqua Jet",
+                                  "Aqua Tail",
+                                  "Icy Wind"
+                              ],
+        "BaseAttack":  85,
+        "BaseDefense":  128,
+        "BaseStamina":  130,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "087",
+        "Name":  "Dewgong",
+        "Classification":  "Sea Lion Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Ice"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass",
+                           "Fighting",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Frost Breath",
+                               "Ice Shard"
+                           ],
+        "Weight":  "120.0 kg",
+        "Height":  "1.7 m",
+        "Candy":  {
+                      "Name":  "Seel candies",
+                      "FamilyID":  86
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "086",
+                                          "Name":  "Seel"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Aqua Jet",
+                                  "Blizzard",
+                                  "Icy Wind"
+                              ],
+        "BaseAttack":  139,
+        "BaseDefense":  184,
+        "BaseStamina":  180,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "088",
+        "Name":  "Grimer",
+        "Classification":  "Sludge Pokemon",
+        "Type I":  [
+                       "Poison"
+                   ],
+        "Weaknesses":  [
+                           "Ground",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Mud Slap",
+                               "Poison Jab"
+                           ],
+        "Weight":  "30.0 kg",
+        "Height":  "0.9 m",
+        "Candy":  {
+                      "Name":  "Grimer candies",
+                      "FamilyID":  88
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  88,
+                                            "Name":  "Grimer candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "089",
+                                      "Name":  "Muk"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Mud Bomb",
+                                  "Sludge",
+                                  "Sludge Bomb"
+                              ],
+        "BaseAttack":  135,
+        "BaseDefense":  90,
+        "BaseStamina":  160,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "089",
+        "Name":  "Muk",
+        "Classification":  "Sludge Pokemon",
+        "Type I":  [
+                       "Poison"
+                   ],
+        "Weaknesses":  [
+                           "Ground",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Lick",
+                               "Poison Jab"
+                           ],
+        "Weight":  "30.0 kg",
+        "Height":  "1.2 m",
+        "Candy":  {
+                      "Name":  "Grimer candies",
+                      "FamilyID":  88
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "088",
+                                          "Name":  "Grimer"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Dark Pulse",
+                                  "Gunk Shot",
+                                  "Sludge Wave"
+                              ],
+        "BaseAttack":  190,
+        "BaseDefense":  184,
+        "BaseStamina":  210,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "090",
+        "Name":  "Shellder",
+        "Classification":  "Bivalve Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Ice Shard",
+                               "Tackle"
+                           ],
+        "Weight":  "4.0 kg",
+        "Height":  "0.3 m",
+        "Candy":  {
+                      "Name":  "Shellder candies",
+                      "FamilyID":  90
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  90,
+                                            "Name":  "Shellder candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "091",
+                                      "Name":  "Cloyster"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Bubble Beam",
+                                  "Icy Wind",
+                                  "Water Pulse"
+                              ],
+        "BaseAttack":  116,
+        "BaseDefense":  168,
+        "BaseStamina":  60,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "091",
+        "Name":  "Cloyster",
+        "Classification":  "Bivalve Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Ice"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass",
+                           "Fighting",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Frost Breath",
+                               "Ice Shard"
+                           ],
+        "Weight":  "132.5 kg",
+        "Height":  "1.5 m",
+        "Candy":  {
+                      "Name":  "Shellder candies",
+                      "FamilyID":  90
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "090",
+                                          "Name":  "Shellder"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Blizzard",
+                                  "Hydro Pump",
+                                  "Icy Wind"
+                              ],
+        "BaseAttack":  186,
+        "BaseDefense":  323,
+        "BaseStamina":  100,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "092",
+        "Name":  "Gastly",
+        "Classification":  "Gas Pokemon",
+        "Type I":  [
+                       "Ghost"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Ground",
+                           "Psychic",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Lick",
+                               "Sucker Punch"
+                           ],
+        "Weight":  "0.1 kg",
+        "Height":  "1.3 m",
+        "Candy":  {
+                      "Name":  "Gastly candies",
+                      "FamilyID":  92
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  92,
+                                            "Name":  "Gastly candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "093",
+                                      "Name":  "Haunter"
+                                  },
+                                  {
+                                      "Number":  "094",
+                                      "Name":  "Gengar"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Dark Pulse",
+                                  "Ominous Wind",
+                                  "Sludge Bomb"
+                              ],
+        "BaseAttack":  186,
+        "BaseDefense":  70,
+        "BaseStamina":  60,
+        "CaptureRate":  0.32,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "093",
+        "Name":  "Haunter",
+        "Classification":  "Gas Pokemon",
+        "Type I":  [
+                       "Ghost"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Ground",
+                           "Psychic",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Lick",
+                               "Shadow Claw"
+                           ],
+        "Weight":  "0.1 kg",
+        "Height":  "1.6 m",
+        "Candy":  {
+                      "Name":  "Gastly candies",
+                      "FamilyID":  92
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  100,
+                                            "Family":  92,
+                                            "Name":  "Gastly candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "094",
+                                      "Name":  "Gengar"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "092",
+                                          "Name":  "Gastly"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Dark Pulse",
+                                  "Shadow Ball",
+                                  "Sludge Bomb"
+                              ],
+        "BaseAttack":  223,
+        "BaseDefense":  112,
+        "BaseStamina":  90,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "094",
+        "Name":  "Gengar",
+        "Classification":  "Shadow Pokemon",
+        "Type I":  [
+                       "Ghost"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Ground",
+                           "Psychic",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Shadow Claw",
+                               "Sucker Punch"
+                           ],
+        "Weight":  "40.5 kg",
+        "Height":  "1.5 m",
+        "Candy":  {
+                      "Name":  "Gastly candies",
+                      "FamilyID":  92
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "092",
+                                          "Name":  "Gastly"
+                                      },
+                                      {
+                                          "Number":  "093",
+                                          "Name":  "Haunter"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Dark Pulse",
+                                  "Shadow Ball",
+                                  "Sludge Bomb"
+                              ],
+        "BaseAttack":  261,
+        "BaseDefense":  156,
+        "BaseStamina":  120,
+        "CaptureRate":  0.08,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "095",
+        "Name":  "Onix",
+        "Classification":  "Rock Snake Pokemon",
+        "Type I":  [
+                       "Rock"
+                   ],
+        "Type II":  [
+                        "Ground"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Ice",
+                           "Fighting",
+                           "Ground",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Rock Throw",
+                               "Tackle"
+                           ],
+        "Weight":  "210.0 kg",
+        "Height":  "8.8 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  95
+                  },
+        "Special Attack(s)":  [
+                                  "Iron Head",
+                                  "Rock Slide",
+                                  "Stone Edge"
+                              ],
+        "BaseAttack":  85,
+        "BaseDefense":  288,
+        "BaseStamina":  70,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "096",
+        "Name":  "Drowzee",
+        "Classification":  "Hypnosis Pokemon",
+        "Type I":  [
+                       "Psychic"
+                   ],
+        "Weaknesses":  [
+                           "Bug",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Confusion",
+                               "Pound"
+                           ],
+        "Weight":  "32.4 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Drowzee candies",
+                      "FamilyID":  96
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  96,
+                                            "Name":  "Drowzee candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "097",
+                                      "Name":  "Hypno"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Psybeam",
+                                  "Psychic",
+                                  "Psyshock"
+                              ],
+        "BaseAttack":  89,
+        "BaseDefense":  158,
+        "BaseStamina":  120,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "097",
+        "Name":  "Hypno",
+        "Classification":  "Hypnosis Pokemon",
+        "Type I":  [
+                       "Psychic"
+                   ],
+        "Weaknesses":  [
+                           "Bug",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Confusion",
+                               "Zen Headbutt"
+                           ],
+        "Weight":  "75.6 kg",
+        "Height":  "1.6 m",
+        "Candy":  {
+                      "Name":  "Drowzee candies",
+                      "FamilyID":  96
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "096",
+                                          "Name":  "Drowzee"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Psychic",
+                                  "Psyshock",
+                                  "Shadow Ball"
+                              ],
+        "BaseAttack":  144,
+        "BaseDefense":  215,
+        "BaseStamina":  170,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "098",
+        "Name":  "Krabby",
+        "Classification":  "River Crab Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bubble",
+                               "Mud Shot"
+                           ],
+        "Weight":  "6.5 kg",
+        "Height":  "0.4 m",
+        "Candy":  {
+                      "Name":  "Krabby candies",
+                      "FamilyID":  98
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  98,
+                                            "Name":  "Krabby candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "099",
+                                      "Name":  "Kingler"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Bubble Beam",
+                                  "Vice Grip",
+                                  "Water Pulse"
+                              ],
+        "BaseAttack":  181,
+        "BaseDefense":  156,
+        "BaseStamina":  60,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.15,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "099",
+        "Name":  "Kingler",
+        "Classification":  "Pincer Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Metal Claw",
+                               "Mud Shot"
+                           ],
+        "Weight":  "60.0 kg",
+        "Height":  "1.3 m",
+        "Candy":  {
+                      "Name":  "Krabby candies",
+                      "FamilyID":  98
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "098",
+                                          "Name":  "Krabby"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Vice Grip",
+                                  "Water Pulse",
+                                  "X Scissor"
+                              ],
+        "BaseAttack":  240,
+        "BaseDefense":  214,
+        "BaseStamina":  110,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "100",
+        "Name":  "Voltorb",
+        "Classification":  "Ball Pokemon",
+        "Type I":  [
+                       "Electric"
+                   ],
+        "Weaknesses":  [
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Spark",
+                               "Tackle"
+                           ],
+        "Weight":  "10.4 kg",
+        "Height":  "0.5 m",
+        "Candy":  {
+                      "Name":  "Voltorb candies",
+                      "FamilyID":  100
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  100,
+                                            "Name":  "Voltorb candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "101",
+                                      "Name":  "Electrode"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Discharge",
+                                  "Signal Beam",
+                                  "Thunderbolt"
+                              ],
+        "BaseAttack":  109,
+        "BaseDefense":  114,
+        "BaseStamina":  80,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "101",
+        "Name":  "Electrode",
+        "Classification":  "Ball Pokemon",
+        "Type I":  [
+                       "Electric"
+                   ],
+        "Weaknesses":  [
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Spark",
+                               "Tackle"
+                           ],
+        "Weight":  "66.6 kg",
+        "Height":  "1.2 m",
+        "Candy":  {
+                      "Name":  "Voltorb candies",
+                      "FamilyID":  100
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "100",
+                                          "Name":  "Voltorb"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Discharge",
+                                  "Hyper Beam",
+                                  "Thunderbolt"
+                              ],
+        "BaseAttack":  173,
+        "BaseDefense":  179,
+        "BaseStamina":  120,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "102",
+        "Name":  "Exeggcute",
+        "Classification":  "Egg Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Type II":  [
+                        "Psychic"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Poison",
+                           "Flying",
+                           "Bug",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Confusion"
+                           ],
+        "Weight":  "2.5 kg",
+        "Height":  "0.4 m",
+        "Candy":  {
+                      "Name":  "Exeggcute candies",
+                      "FamilyID":  102
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  102,
+                                            "Name":  "Exeggcute candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "103",
+                                      "Name":  "Exeggutor"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Ancient Power",
+                                  "Psychic",
+                                  "Seed Bomb"
+                              ],
+        "BaseAttack":  107,
+        "BaseDefense":  140,
+        "BaseStamina":  120,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "103",
+        "Name":  "Exeggutor",
+        "Classification":  "Coconut Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Type II":  [
+                        "Psychic"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Poison",
+                           "Flying",
+                           "Bug",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Confusion",
+                               "Zen Headbutt"
+                           ],
+        "Weight":  "120.0 kg",
+        "Height":  "2.0 m",
+        "Candy":  {
+                      "Name":  "Exeggcute candies",
+                      "FamilyID":  102
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "102",
+                                          "Name":  "Exeggcute"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Psychic",
+                                  "Seed Bomb",
+                                  "Solar Beam"
+                              ],
+        "BaseAttack":  233,
+        "BaseDefense":  158,
+        "BaseStamina":  190,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "104",
+        "Name":  "Cubone",
+        "Classification":  "Lonely Pokemon",
+        "Type I":  [
+                       "Ground"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Ice"
+                       ],
+        "Fast Attack(s)":  [
+                               "Mud Slap",
+                               "Rock Smash"
+                           ],
+        "Weight":  "6.5 kg",
+        "Height":  "0.4 m",
+        "Candy":  {
+                      "Name":  "Cubone candies",
+                      "FamilyID":  104
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  104,
+                                            "Name":  "Cubone candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "105",
+                                      "Name":  "Marowak"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Bone Club",
+                                  "Bulldoze",
+                                  "Dig"
+                              ],
+        "BaseAttack":  90,
+        "BaseDefense":  165,
+        "BaseStamina":  100,
+        "CaptureRate":  0.32,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "105",
+        "Name":  "Marowak",
+        "Classification":  "Bone Keeper Pokemon",
+        "Type I":  [
+                       "Ground"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Ice"
+                       ],
+        "Fast Attack(s)":  [
+                               "Mud Slap",
+                               "Rock Smash"
+                           ],
+        "Weight":  "45.0 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Cubone candies",
+                      "FamilyID":  104
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "104",
+                                          "Name":  "Cubone"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Bone Club",
+                                  "Dig",
+                                  "Earthquake"
+                              ],
+        "BaseAttack":  144,
+        "BaseDefense":  200,
+        "BaseStamina":  120,
+        "CaptureRate":  0.12,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "106",
+        "Name":  "Hitmonlee",
+        "Classification":  "Kicking Pokemon",
+        "Type I":  [
+                       "Fighting"
+                   ],
+        "Weaknesses":  [
+                           "Flying",
+                           "Psychic",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Low Kick",
+                               "Rock Smash"
+                           ],
+        "Weight":  "49.8 kg",
+        "Height":  "1.5 m",
+        "Candy":  {
+                      "Name":  "Tyrogue candies",
+                      "FamilyID":  236
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "236",
+                                          "Name":  "Tyrogue"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Brick Break",
+                                  "Low Sweep",
+                                  "Stone Edge"
+                              ],
+        "BaseAttack":  224,
+        "BaseDefense":  211,
+        "BaseStamina":  100,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "107",
+        "Name":  "Hitmonchan",
+        "Classification":  "Punching Pokemon",
+        "Type I":  [
+                       "Fighting"
+                   ],
+        "Weaknesses":  [
+                           "Flying",
+                           "Psychic",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bullet Punch",
+                               "Rock Smash"
+                           ],
+        "Weight":  "50.2 kg",
+        "Height":  "1.4 m",
+        "Candy":  {
+                      "Name":  "Tyrogue candies",
+                      "FamilyID":  236
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "236",
+                                          "Name":  "Tyrogue"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Brick Break",
+                                  "Fire Punch",
+                                  "Ice Punch",
+                                  "Thunder Punch"
+                              ],
+        "BaseAttack":  193,
+        "BaseDefense":  212,
+        "BaseStamina":  100,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "108",
+        "Name":  "Lickitung",
+        "Classification":  "Licking Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Lick",
+                               "Zen Headbutt"
+                           ],
+        "Weight":  "65.5 kg",
+        "Height":  "1.2 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  108
+                  },
+        "Special Attack(s)":  [
+                                  "Hyper Beam",
+                                  "Power Whip",
+                                  "Stomp"
+                              ],
+        "BaseAttack":  108,
+        "BaseDefense":  137,
+        "BaseStamina":  180,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "109",
+        "Name":  "Koffing",
+        "Classification":  "Poison Gas Pokemon",
+        "Type I":  [
+                       "Poison"
+                   ],
+        "Weaknesses":  [
+                           "Ground",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "1.0 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "Koffing candies",
+                      "FamilyID":  109
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  109,
+                                            "Name":  "Koffing candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "110",
+                                      "Name":  "Weezing"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Dark Pulse",
+                                  "Sludge",
+                                  "Sludge Bomb"
+                              ],
+        "BaseAttack":  119,
+        "BaseDefense":  164,
+        "BaseStamina":  80,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "110",
+        "Name":  "Weezing",
+        "Classification":  "Poison Gas Pokemon",
+        "Type I":  [
+                       "Poison"
+                   ],
+        "Weaknesses":  [
+                           "Ground",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "9.5 kg",
+        "Height":  "1.2 m",
+        "Candy":  {
+                      "Name":  "Koffing candies",
+                      "FamilyID":  109
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "109",
+                                          "Name":  "Koffing"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Dark Pulse",
+                                  "Shadow Ball",
+                                  "Sludge Bomb"
+                              ],
+        "BaseAttack":  174,
+        "BaseDefense":  221,
+        "BaseStamina":  130,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "111",
+        "Name":  "Rhyhorn",
+        "Classification":  "Spikes Pokemon",
+        "Type I":  [
+                       "Ground"
+                   ],
+        "Type II":  [
+                        "Rock"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Ice",
+                           "Fighting",
+                           "Ground",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Mud Slap",
+                               "Rock Smash"
+                           ],
+        "Weight":  "115.0 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Rhyhorn candies",
+                      "FamilyID":  111
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  111,
+                                            "Name":  "Rhyhorn candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "112",
+                                      "Name":  "Rhydon"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Bulldoze",
+                                  "Horn Attack",
+                                  "Stomp"
+                              ],
+        "BaseAttack":  140,
+        "BaseDefense":  157,
+        "BaseStamina":  160,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "112",
+        "Name":  "Rhydon",
+        "Classification":  "Drill Pokemon",
+        "Type I":  [
+                       "Ground"
+                   ],
+        "Type II":  [
+                        "Rock"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Ice",
+                           "Fighting",
+                           "Ground",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Mud Slap",
+                               "Rock Smash"
+                           ],
+        "Weight":  "120.0 kg",
+        "Height":  "1.9 m",
+        "Candy":  {
+                      "Name":  "Rhyhorn candies",
+                      "FamilyID":  111
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "111",
+                                          "Name":  "Rhyhorn"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Earthquake",
+                                  "Megahorn",
+                                  "Stone Edge"
+                              ],
+        "BaseAttack":  222,
+        "BaseDefense":  206,
+        "BaseStamina":  210,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "113",
+        "Name":  "Chansey",
+        "Classification":  "Egg Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Pound",
+                               "Zen Headbutt"
+                           ],
+        "Weight":  "34.6 kg",
+        "Height":  "1.1 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  113
+                  },
+        "Special Attack(s)":  [
+                                  "Dazzling Gleam",
+                                  "Hyper Beam",
+                                  "Psychic"
+                              ],
+        "BaseAttack":  60,
+        "BaseDefense":  176,
+        "BaseStamina":  500,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "114",
+        "Name":  "Tangela",
+        "Classification":  "Vine Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Poison",
+                           "Flying",
+                           "Bug"
+                       ],
+        "Fast Attack(s)":  [
+                               "Vine Whip"
+                           ],
+        "Weight":  "35.0 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  114
+                  },
+        "Special Attack(s)":  [
+                                  "Power Whip",
+                                  "Sludge Bomb",
+                                  "Solar Beam"
+                              ],
+        "BaseAttack":  183,
+        "BaseDefense":  205,
+        "BaseStamina":  130,
+        "CaptureRate":  0.32,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "115",
+        "Name":  "Kangaskhan",
+        "Classification":  "Parent Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Low Kick",
+                               "Mud Slap"
+                           ],
+        "Weight":  "80.0 kg",
+        "Height":  "2.2 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  115
+                  },
+        "Special Attack(s)":  [
+                                  "Brick Break",
+                                  "Earthquake",
+                                  "Stomp"
+                              ],
+        "BaseAttack":  181,
+        "BaseDefense":  165,
+        "BaseStamina":  210,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "116",
+        "Name":  "Horsea",
+        "Classification":  "Dragon Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bubble",
+                               "Water Gun"
+                           ],
+        "Weight":  "8.0 kg",
+        "Height":  "0.4 m",
+        "Candy":  {
+                      "Name":  "Horsea candies",
+                      "FamilyID":  116
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  116,
+                                            "Name":  "Horsea candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "117",
+                                      "Name":  "Seadra"
+                                  },
+                                  {
+                                      "Number":  "230",
+                                      "Name":  "Kingdra"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Bubble Beam",
+                                  "Dragon Pulse",
+                                  "Flash Cannon"
+                              ],
+        "BaseAttack":  129,
+        "BaseDefense":  125,
+        "BaseStamina":  60,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "117",
+        "Name":  "Seadra",
+        "Classification":  "Dragon Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Dragon Breath",
+                               "Water Gun"
+                           ],
+        "Weight":  "25.0 kg",
+        "Height":  "1.2 m",
+        "Candy":  {
+                      "Name":  "Horsea candies",
+                      "FamilyID":  116
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "116",
+                                          "Name":  "Horsea"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Blizzard",
+                                  "Dragon Pulse",
+                                  "Hydro Pump"
+                              ],
+        "BaseAttack":  187,
+        "BaseDefense":  182,
+        "BaseStamina":  110,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "118",
+        "Name":  "Goldeen",
+        "Classification":  "Goldfish Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Mud Shot",
+                               "Peck"
+                           ],
+        "Weight":  "15.0 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "Goldeen candies",
+                      "FamilyID":  118
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  118,
+                                            "Name":  "Goldeen candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "119",
+                                      "Name":  "Seaking"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Aqua Tail",
+                                  "Horn Attack",
+                                  "Water Pulse"
+                              ],
+        "BaseAttack":  123,
+        "BaseDefense":  115,
+        "BaseStamina":  90,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.15,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "119",
+        "Name":  "Seaking",
+        "Classification":  "Goldfish Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Peck",
+                               "Poison Jab"
+                           ],
+        "Weight":  "39.0 kg",
+        "Height":  "1.3 m",
+        "Candy":  {
+                      "Name":  "Goldeen candies",
+                      "FamilyID":  118
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "118",
+                                          "Name":  "Goldeen"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Drill Run",
+                                  "Icy Wind",
+                                  "Megahorn"
+                              ],
+        "BaseAttack":  175,
+        "BaseDefense":  154,
+        "BaseStamina":  160,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "120",
+        "Name":  "Staryu",
+        "Classification":  "Starshape Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle",
+                               "Water Gun"
+                           ],
+        "Weight":  "34.5 kg",
+        "Height":  "0.8 m",
+        "Candy":  {
+                      "Name":  "Staryu candies",
+                      "FamilyID":  120
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  120,
+                                            "Name":  "Staryu candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "121",
+                                      "Name":  "Starmie"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Bubble Beam",
+                                  "Power Gem",
+                                  "Swift"
+                              ],
+        "BaseAttack":  137,
+        "BaseDefense":  112,
+        "BaseStamina":  60,
+        "CaptureRate":  0.4,
+        "FleeRate":  0.15,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "121",
+        "Name":  "Starmie",
+        "Classification":  "Mysterious Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Psychic"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass",
+                           "Bug",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle",
+                               "Water Gun"
+                           ],
+        "Weight":  "80.0 kg",
+        "Height":  "1.1 m",
+        "Candy":  {
+                      "Name":  "Staryu candies",
+                      "FamilyID":  120
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "120",
+                                          "Name":  "Staryu"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Hydro Pump",
+                                  "Power Gem",
+                                  "Psychic"
+                              ],
+        "BaseAttack":  210,
+        "BaseDefense":  184,
+        "BaseStamina":  120,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "122",
+        "Name":  "Mr Mime",
+        "Classification":  "Barrier Pokemon",
+        "Type I":  [
+                       "Psychic"
+                   ],
+        "Type II":  [
+                        "Fairy"
+                    ],
+        "Weaknesses":  [
+                           "Poison",
+                           "Ghost",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Confusion",
+                               "Zen Headbutt"
+                           ],
+        "Weight":  "54.5 kg",
+        "Height":  "1.3 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  122
+                  },
+        "Special Attack(s)":  [
+                                  "Psybeam",
+                                  "Psychic",
+                                  "Shadow Ball"
+                              ],
+        "BaseAttack":  192,
+        "BaseDefense":  233,
+        "BaseStamina":  80,
+        "CaptureRate":  0.24,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "123",
+        "Name":  "Scyther",
+        "Classification":  "Mantis Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Electric",
+                           "Ice",
+                           "Flying",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Fury Cutter",
+                               "Steel Wing"
+                           ],
+        "Weight":  "56.0 kg",
+        "Height":  "1.5 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  123
+                  },
+        "Special Attack(s)":  [
+                                  "Bug Buzz",
+                                  "Night Slash",
+                                  "X Scissor"
+                              ],
+        "BaseAttack":  218,
+        "BaseDefense":  170,
+        "BaseStamina":  140,
+        "CaptureRate":  0.24,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "124",
+        "Name":  "Jynx",
+        "Classification":  "Humanshape Pokemon",
+        "Type I":  [
+                       "Ice"
+                   ],
+        "Type II":  [
+                        "Psychic"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Bug",
+                           "Rock",
+                           "Ghost",
+                           "Dark",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Frost Breath",
+                               "Pound"
+                           ],
+        "Weight":  "40.6 kg",
+        "Height":  "1.4 m",
+        "Candy":  {
+                      "Name":  "Jynx candies",
+                      "FamilyID":  124
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "238",
+                                          "Name":  "Smoochum"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Draining Kiss",
+                                  "Ice Punch",
+                                  "Psyshock"
+                              ],
+        "BaseAttack":  223,
+        "BaseDefense":  182,
+        "BaseStamina":  130,
+        "CaptureRate":  0.24,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "125",
+        "Name":  "Electabuzz",
+        "Classification":  "Electric Pokemon",
+        "Type I":  [
+                       "Electric"
+                   ],
+        "Weaknesses":  [
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Low Kick",
+                               "Thunder Shock"
+                           ],
+        "Weight":  "30.0 kg",
+        "Height":  "1.1 m",
+        "Candy":  {
+                      "Name":  "Electabuzz candies",
+                      "FamilyID":  125
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "239",
+                                          "Name":  "Elekid"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Thunder",
+                                  "Thunder Punch",
+                                  "Thunderbolt"
+                              ],
+        "BaseAttack":  198,
+        "BaseDefense":  173,
+        "BaseStamina":  130,
+        "CaptureRate":  0.24,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "126",
+        "Name":  "Magmar",
+        "Classification":  "Spitfire Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Ember",
+                               "Karate Chop"
+                           ],
+        "Weight":  "44.5 kg",
+        "Height":  "1.3 m",
+        "Candy":  {
+                      "Name":  "Magmar candies",
+                      "FamilyID":  126
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "240",
+                                          "Name":  "Magby"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Fire Blast",
+                                  "Fire Punch",
+                                  "Flamethrower"
+                              ],
+        "BaseAttack":  206,
+        "BaseDefense":  169,
+        "BaseStamina":  130,
+        "CaptureRate":  0.24,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "127",
+        "Name":  "Pinsir",
+        "Classification":  "Stagbeetle Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Flying",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Fury Cutter",
+                               "Rock Smash"
+                           ],
+        "Weight":  "55.0 kg",
+        "Height":  "1.5 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  127
+                  },
+        "Special Attack(s)":  [
+                                  "Submission",
+                                  "Vice Grip",
+                                  "X Scissor"
+                              ],
+        "BaseAttack":  238,
+        "BaseDefense":  197,
+        "BaseStamina":  130,
+        "CaptureRate":  0.24,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "128",
+        "Name":  "Tauros",
+        "Classification":  "Wild Bull Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle",
+                               "Zen Headbutt"
+                           ],
+        "Weight":  "88.4 kg",
+        "Height":  "1.4 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  128
+                  },
+        "Special Attack(s)":  [
+                                  "Earthquake",
+                                  "Horn Attack",
+                                  "Iron Head"
+                              ],
+        "BaseAttack":  198,
+        "BaseDefense":  197,
+        "BaseStamina":  150,
+        "CaptureRate":  0.24,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "129",
+        "Name":  "Magikarp",
+        "Classification":  "Fish Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Splash"
+                           ],
+        "Weight":  "10.0 kg",
+        "Height":  "0.9 m",
+        "Candy":  {
+                      "Name":  "Magikarp candies",
+                      "FamilyID":  129
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  400,
+                                            "Family":  129,
+                                            "Name":  "Magikarp candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "130",
+                                      "Name":  "Gyarados"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  29,
+        "BaseDefense":  102,
+        "BaseStamina":  40,
+        "CaptureRate":  0.56,
+        "FleeRate":  0.15,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "130",
+        "Name":  "Gyarados",
+        "Classification":  "Atrocious Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bite"
+                           ],
+        "Weight":  "235.0 kg",
+        "Height":  "6.5 m",
+        "Candy":  {
+                      "Name":  "Magikarp candies",
+                      "FamilyID":  129
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "129",
+                                          "Name":  "Magikarp"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Dragon Pulse",
+                                  "Hydro Pump",
+                                  "Twister"
+                              ],
+        "BaseAttack":  237,
+        "BaseDefense":  197,
+        "BaseStamina":  190,
+        "CaptureRate":  0.08,
+        "FleeRate":  0.07,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "131",
+        "Name":  "Lapras",
+        "Classification":  "Transport Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Ice"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass",
+                           "Fighting",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Frost Breath",
+                               "Ice Shard"
+                           ],
+        "Weight":  "220.0 kg",
+        "Height":  "2.5 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  131
+                  },
+        "Special Attack(s)":  [
+                                  "Blizzard",
+                                  "Dragon Pulse",
+                                  "Ice Beam"
+                              ],
+        "BaseAttack":  186,
+        "BaseDefense":  190,
+        "BaseStamina":  260,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "132",
+        "Name":  "Ditto",
+        "Classification":  "Transform Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Transform"
+                           ],
+        "Weight":  "4.0 kg",
+        "Height":  "0.3 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  132
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  91,
+        "BaseDefense":  91,
+        "BaseStamina":  96,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "133",
+        "Name":  "Eevee",
+        "Classification":  "Evolution Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Quick Attack",
+                               "Tackle"
+                           ],
+        "Weight":  "6.5 kg",
+        "Height":  "0.3 m",
+        "Candy":  {
+                      "Name":  "Eevee candies",
+                      "FamilyID":  133
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  133,
+                                            "Name":  "Eevee candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "134",
+                                      "Name":  "Vaporeon"
+                                  },
+                                  {
+                                      "Number":  "135",
+                                      "Name":  "Jolteon"
+                                  },
+                                  {
+                                      "Number":  "136",
+                                      "Name":  "Flareon"
+                                  },
+                                  {
+                                      "Number":  "196",
+                                      "Name":  "Espeon"
+                                  },
+                                  {
+                                      "Number":  "197",
+                                      "Name":  "Umbreon"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Body Slam",
+                                  "Dig",
+                                  "Swift"
+                              ],
+        "BaseAttack":  104,
+        "BaseDefense":  121,
+        "BaseStamina":  110,
+        "CaptureRate":  0.32,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "134",
+        "Name":  "Vaporeon",
+        "Classification":  "Bubble Jet Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Water Gun"
+                           ],
+        "Weight":  "29.0 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Eevee candies",
+                      "FamilyID":  133
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "133",
+                                          "Name":  "Eevee"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Aqua Tail",
+                                  "Hydro Pump",
+                                  "Water Pulse"
+                              ],
+        "BaseAttack":  205,
+        "BaseDefense":  177,
+        "BaseStamina":  260,
+        "CaptureRate":  0.12,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "135",
+        "Name":  "Jolteon",
+        "Classification":  "Lightning Pokemon",
+        "Type I":  [
+                       "Electric"
+                   ],
+        "Weaknesses":  [
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Thunder Shock"
+                           ],
+        "Weight":  "24.5 kg",
+        "Height":  "0.8 m",
+        "Candy":  {
+                      "Name":  "Eevee candies",
+                      "FamilyID":  133
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "133",
+                                          "Name":  "Eevee"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Discharge",
+                                  "Thunder",
+                                  "Thunderbolt"
+                              ],
+        "BaseAttack":  232,
+        "BaseDefense":  201,
+        "BaseStamina":  130,
+        "CaptureRate":  0.12,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "136",
+        "Name":  "Flareon",
+        "Classification":  "Flame Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Ember"
+                           ],
+        "Weight":  "25.0 kg",
+        "Height":  "0.9 m",
+        "Candy":  {
+                      "Name":  "Eevee candies",
+                      "FamilyID":  133
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "133",
+                                          "Name":  "Eevee"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Fire Blast",
+                                  "Flamethrower",
+                                  "Heat Wave"
+                              ],
+        "BaseAttack":  246,
+        "BaseDefense":  204,
+        "BaseStamina":  130,
+        "CaptureRate":  0.12,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "137",
+        "Name":  "Porygon",
+        "Classification":  "Virtual Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle",
+                               "Zen Headbutt"
+                           ],
+        "Weight":  "36.5 kg",
+        "Height":  "0.8 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  137
+                  },
+        "Special Attack(s)":  [
+                                  "Discharge",
+                                  "Psybeam",
+                                  "Signal Beam"
+                              ],
+        "BaseAttack":  153,
+        "BaseDefense":  139,
+        "BaseStamina":  130,
+        "CaptureRate":  0.32,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  3
+    },
+    {
+        "Number":  "138",
+        "Name":  "Omanyte",
+        "Classification":  "Spiral Pokemon",
+        "Type I":  [
+                       "Rock"
+                   ],
+        "Type II":  [
+                        "Water"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass",
+                           "Fighting",
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Mud Shot",
+                               "Water Gun"
+                           ],
+        "Weight":  "7.5 kg",
+        "Height":  "0.4 m",
+        "Candy":  {
+                      "Name":  "Omanyte candies",
+                      "FamilyID":  138
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  138,
+                                            "Name":  "Omanyte candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "139",
+                                      "Name":  "Omastar"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Ancient Power",
+                                  "Brine",
+                                  "Rock Tomb"
+                              ],
+        "BaseAttack":  155,
+        "BaseDefense":  174,
+        "BaseStamina":  70,
+        "CaptureRate":  0.32,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "139",
+        "Name":  "Omastar",
+        "Classification":  "Spiral Pokemon",
+        "Type I":  [
+                       "Rock"
+                   ],
+        "Type II":  [
+                        "Water"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass",
+                           "Fighting",
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Mud Shot",
+                               "Water Gun"
+                           ],
+        "Weight":  "35.0 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Omanyte candies",
+                      "FamilyID":  138
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "138",
+                                          "Name":  "Omanyte"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Ancient Power",
+                                  "Hydro Pump",
+                                  "Rock Slide"
+                              ],
+        "BaseAttack":  207,
+        "BaseDefense":  227,
+        "BaseStamina":  140,
+        "CaptureRate":  0.12,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "140",
+        "Name":  "Kabuto",
+        "Classification":  "Shellfish Pokemon",
+        "Type I":  [
+                       "Rock"
+                   ],
+        "Type II":  [
+                        "Water"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass",
+                           "Fighting",
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Mud Shot",
+                               "Scratch"
+                           ],
+        "Weight":  "11.5 kg",
+        "Height":  "0.5 m",
+        "Candy":  {
+                      "Name":  "Kabuto candies",
+                      "FamilyID":  140
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  140,
+                                            "Name":  "Kabuto candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "141",
+                                      "Name":  "Kabutops"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Ancient Power",
+                                  "Aqua Jet",
+                                  "Rock Tomb"
+                              ],
+        "BaseAttack":  148,
+        "BaseDefense":  162,
+        "BaseStamina":  60,
+        "CaptureRate":  0.32,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "141",
+        "Name":  "Kabutops",
+        "Classification":  "Shellfish Pokemon",
+        "Type I":  [
+                       "Rock"
+                   ],
+        "Type II":  [
+                        "Water"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass",
+                           "Fighting",
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Fury Cutter",
+                               "Mud Shot"
+                           ],
+        "Weight":  "40.5 kg",
+        "Height":  "1.3 m",
+        "Candy":  {
+                      "Name":  "Kabuto candies",
+                      "FamilyID":  140
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "140",
+                                          "Name":  "Kabuto"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Ancient Power",
+                                  "Stone Edge",
+                                  "Water Pulse"
+                              ],
+        "BaseAttack":  220,
+        "BaseDefense":  203,
+        "BaseStamina":  120,
+        "CaptureRate":  0.12,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "142",
+        "Name":  "Aerodactyl",
+        "Classification":  "Fossil Pokemon",
+        "Type I":  [
+                       "Rock"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Electric",
+                           "Ice",
+                           "Rock",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bite",
+                               "Steel Wing"
+                           ],
+        "Weight":  "59.0 kg",
+        "Height":  "1.8 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  142
+                  },
+        "Special Attack(s)":  [
+                                  "Ancient Power",
+                                  "Hyper Beam",
+                                  "Iron Head"
+                              ],
+        "BaseAttack":  221,
+        "BaseDefense":  164,
+        "BaseStamina":  160,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "143",
+        "Name":  "Snorlax",
+        "Classification":  "Sleeping Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Lick",
+                               "Zen Headbutt"
+                           ],
+        "Weight":  "460.0 kg",
+        "Height":  "2.1 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  143
+                  },
+        "Special Attack(s)":  [
+                                  "Body Slam",
+                                  "Earthquake",
+                                  "Hyper Beam"
+                              ],
+        "BaseAttack":  190,
+        "BaseDefense":  190,
+        "BaseStamina":  320,
+        "CaptureRate":  0.16,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "144",
+        "Name":  "Articuno",
+        "Classification":  "Freeze Pokemon",
+        "Type I":  [
+                       "Ice"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Electric",
+                           "Rock",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Frost Breath"
+                           ],
+        "Weight":  "55.4 kg",
+        "Height":  "1.7 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  144
+                  },
+        "Special Attack(s)":  [
+                                  "Blizzard",
+                                  "Ice Beam",
+                                  "Icy Wind"
+                              ],
+        "BaseAttack":  192,
+        "BaseDefense":  249,
+        "BaseStamina":  180,
+        "CaptureRate":  0,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "145",
+        "Name":  "Zapdos",
+        "Classification":  "Electric Pokemon",
+        "Type I":  [
+                       "Electric"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Ice",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Thunder Shock"
+                           ],
+        "Weight":  "52.6 kg",
+        "Height":  "1.6 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  145
+                  },
+        "Special Attack(s)":  [
+                                  "Discharge",
+                                  "Thunder",
+                                  "Thunderbolt"
+                              ],
+        "BaseAttack":  253,
+        "BaseDefense":  188,
+        "BaseStamina":  180,
+        "CaptureRate":  0,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "146",
+        "Name":  "Moltres",
+        "Classification":  "Flame Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Electric",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Ember"
+                           ],
+        "Weight":  "60.0 kg",
+        "Height":  "2.0 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  146
+                  },
+        "Special Attack(s)":  [
+                                  "Fire Blast",
+                                  "Flamethrower",
+                                  "Heat Wave"
+                              ],
+        "BaseAttack":  251,
+        "BaseDefense":  184,
+        "BaseStamina":  180,
+        "CaptureRate":  0,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "147",
+        "Name":  "Dratini",
+        "Classification":  "Dragon Pokemon",
+        "Type I":  [
+                       "Dragon"
+                   ],
+        "Weaknesses":  [
+                           "Ice",
+                           "Dragon",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Dragon Breath"
+                           ],
+        "Weight":  "3.3 kg",
+        "Height":  "1.8 m",
+        "Candy":  {
+                      "Name":  "Dratini candies",
+                      "FamilyID":  147
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  147,
+                                            "Name":  "Dratini candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "148",
+                                      "Name":  "Dragonair"
+                                  },
+                                  {
+                                      "Number":  "149",
+                                      "Name":  "Dragonite"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Aqua Tail",
+                                  "Twister",
+                                  "Wrap"
+                              ],
+        "BaseAttack":  119,
+        "BaseDefense":  94,
+        "BaseStamina":  82,
+        "CaptureRate":  0.32,
+        "FleeRate":  0.09,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "148",
+        "Name":  "Dragonair",
+        "Classification":  "Dragon Pokemon",
+        "Type I":  [
+                       "Dragon"
+                   ],
+        "Weaknesses":  [
+                           "Ice",
+                           "Dragon",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Dragon Breath"
+                           ],
+        "Weight":  "16.5 kg",
+        "Height":  "4.0 m",
+        "Candy":  {
+                      "Name":  "Dratini candies",
+                      "FamilyID":  147
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  100,
+                                            "Family":  147,
+                                            "Name":  "Dratini candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "149",
+                                      "Name":  "Dragonite"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "147",
+                                          "Name":  "Dratini"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Aqua Tail",
+                                  "Dragon Pulse",
+                                  "Wrap"
+                              ],
+        "BaseAttack":  163,
+        "BaseDefense":  138,
+        "BaseStamina":  122,
+        "CaptureRate":  0.08,
+        "FleeRate":  0.06,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "149",
+        "Name":  "Dragonite",
+        "Classification":  "Dragon Pokemon",
+        "Type I":  [
+                       "Dragon"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Ice",
+                           "Rock",
+                           "Dragon",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Dragon Breath",
+                               "Steel Wing"
+                           ],
+        "Weight":  "210.0 kg",
+        "Height":  "2.2 m",
+        "Candy":  {
+                      "Name":  "Dratini candies",
+                      "FamilyID":  147
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "147",
+                                          "Name":  "Dratini"
+                                      },
+                                      {
+                                          "Number":  "148",
+                                          "Name":  "Dragonair"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Dragon Claw",
+                                  "Dragon Pulse",
+                                  "Hyper Beam"
+                              ],
+        "BaseAttack":  263,
+        "BaseDefense":  201,
+        "BaseStamina":  182,
+        "CaptureRate":  0.04,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "150",
+        "Name":  "Mewtwo",
+        "Classification":  "Genetic Pokemon",
+        "Type I":  [
+                       "Psychic"
+                   ],
+        "Weaknesses":  [
+                           "Bug",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Confusion",
+                               "Psycho Cut"
+                           ],
+        "Weight":  "122.0 kg",
+        "Height":  "2.0 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  150
+                  },
+        "Special Attack(s)":  [
+                                  "Hyper Beam",
+                                  "Psychic",
+                                  "Shadow Ball"
+                              ],
+        "BaseAttack":  330,
+        "BaseDefense":  200,
+        "BaseStamina":  212,
+        "CaptureRate":  0,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "151",
+        "Name":  "Mew",
+        "Classification":  "New Species Pokemon",
+        "Type I":  [
+                       "Psychic"
+                   ],
+        "Weaknesses":  [
+                           "Bug",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Pound"
+                           ],
+        "Weight":  "4.0 kg",
+        "Height":  "0.4 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  151
+                  },
+        "Special Attack(s)":  [
+                                  "Blizzard",
+                                  "Dragon Pulse",
+                                  "Earthquake",
+                                  "Fire Blast",
+                                  "Hyper Beam",
+                                  "Psychic",
+                                  "Solar Beam",
+                                  "Thunder"
+                              ],
+        "BaseAttack":  210,
+        "BaseDefense":  210,
+        "BaseStamina":  200,
+        "CaptureRate":  0,
+        "FleeRate":  0.1,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "152",
+        "Name":  "Chikorita",
+        "Classification":  "Leaf Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Poison",
+                           "Flying",
+                           "Bug"
+                       ],
+        "Fast Attack(s)":  [
+                               "Razor Leaf",
+                               "Tackle"
+                           ],
+        "Weight":  "6.4 kg",
+        "Height":  "0.9 m",
+        "Candy":  {
+                      "Name":  "Chikorita candies",
+                      "FamilyID":  152
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  152,
+                                            "Name":  "Chikorita candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "153",
+                                      "Name":  "Bayleef"
+                                  },
+                                  {
+                                      "Number":  "154",
+                                      "Name":  "Meganium"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  92,
+        "BaseDefense":  122,
+        "BaseStamina":  90,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "153",
+        "Name":  "Bayleef",
+        "Classification":  "Leaf Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Poison",
+                           "Flying",
+                           "Bug"
+                       ],
+        "Fast Attack(s)":  [
+                               "Razor Leaf",
+                               "Tackle"
+                           ],
+        "Weight":  "15.8 kg",
+        "Height":  "1.2 m",
+        "Candy":  {
+                      "Name":  "Chikorita candies",
+                      "FamilyID":  152
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  100,
+                                            "Family":  152,
+                                            "Name":  "Chikorita candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "154",
+                                      "Name":  "Meganium"
+                                  }
+                              ],
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "152",
+                                          "Name":  "Chikorita"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  122,
+        "BaseDefense":  155,
+        "BaseStamina":  120,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "154",
+        "Name":  "Meganium",
+        "Classification":  "Herb Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Poison",
+                           "Flying",
+                           "Bug"
+                       ],
+        "Fast Attack(s)":  [
+                               "Razor Leaf",
+                               "Vine Whip"
+                           ],
+        "Weight":  "100.5 kg",
+        "Height":  "1.8 m",
+        "Candy":  {
+                      "Name":  "Chikorita candies",
+                      "FamilyID":  152
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "152",
+                                          "Name":  "Chikorita"
+                                      },
+                                      {
+                                          "Number":  "153",
+                                          "Name":  "Bayleef"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  168,
+        "BaseDefense":  202,
+        "BaseStamina":  160,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "155",
+        "Name":  "Cyndaquil",
+        "Classification":  "Fire Mouse Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Ember",
+                               "Tackle"
+                           ],
+        "Weight":  "7.9 kg",
+        "Height":  "0.5 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  155
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  116,
+        "BaseDefense":  96,
+        "BaseStamina":  78,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "156",
+        "Name":  "Quilava",
+        "Classification":  "Volcano Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Ember",
+                               "Tackle"
+                           ],
+        "Weight":  "19.0 kg",
+        "Height":  "0.9 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  155
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "155",
+                                          "Name":  "Cyndaquil"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  158,
+        "BaseDefense":  129,
+        "BaseStamina":  116,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "157",
+        "Name":  "Typhlosion",
+        "Classification":  "Volcano Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Ember",
+                               "Shadow Claw"
+                           ],
+        "Weight":  "79.5 kg",
+        "Height":  "1.7 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  155
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "155",
+                                          "Name":  "Cyndaquil"
+                                      },
+                                      {
+                                          "Number":  "156",
+                                          "Name":  "Quilava"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  223,
+        "BaseDefense":  176,
+        "BaseStamina":  156,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "158",
+        "Name":  "Totodile",
+        "Classification":  "Big Jaw Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Scratch",
+                               "Water Gun"
+                           ],
+        "Weight":  "9.5 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  158
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  117,
+        "BaseDefense":  116,
+        "BaseStamina":  100,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "159",
+        "Name":  "Croconaw",
+        "Classification":  "Big Jaw Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Scratch",
+                               "Water Gun"
+                           ],
+        "Weight":  "25.0 kg",
+        "Height":  "1.1 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  158
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "158",
+                                          "Name":  "Totodile"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  150,
+        "BaseDefense":  151,
+        "BaseStamina":  130,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "160",
+        "Name":  "Feraligatr",
+        "Classification":  "Big Jaw Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bite",
+                               "Water Gun"
+                           ],
+        "Weight":  "88.8 kg",
+        "Height":  "2.3 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  158
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "158",
+                                          "Name":  "Totodile"
+                                      },
+                                      {
+                                          "Number":  "159",
+                                          "Name":  "Croconaw"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  205,
+        "BaseDefense":  197,
+        "BaseStamina":  170,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "161",
+        "Name":  "Sentret",
+        "Classification":  "Scout Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Quick Attack",
+                               "Scratch"
+                           ],
+        "Weight":  "6.0 kg",
+        "Height":  "0.8 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  161
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  79,
+        "BaseDefense":  77,
+        "BaseStamina":  70,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "162",
+        "Name":  "Furret",
+        "Classification":  "Long Body Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Quick Attack",
+                               "Sucker Punch"
+                           ],
+        "Weight":  "32.5 kg",
+        "Height":  "1.8 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  161
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "161",
+                                          "Name":  "Sentret"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  148,
+        "BaseDefense":  130,
+        "BaseStamina":  170,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "163",
+        "Name":  "Hoothoot",
+        "Classification":  "Owl Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Peck",
+                               "Tackle"
+                           ],
+        "Weight":  "21.2 kg",
+        "Height":  "0.7 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  163
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  67,
+        "BaseDefense":  101,
+        "BaseStamina":  120,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "164",
+        "Name":  "Noctowl",
+        "Classification":  "Owl Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Peck",
+                               "Tackle"
+                           ],
+        "Weight":  "40.8 kg",
+        "Height":  "1.6 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  163
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "163",
+                                          "Name":  "Hoothoot"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  145,
+        "BaseDefense":  179,
+        "BaseStamina":  200,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "165",
+        "Name":  "Ledyba",
+        "Classification":  "Five Star Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Electric",
+                           "Ice",
+                           "Flying",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bug Bite",
+                               "Tackle"
+                           ],
+        "Weight":  "10.8 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  165
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  72,
+        "BaseDefense":  142,
+        "BaseStamina":  80,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "166",
+        "Name":  "Ledian",
+        "Classification":  "Five Star Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Electric",
+                           "Ice",
+                           "Flying",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bug Bite",
+                               "Tackle"
+                           ],
+        "Weight":  "35.6 kg",
+        "Height":  "1.4 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  165
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "165",
+                                          "Name":  "Ledyba"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  107,
+        "BaseDefense":  209,
+        "BaseStamina":  110,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "167",
+        "Name":  "Spinarak",
+        "Classification":  "String Spit Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Flying",
+                           "Psychic",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bug Bite",
+                               "Poison Sting"
+                           ],
+        "Weight":  "8.5 kg",
+        "Height":  "0.5 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  167
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  105,
+        "BaseDefense":  73,
+        "BaseStamina":  80,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "168",
+        "Name":  "Ariados",
+        "Classification":  "Long Leg Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Flying",
+                           "Psychic",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bug Bite",
+                               "Poison Sting"
+                           ],
+        "Weight":  "33.5 kg",
+        "Height":  "1.1 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  167
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "167",
+                                          "Name":  "Spinarak"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  161,
+        "BaseDefense":  128,
+        "BaseStamina":  140,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "169",
+        "Name":  "Crobat",
+        "Classification":  "Bat Pokemon",
+        "Type I":  [
+                       "Poison"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Psychic",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bite",
+                               "Wing Attack"
+                           ],
+        "Weight":  "75.0 kg",
+        "Height":  "1.8 m",
+        "Candy":  {
+                      "Name":  "Zubat candies",
+                      "FamilyID":  41
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "041",
+                                          "Name":  "Zubat"
+                                      },
+                                      {
+                                          "Number":  "042",
+                                          "Name":  "Golbat"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  194,
+        "BaseDefense":  178,
+        "BaseStamina":  170,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "170",
+        "Name":  "Chinchou",
+        "Classification":  "Angler Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Electric"
+                    ],
+        "Weaknesses":  [
+                           "Grass",
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bubble",
+                               "Spark"
+                           ],
+        "Weight":  "12.0 kg",
+        "Height":  "0.5 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  170
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  106,
+        "BaseDefense":  106,
+        "BaseStamina":  150,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "171",
+        "Name":  "Lanturn",
+        "Classification":  "Light Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Electric"
+                    ],
+        "Weaknesses":  [
+                           "Grass",
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Spark",
+                               "Water Gun"
+                           ],
+        "Weight":  "22.5 kg",
+        "Height":  "1.2 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  170
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "170",
+                                          "Name":  "Chinchou"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  146,
+        "BaseDefense":  146,
+        "BaseStamina":  250,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "172",
+        "Name":  "Pichu",
+        "Classification":  "Tiny Mouse Pokemon",
+        "Type I":  [
+                       "Electric"
+                   ],
+        "Weaknesses":  [
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Quick Attack",
+                               "Thunder Shock"
+                           ],
+        "Weight":  "2.0 kg",
+        "Height":  "0.3 m",
+        "Candy":  {
+                      "Name":  "Pikachu candies",
+                      "FamilyID":  25
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  25,
+                                            "Name":  "Pikachu candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "025",
+                                      "Name":  "Pikachu"
+                                  },
+                                  {
+                                      "Number":  "026",
+                                      "Name":  "Raichu"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Disarming Voice",
+                                  "Thunder Punch",
+                                  "Thunderbolt"
+                              ],
+        "BaseAttack":  77,
+        "BaseDefense":  63,
+        "BaseStamina":  40,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "173",
+        "Name":  "Cleffa",
+        "Classification":  "Star Shape Pokemon",
+        "Type I":  [
+                       "Fairy"
+                   ],
+        "Weaknesses":  [
+                           "Poison",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Pound",
+                               "Zen Headbutt"
+                           ],
+        "Weight":  "3.0 kg",
+        "Height":  "0.3 m",
+        "Candy":  {
+                      "Name":  "Clefairy candies",
+                      "FamilyID":  35
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  35,
+                                            "Name":  "Clefairy candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "035",
+                                      "Name":  "Clefairy"
+                                  },
+                                  {
+                                      "Number":  "036",
+                                      "Name":  "Clefable"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Body Slam",
+                                  "Psychic",
+                                  "Signal Beam"
+                              ],
+        "BaseAttack":  75,
+        "BaseDefense":  91,
+        "BaseStamina":  100,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "174",
+        "Name":  "Igglybuff",
+        "Classification":  "Balloon Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Type II":  [
+                        "Fairy"
+                    ],
+        "Weaknesses":  [
+                           "Poison",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Feint Attack",
+                               "Pound"
+                           ],
+        "Weight":  "1.0 kg",
+        "Height":  "0.3 m",
+        "Candy":  {
+                      "Name":  "Jigglypuff candies",
+                      "FamilyID":  39
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  39,
+                                            "Name":  "Jigglypuff candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "039",
+                                      "Name":  "Jigglypuff"
+                                  },
+                                  {
+                                      "Number":  "040",
+                                      "Name":  "Wigglytuff"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Body Slam",
+                                  "Psychic",
+                                  "Shadow Ball"
+                              ],
+        "BaseAttack":  69,
+        "BaseDefense":  34,
+        "BaseStamina":  180,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "175",
+        "Name":  "Togepi",
+        "Classification":  "Spike Ball Pokemon",
+        "Type I":  [
+                       "Fairy"
+                   ],
+        "Weaknesses":  [
+                           "Poison",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Peck",
+                               "Zen Headbutt"
+                           ],
+        "Weight":  "1.5 kg",
+        "Height":  "0.3 m",
+        "Candy":  {
+                      "Name":  "Togepi candies",
+                      "FamilyID":  175
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  50,
+                                            "Family":  175,
+                                            "Name":  "Togepi candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "176",
+                                      "Name":  "Togetic"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Ancient Power",
+                                  "Dazzling Gleam",
+                                  "Psyshock"
+                              ],
+        "BaseAttack":  67,
+        "BaseDefense":  116,
+        "BaseStamina":  70,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "176",
+        "Name":  "Togetic",
+        "Classification":  "Happiness Pokemon",
+        "Type I":  [
+                       "Fairy"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Poison",
+                           "Rock",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Steel Wing",
+                               "Zen Headbutt"
+                           ],
+        "Weight":  "3.2 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "Togepi candies",
+                      "FamilyID":  175
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "175",
+                                          "Name":  "Togepi"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Aerial Ace",
+                                  "Ancient Power",
+                                  "Dazzling Gleam"
+                              ],
+        "BaseAttack":  139,
+        "BaseDefense":  191,
+        "BaseStamina":  110,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "177",
+        "Name":  "Natu",
+        "Classification":  "Little Bird Pokemon",
+        "Type I":  [
+                       "Psychic"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Rock",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Peck"
+                           ],
+        "Weight":  "2.0 kg",
+        "Height":  "0.2 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  177
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  134,
+        "BaseDefense":  89,
+        "BaseStamina":  80,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "178",
+        "Name":  "Xatu",
+        "Classification":  "Mystic Pokemon",
+        "Type I":  [
+                       "Psychic"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Rock",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "15.0 kg",
+        "Height":  "1.5 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  177
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "177",
+                                          "Name":  "Natu"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  192,
+        "BaseDefense":  146,
+        "BaseStamina":  130,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "179",
+        "Name":  "Mareep",
+        "Classification":  "Wool Pokemon",
+        "Type I":  [
+                       "Electric"
+                   ],
+        "Weaknesses":  [
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "7.8 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  179
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  114,
+        "BaseDefense":  82,
+        "BaseStamina":  110,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "180",
+        "Name":  "Flaaffy",
+        "Classification":  "Wool Pokemon",
+        "Type I":  [
+                       "Electric"
+                   ],
+        "Weaknesses":  [
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "13.3 kg",
+        "Height":  "0.8 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  179
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "179",
+                                          "Name":  "Mareep"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  145,
+        "BaseDefense":  112,
+        "BaseStamina":  140,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "181",
+        "Name":  "Ampharos",
+        "Classification":  "Light Pokemon",
+        "Type I":  [
+                       "Electric"
+                   ],
+        "Weaknesses":  [
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "61.5 kg",
+        "Height":  "1.4 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  179
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "179",
+                                          "Name":  "Mareep"
+                                      },
+                                      {
+                                          "Number":  "180",
+                                          "Name":  "Flaaffy"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  211,
+        "BaseDefense":  172,
+        "BaseStamina":  180,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "182",
+        "Name":  "Bellossom",
+        "Classification":  "Flower Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Poison",
+                           "Flying",
+                           "Bug"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "5.8 kg",
+        "Height":  "0.4 m",
+        "Candy":  {
+                      "Name":  "Oddish candies",
+                      "FamilyID":  43
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "043",
+                                          "Name":  "Oddish"
+                                      },
+                                      {
+                                          "Number":  "044",
+                                          "Name":  "Gloom"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  169,
+        "BaseDefense":  189,
+        "BaseStamina":  150,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "183",
+        "Name":  "Marill",
+        "Classification":  "Aquamouse Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Fairy"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass",
+                           "Poison"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "8.5 kg",
+        "Height":  "0.4 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  183
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  37,
+        "BaseDefense":  93,
+        "BaseStamina":  140,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "184",
+        "Name":  "Azumarill",
+        "Classification":  "Aquarabbit Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Fairy"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass",
+                           "Poison"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "28.5 kg",
+        "Height":  "0.8 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  183
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "183",
+                                          "Name":  "Marill"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  112,
+        "BaseDefense":  152,
+        "BaseStamina":  200,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "185",
+        "Name":  "Sudowoodo",
+        "Classification":  "Imitation Pokemon",
+        "Type I":  [
+                       "Rock"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Fighting",
+                           "Ground",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "38.0 kg",
+        "Height":  "1.2 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  185
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  167,
+        "BaseDefense":  198,
+        "BaseStamina":  140,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "186",
+        "Name":  "Politoed",
+        "Classification":  "Frog Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "33.9 kg",
+        "Height":  "1.1 m",
+        "Candy":  {
+                      "Name":  "Poliwag candies",
+                      "FamilyID":  60
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "060",
+                                          "Name":  "Poliwag"
+                                      },
+                                      {
+                                          "Number":  "061",
+                                          "Name":  "Poliwhirl"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  174,
+        "BaseDefense":  192,
+        "BaseStamina":  180,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "187",
+        "Name":  "Hoppip",
+        "Classification":  "Cottonweed Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Poison",
+                           "Flying",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "0.5 kg",
+        "Height":  "0.4 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  187
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  67,
+        "BaseDefense":  101,
+        "BaseStamina":  70,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "188",
+        "Name":  "Skiploom",
+        "Classification":  "Cottonweed Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Poison",
+                           "Flying",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "1.0 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  187
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "187",
+                                          "Name":  "Hoppip"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  91,
+        "BaseDefense":  127,
+        "BaseStamina":  110,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "189",
+        "Name":  "Jumpluff",
+        "Classification":  "Cottonweed Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Poison",
+                           "Flying",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "3.0 kg",
+        "Height":  "0.8 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  187
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "187",
+                                          "Name":  "Hoppip"
+                                      },
+                                      {
+                                          "Number":  "188",
+                                          "Name":  "Skiploom"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  118,
+        "BaseDefense":  197,
+        "BaseStamina":  150,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "190",
+        "Name":  "Aipom",
+        "Classification":  "Long Tail Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "11.5 kg",
+        "Height":  "0.8 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  190
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  136,
+        "BaseDefense":  112,
+        "BaseStamina":  110,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "191",
+        "Name":  "Sunkern",
+        "Classification":  "Seed Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Poison",
+                           "Flying",
+                           "Bug"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "1.8 kg",
+        "Height":  "0.3 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  191
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  55,
+        "BaseDefense":  55,
+        "BaseStamina":  60,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "192",
+        "Name":  "Sunflora",
+        "Classification":  "Sun Pokemon",
+        "Type I":  [
+                       "Grass"
+                   ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Poison",
+                           "Flying",
+                           "Bug"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "8.5 kg",
+        "Height":  "0.8 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  191
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "191",
+                                          "Name":  "Sunkern"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  185,
+        "BaseDefense":  148,
+        "BaseStamina":  150,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "193",
+        "Name":  "Yanma",
+        "Classification":  "Clear Wing Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Electric",
+                           "Ice",
+                           "Flying",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "38.0 kg",
+        "Height":  "1.2 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  193
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  154,
+        "BaseDefense":  94,
+        "BaseStamina":  130,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "194",
+        "Name":  "Wooper",
+        "Classification":  "Water Fish Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Ground"
+                    ],
+        "Weaknesses":  [
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "8.5 kg",
+        "Height":  "0.4 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  194
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  75,
+        "BaseDefense":  75,
+        "BaseStamina":  110,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "195",
+        "Name":  "Quagsire",
+        "Classification":  "Water Fish Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Ground"
+                    ],
+        "Weaknesses":  [
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "75.0 kg",
+        "Height":  "1.4 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  194
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "194",
+                                          "Name":  "Wooper"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  152,
+        "BaseDefense":  152,
+        "BaseStamina":  190,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "196",
+        "Name":  "Espeon",
+        "Classification":  "Sun Pokemon",
+        "Type I":  [
+                       "Psychic"
+                   ],
+        "Weaknesses":  [
+                           "Bug",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Confusion",
+                               "Zen Headbutt"
+                           ],
+        "Weight":  "26.5 kg",
+        "Height":  "0.9 m",
+        "Candy":  {
+                      "Name":  "Eevee candies",
+                      "FamilyID":  133
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "133",
+                                          "Name":  "Eevee"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  261,
+        "BaseDefense":  194,
+        "BaseStamina":  130,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "197",
+        "Name":  "Umbreon",
+        "Classification":  "Moonlight Pokemon",
+        "Type I":  [
+                       "Dark"
+                   ],
+        "Weaknesses":  [
+                           "Fighting",
+                           "Bug",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Bite",
+                               "Feint Attack"
+                           ],
+        "Weight":  "27.0 kg",
+        "Height":  "1.0 m",
+        "Candy":  {
+                      "Name":  "Eevee candies",
+                      "FamilyID":  133
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "133",
+                                          "Name":  "Eevee"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  126,
+        "BaseDefense":  250,
+        "BaseStamina":  190,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "198",
+        "Name":  "Murkrow",
+        "Classification":  "Darkness Pokemon",
+        "Type I":  [
+                       "Dark"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Rock",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "2.1 kg",
+        "Height":  "0.5 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  198
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  175,
+        "BaseDefense":  87,
+        "BaseStamina":  120,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "199",
+        "Name":  "Slowking",
+        "Classification":  "Royal Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Psychic"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass",
+                           "Bug",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "79.5 kg",
+        "Height":  "2.0 m",
+        "Candy":  {
+                      "Name":  "Slowpoke candies",
+                      "FamilyID":  79
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "079",
+                                          "Name":  "Slowpoke"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  177,
+        "BaseDefense":  194,
+        "BaseStamina":  190,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "200",
+        "Name":  "Misdreavus",
+        "Classification":  "Screech Pokemon",
+        "Type I":  [
+                       "Ghost"
+                   ],
+        "Weaknesses":  [
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "1.0 kg",
+        "Height":  "0.7 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  200
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  167,
+        "BaseDefense":  167,
+        "BaseStamina":  120,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "201",
+        "Name":  "Unown",
+        "Classification":  "Symbol Pokemon",
+        "Type I":  [
+                       "Psychic"
+                   ],
+        "Weaknesses":  [
+                           "Bug",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "5.0 kg",
+        "Height":  "0.5 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  201
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  136,
+        "BaseDefense":  91,
+        "BaseStamina":  96,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "202",
+        "Name":  "Wobbuffet",
+        "Classification":  "Patient Pokemon",
+        "Type I":  [
+                       "Psychic"
+                   ],
+        "Weaknesses":  [
+                           "Bug",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "28.5 kg",
+        "Height":  "1.3 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  202
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  60,
+        "BaseDefense":  106,
+        "BaseStamina":  380,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "203",
+        "Name":  "Girafarig",
+        "Classification":  "Long Neck Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Type II":  [
+                        "Psychic"
+                    ],
+        "Weaknesses":  [
+                           "Bug",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "41.5 kg",
+        "Height":  "1.5 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  203
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  182,
+        "BaseDefense":  133,
+        "BaseStamina":  140,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "204",
+        "Name":  "Pineco",
+        "Classification":  "Bagworm Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Flying",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "7.2 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  204
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  108,
+        "BaseDefense":  146,
+        "BaseStamina":  100,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "205",
+        "Name":  "Forretress",
+        "Classification":  "Bagworm Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Steel"
+                    ],
+        "Weaknesses":  [
+                           "Fire"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "125.8 kg",
+        "Height":  "1.2 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  204
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "204",
+                                          "Name":  "Pineco"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  161,
+        "BaseDefense":  242,
+        "BaseStamina":  150,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "206",
+        "Name":  "Dunsparce",
+        "Classification":  "Land Snake Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "14.0 kg",
+        "Height":  "1.5 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  206
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  131,
+        "BaseDefense":  131,
+        "BaseStamina":  200,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "207",
+        "Name":  "Gligar",
+        "Classification":  "Flyscorpion Pokemon",
+        "Type I":  [
+                       "Ground"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ice"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "64.8 kg",
+        "Height":  "1.1 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  207
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  143,
+        "BaseDefense":  204,
+        "BaseStamina":  130,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "208",
+        "Name":  "Steelix",
+        "Classification":  "Iron Snake Pokemon",
+        "Type I":  [
+                       "Steel"
+                   ],
+        "Type II":  [
+                        "Ground"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Water",
+                           "Fighting",
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "400.0 kg",
+        "Height":  "9.2 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  95
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "095",
+                                          "Name":  "Onix"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  148,
+        "BaseDefense":  333,
+        "BaseStamina":  150,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "209",
+        "Name":  "Snubbull",
+        "Classification":  "Fairy Pokemon",
+        "Type I":  [
+                       "Fairy"
+                   ],
+        "Weaknesses":  [
+                           "Poison",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "7.8 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  209
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  137,
+        "BaseDefense":  89,
+        "BaseStamina":  120,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "210",
+        "Name":  "Granbull",
+        "Classification":  "Fairy Pokemon",
+        "Type I":  [
+                       "Fairy"
+                   ],
+        "Weaknesses":  [
+                           "Poison",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "48.7 kg",
+        "Height":  "1.4 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  209
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "209",
+                                          "Name":  "Snubbull"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  212,
+        "BaseDefense":  137,
+        "BaseStamina":  180,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "211",
+        "Name":  "Qwilfish",
+        "Classification":  "Balloon Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Poison"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ground",
+                           "Psychic"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "3.9 kg",
+        "Height":  "0.5 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  211
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  184,
+        "BaseDefense":  148,
+        "BaseStamina":  130,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "212",
+        "Name":  "Scizor",
+        "Classification":  "Pincer Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Steel"
+                    ],
+        "Weaknesses":  [
+                           "Fire"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "118.0 kg",
+        "Height":  "1.8 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  123
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "123",
+                                          "Name":  "Scyther"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  236,
+        "BaseDefense":  191,
+        "BaseStamina":  140,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "213",
+        "Name":  "Shuckle",
+        "Classification":  "Mold Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Rock"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Rock",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "20.5 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  213
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  17,
+        "BaseDefense":  396,
+        "BaseStamina":  40,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "214",
+        "Name":  "Heracross",
+        "Classification":  "Singlehorn Pokemon",
+        "Type I":  [
+                       "Bug"
+                   ],
+        "Type II":  [
+                        "Fighting"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Flying",
+                           "Psychic",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "54.0 kg",
+        "Height":  "1.5 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  214
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  234,
+        "BaseDefense":  189,
+        "BaseStamina":  160,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "215",
+        "Name":  "Sneasel",
+        "Classification":  "Sharp Claw Pokemon",
+        "Type I":  [
+                       "Dark"
+                   ],
+        "Type II":  [
+                        "Ice"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Fighting",
+                           "Bug",
+                           "Rock",
+                           "Steel",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "28.0 kg",
+        "Height":  "0.9 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  215
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  189,
+        "BaseDefense":  157,
+        "BaseStamina":  110,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "216",
+        "Name":  "Teddiursa",
+        "Classification":  "Little Bear Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "8.8 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  216
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  142,
+        "BaseDefense":  93,
+        "BaseStamina":  120,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "217",
+        "Name":  "Ursaring",
+        "Classification":  "Hibernator Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "125.8 kg",
+        "Height":  "1.8 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  216
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "216",
+                                          "Name":  "Teddiursa"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  236,
+        "BaseDefense":  144,
+        "BaseStamina":  180,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "218",
+        "Name":  "Slugma",
+        "Classification":  "Lava Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "35.0 kg",
+        "Height":  "0.7 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  218
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  118,
+        "BaseDefense":  71,
+        "BaseStamina":  80,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "219",
+        "Name":  "Magcargo",
+        "Classification":  "Lava Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Type II":  [
+                        "Rock"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Fighting",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "55.0 kg",
+        "Height":  "0.8 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  218
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "218",
+                                          "Name":  "Slugma"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  139,
+        "BaseDefense":  209,
+        "BaseStamina":  100,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "220",
+        "Name":  "Swinub",
+        "Classification":  "Pig Pokemon",
+        "Type I":  [
+                       "Ice"
+                   ],
+        "Type II":  [
+                        "Ground"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Water",
+                           "Grass",
+                           "Fighting",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "6.5 kg",
+        "Height":  "0.4 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  220
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  90,
+        "BaseDefense":  74,
+        "BaseStamina":  100,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "221",
+        "Name":  "Piloswine",
+        "Classification":  "Swine Pokemon",
+        "Type I":  [
+                       "Ice"
+                   ],
+        "Type II":  [
+                        "Ground"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Water",
+                           "Grass",
+                           "Fighting",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "55.8 kg",
+        "Height":  "1.1 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  220
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "220",
+                                          "Name":  "Swinub"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  181,
+        "BaseDefense":  147,
+        "BaseStamina":  200,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "222",
+        "Name":  "Corsola",
+        "Classification":  "Coral Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Rock"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass",
+                           "Fighting",
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "5.0 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  222
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  118,
+        "BaseDefense":  156,
+        "BaseStamina":  110,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "223",
+        "Name":  "Remoraid",
+        "Classification":  "Jet Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "12.0 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  223
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  127,
+        "BaseDefense":  69,
+        "BaseStamina":  70,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "224",
+        "Name":  "Octillery",
+        "Classification":  "Jet Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "28.5 kg",
+        "Height":  "0.9 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  223
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "223",
+                                          "Name":  "Remoraid"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  197,
+        "BaseDefense":  141,
+        "BaseStamina":  150,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "225",
+        "Name":  "Delibird",
+        "Classification":  "Delivery Pokemon",
+        "Type I":  [
+                       "Ice"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Electric",
+                           "Rock",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "16.0 kg",
+        "Height":  "0.9 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  225
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  128,
+        "BaseDefense":  90,
+        "BaseStamina":  90,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "226",
+        "Name":  "Mantine",
+        "Classification":  "Kite Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "220.0 kg",
+        "Height":  "2.1 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  226
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  148,
+        "BaseDefense":  260,
+        "BaseStamina":  130,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "227",
+        "Name":  "Skarmory",
+        "Classification":  "Armor Bird Pokemon",
+        "Type I":  [
+                       "Steel"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Electric"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "50.5 kg",
+        "Height":  "1.7 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  227
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  148,
+        "BaseDefense":  260,
+        "BaseStamina":  130,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "228",
+        "Name":  "Houndour",
+        "Classification":  "Dark Pokemon",
+        "Type I":  [
+                       "Dark"
+                   ],
+        "Type II":  [
+                        "Fire"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Fighting",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "10.8 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  228
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  152,
+        "BaseDefense":  93,
+        "BaseStamina":  90,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "229",
+        "Name":  "Houndoom",
+        "Classification":  "Dark Pokemon",
+        "Type I":  [
+                       "Dark"
+                   ],
+        "Type II":  [
+                        "Fire"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Fighting",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "35.0 kg",
+        "Height":  "1.4 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  228
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "228",
+                                          "Name":  "Houndour"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  224,
+        "BaseDefense":  159,
+        "BaseStamina":  150,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "230",
+        "Name":  "Kingdra",
+        "Classification":  "Dragon Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Type II":  [
+                        "Dragon"
+                    ],
+        "Weaknesses":  [
+                           "Dragon",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "152.0 kg",
+        "Height":  "1.8 m",
+        "Candy":  {
+                      "Name":  "Horsea candies",
+                      "FamilyID":  116
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "116",
+                                          "Name":  "Horsea"
+                                      },
+                                      {
+                                          "Number":  "117",
+                                          "Name":  "Seadra"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  194,
+        "BaseDefense":  194,
+        "BaseStamina":  150,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "231",
+        "Name":  "Phanpy",
+        "Classification":  "Long Nose Pokemon",
+        "Type I":  [
+                       "Ground"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Ice"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "33.5 kg",
+        "Height":  "0.5 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  231
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  107,
+        "BaseDefense":  107,
+        "BaseStamina":  180,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "232",
+        "Name":  "Donphan",
+        "Classification":  "Armor Pokemon",
+        "Type I":  [
+                       "Ground"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Ice"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "120.0 kg",
+        "Height":  "1.1 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  231
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "231",
+                                          "Name":  "Phanpy"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  214,
+        "BaseDefense":  214,
+        "BaseStamina":  180,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "233",
+        "Name":  "Porygon2",
+        "Classification":  "Virtual Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "32.5 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  137
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "137",
+                                          "Name":  "Porygon"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  198,
+        "BaseDefense":  183,
+        "BaseStamina":  170,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "234",
+        "Name":  "Stantler",
+        "Classification":  "Big Horn Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "71.2 kg",
+        "Height":  "1.4 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  234
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  192,
+        "BaseDefense":  132,
+        "BaseStamina":  146,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "235",
+        "Name":  "Smeargle",
+        "Classification":  "Painter Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "58.0 kg",
+        "Height":  "1.2 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  235
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  40,
+        "BaseDefense":  88,
+        "BaseStamina":  110,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "236",
+        "Name":  "Tyrogue",
+        "Classification":  "Scuffle Pokemon",
+        "Type I":  [
+                       "Fighting"
+                   ],
+        "Weaknesses":  [
+                           "Flying",
+                           "Psychic",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Low Kick",
+                               "Rock Smash"
+                           ],
+        "Weight":  "21.0 kg",
+        "Height":  "0.7 m",
+        "Candy":  {
+                      "Name":  "Tyrogue candies",
+                      "FamilyID":  236
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  236,
+                                            "Name":  "Tyrogue candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "106",
+                                      "Name":  "Hitmonlee"
+                                  },
+                                  {
+                                      "Number":  "107",
+                                      "Name":  "Hitmonchan"
+                                  },
+                                  {
+                                      "Number":  "237",
+                                      "Name":  "Hitmontop"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Body Slam",
+                                  "Brick Break",
+                                  "Low Sweep"
+                              ],
+        "BaseAttack":  64,
+        "BaseDefense":  64,
+        "BaseStamina":  70,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "237",
+        "Name":  "Hitmontop",
+        "Classification":  "Handstand Pokemon",
+        "Type I":  [
+                       "Fighting"
+                   ],
+        "Weaknesses":  [
+                           "Flying",
+                           "Psychic",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "48.0 kg",
+        "Height":  "1.4 m",
+        "Candy":  {
+                      "Name":  "Tyrogue candies",
+                      "FamilyID":  236
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "236",
+                                          "Name":  "Tyrogue"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  173,
+        "BaseDefense":  214,
+        "BaseStamina":  100,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "238",
+        "Name":  "Smoochum",
+        "Classification":  "Kiss Pokemon",
+        "Type I":  [
+                       "Ice"
+                   ],
+        "Type II":  [
+                        "Psychic"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Bug",
+                           "Rock",
+                           "Ghost",
+                           "Dark",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Frost Breath",
+                               "Pound"
+                           ],
+        "Weight":  "6.0 kg",
+        "Height":  "0.4 m",
+        "Candy":  {
+                      "Name":  "Jynx candies",
+                      "FamilyID":  124
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  124,
+                                            "Name":  "Jynx candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "124",
+                                      "Name":  "Jynx"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Ice Beam",
+                                  "Ice Punch",
+                                  "Psyshock"
+                              ],
+        "BaseAttack":  153,
+        "BaseDefense":  116,
+        "BaseStamina":  90,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "239",
+        "Name":  "Elekid",
+        "Classification":  "Electric Pokemon",
+        "Type I":  [
+                       "Electric"
+                   ],
+        "Weaknesses":  [
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Low Kick",
+                               "Thunder Shock"
+                           ],
+        "Weight":  "23.5 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "Electabuzz candies",
+                      "FamilyID":  125
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  125,
+                                            "Name":  "Electabuzz candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "125",
+                                      "Name":  "Electabuzz"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Discharge",
+                                  "Thunder Punch",
+                                  "Thunderbolt"
+                              ],
+        "BaseAttack":  135,
+        "BaseDefense":  110,
+        "BaseStamina":  90,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "240",
+        "Name":  "Magby",
+        "Classification":  "Live Coal Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Ember",
+                               "Karate Chop"
+                           ],
+        "Weight":  "21.4 kg",
+        "Height":  "0.7 m",
+        "Candy":  {
+                      "Name":  "Magmar candies",
+                      "FamilyID":  126
+                  },
+        "Next Evolution Requirements":  {
+                                            "Amount":  25,
+                                            "Family":  126,
+                                            "Name":  "Magmar candies"
+                                        },
+        "Next evolution(s)":  [
+                                  {
+                                      "Number":  "126",
+                                      "Name":  "Magmar"
+                                  }
+                              ],
+        "Special Attack(s)":  [
+                                  "Brick Break",
+                                  "Fire Punch",
+                                  "Flamethrower"
+                              ],
+        "BaseAttack":  151,
+        "BaseDefense":  108,
+        "BaseStamina":  90,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  5
+    },
+    {
+        "Number":  "241",
+        "Name":  "Miltank",
+        "Classification":  "Milk Cow Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "75.5 kg",
+        "Height":  "1.2 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  241
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  157,
+        "BaseDefense":  211,
+        "BaseStamina":  190,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "242",
+        "Name":  "Blissey",
+        "Classification":  "Happiness Pokemon",
+        "Type I":  [
+                       "Normal"
+                   ],
+        "Weaknesses":  [
+                           "Fighting"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "46.8 kg",
+        "Height":  "1.5 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  113
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "113",
+                                          "Name":  "Chansey"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  129,
+        "BaseDefense":  229,
+        "BaseStamina":  510,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "243",
+        "Name":  "Raikou",
+        "Classification":  "Thunder Pokemon",
+        "Type I":  [
+                       "Electric"
+                   ],
+        "Weaknesses":  [
+                           "Ground"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "178.0 kg",
+        "Height":  "1.9 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  243
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  241,
+        "BaseDefense":  210,
+        "BaseStamina":  180,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "244",
+        "Name":  "Entei",
+        "Classification":  "Volcano Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Weaknesses":  [
+                           "Water",
+                           "Ground",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "198.0 kg",
+        "Height":  "2.1 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  244
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  235,
+        "BaseDefense":  176,
+        "BaseStamina":  230,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "245",
+        "Name":  "Suicune",
+        "Classification":  "Aurora Pokemon",
+        "Type I":  [
+                       "Water"
+                   ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Grass"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "187.0 kg",
+        "Height":  "2.0 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  245
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  180,
+        "BaseDefense":  235,
+        "BaseStamina":  200,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "246",
+        "Name":  "Larvitar",
+        "Classification":  "Rock Skin Pokemon",
+        "Type I":  [
+                       "Rock"
+                   ],
+        "Type II":  [
+                        "Ground"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Ice",
+                           "Fighting",
+                           "Ground",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "72.0 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  246
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  115,
+        "BaseDefense":  93,
+        "BaseStamina":  100,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "247",
+        "Name":  "Pupitar",
+        "Classification":  "Hard Shell Pokemon",
+        "Type I":  [
+                       "Rock"
+                   ],
+        "Type II":  [
+                        "Ground"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Ice",
+                           "Fighting",
+                           "Ground",
+                           "Steel"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "152.0 kg",
+        "Height":  "1.2 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  246
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "246",
+                                          "Name":  "Larvitar"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  155,
+        "BaseDefense":  133,
+        "BaseStamina":  140,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "248",
+        "Name":  "Tyranitar",
+        "Classification":  "Armor Pokemon",
+        "Type I":  [
+                       "Rock"
+                   ],
+        "Type II":  [
+                        "Dark"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Grass",
+                           "Fighting",
+                           "Ground",
+                           "Bug",
+                           "Steel",
+                           "Fairy"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "202.0 kg",
+        "Height":  "2.0 m",
+        "Candy":  {
+                      "Name":  null,
+                      "FamilyID":  246
+                  },
+        "Previous evolution(s)":  [
+                                      {
+                                          "Number":  "246",
+                                          "Name":  "Larvitar"
+                                      },
+                                      {
+                                          "Number":  "247",
+                                          "Name":  "Pupitar"
+                                      }
+                                  ],
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  251,
+        "BaseDefense":  212,
+        "BaseStamina":  200,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "249",
+        "Name":  "Lugia",
+        "Classification":  "Diving Pokemon",
+        "Type I":  [
+                       "Psychic"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Electric",
+                           "Ice",
+                           "Rock",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "216.0 kg",
+        "Height":  "5.2 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  249
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  193,
+        "BaseDefense":  323,
+        "BaseStamina":  212,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "250",
+        "Name":  "Ho oh",
+        "Classification":  "Rainbow Pokemon",
+        "Type I":  [
+                       "Fire"
+                   ],
+        "Type II":  [
+                        "Flying"
+                    ],
+        "Weaknesses":  [
+                           "Water",
+                           "Electric",
+                           "Rock"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "199.0 kg",
+        "Height":  "3.8 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  250
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  263,
+        "BaseDefense":  301,
+        "BaseStamina":  212,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
+    },
+    {
+        "Number":  "251",
+        "Name":  "Celebi",
+        "Classification":  "Time Travel Pokemon",
+        "Type I":  [
+                       "Psychic"
+                   ],
+        "Type II":  [
+                        "Grass"
+                    ],
+        "Weaknesses":  [
+                           "Fire",
+                           "Ice",
+                           "Poison",
+                           "Flying",
+                           "Bug",
+                           "Ghost",
+                           "Dark"
+                       ],
+        "Fast Attack(s)":  [
+                               "Tackle"
+                           ],
+        "Weight":  "5.0 kg",
+        "Height":  "0.6 m",
+        "Candy":  {
+                      "Name":  "",
+                      "FamilyID":  251
+                  },
+        "Special Attack(s)":  [
+                                  "Struggle"
+                              ],
+        "BaseAttack":  210,
+        "BaseDefense":  210,
+        "BaseStamina":  200,
+        "CaptureRate":  0,
+        "FleeRate":  0.05,
+        "BuddyDistanceNeeded":  1
     }
 ]

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -4170,7 +4170,8 @@
                        ],
         "Fast Attack(s)":  [
                                "Lick",
-                               "Poison Jab"
+                               "Poison Jab",
+                               "Acid"
                            ],
         "Weight":  "30.0 kg",
         "Height":  "1.2 m",
@@ -5888,7 +5889,8 @@
                            "Rock"
                        ],
         "Fast Attack(s)":  [
-                               "Bite"
+                               "Bite",
+                               "Dragon Breath"
                            ],
         "Weight":  "235.0 kg",
         "Height":  "6.5 m",
@@ -6166,6 +6168,7 @@
                        ],
         "Fast Attack(s)":  [
                                "Tackle",
+                               "Quick Attack",
                                "Zen Headbutt"
                            ],
         "Weight":  "36.5 kg",

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -3911,7 +3911,7 @@
         "Weight":  "15.0 kg",
         "Height":  "0.8 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Farfetchd candies",
                       "FamilyID":  83
                   },
         "Special Attack(s)":  [
@@ -4457,7 +4457,7 @@
         "Weight":  "210.0 kg",
         "Height":  "8.8 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Onix candies",
                       "FamilyID":  95
                   },
         "Special Attack(s)":  [
@@ -5002,7 +5002,7 @@
         "Weight":  "65.5 kg",
         "Height":  "1.2 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Lickitung candies",
                       "FamilyID":  108
                   },
         "Special Attack(s)":  [
@@ -5212,7 +5212,7 @@
         "Weight":  "34.6 kg",
         "Height":  "1.1 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Chansey candies",
                       "FamilyID":  113
                   },
         "Special Attack(s)":  [
@@ -5247,7 +5247,7 @@
         "Weight":  "35.0 kg",
         "Height":  "1.0 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Tangela candies",
                       "FamilyID":  114
                   },
         "Special Attack(s)":  [
@@ -5279,7 +5279,7 @@
         "Weight":  "80.0 kg",
         "Height":  "2.2 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Kangaskhan candies",
                       "FamilyID":  115
                   },
         "Special Attack(s)":  [
@@ -5575,7 +5575,7 @@
         "Weight":  "54.5 kg",
         "Height":  "1.3 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Mr Mime candies",
                       "FamilyID":  122
                   },
         "Special Attack(s)":  [
@@ -5614,7 +5614,7 @@
         "Weight":  "56.0 kg",
         "Height":  "1.5 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Scyther candies",
                       "FamilyID":  123
                   },
         "Special Attack(s)":  [
@@ -5772,7 +5772,7 @@
         "Weight":  "55.0 kg",
         "Height":  "1.5 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Pinsir candies",
                       "FamilyID":  127
                   },
         "Special Attack(s)":  [
@@ -5804,7 +5804,7 @@
         "Weight":  "88.4 kg",
         "Height":  "1.4 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Tauros candies",
                       "FamilyID":  128
                   },
         "Special Attack(s)":  [
@@ -5924,7 +5924,7 @@
         "Weight":  "220.0 kg",
         "Height":  "2.5 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Lapras candies",
                       "FamilyID":  131
                   },
         "Special Attack(s)":  [
@@ -5955,7 +5955,7 @@
         "Weight":  "4.0 kg",
         "Height":  "0.3 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Ditto candies",
                       "FamilyID":  132
                   },
         "Special Attack(s)":  [
@@ -6158,7 +6158,7 @@
         "Weight":  "36.5 kg",
         "Height":  "0.8 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Porygon candies",
                       "FamilyID":  137
                   },
         "Special Attack(s)":  [
@@ -6383,7 +6383,7 @@
         "Weight":  "59.0 kg",
         "Height":  "1.8 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Aerodactyl candies",
                       "FamilyID":  142
                   },
         "Special Attack(s)":  [
@@ -6415,7 +6415,7 @@
         "Weight":  "460.0 kg",
         "Height":  "2.1 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Snorlax candies",
                       "FamilyID":  143
                   },
         "Special Attack(s)":  [
@@ -6452,7 +6452,7 @@
         "Weight":  "55.4 kg",
         "Height":  "1.7 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Articuno candies",
                       "FamilyID":  144
                   },
         "Special Attack(s)":  [
@@ -6487,7 +6487,7 @@
         "Weight":  "52.6 kg",
         "Height":  "1.6 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Zapdos candies",
                       "FamilyID":  145
                   },
         "Special Attack(s)":  [
@@ -6523,7 +6523,7 @@
         "Weight":  "60.0 kg",
         "Height":  "2.0 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Moltres candies",
                       "FamilyID":  146
                   },
         "Special Attack(s)":  [
@@ -6703,7 +6703,7 @@
         "Weight":  "122.0 kg",
         "Height":  "2.0 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Mewtwo candies",
                       "FamilyID":  150
                   },
         "Special Attack(s)":  [
@@ -6736,7 +6736,7 @@
         "Weight":  "4.0 kg",
         "Height":  "0.4 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Mew candies",
                       "FamilyID":  151
                   },
         "Special Attack(s)":  [
@@ -6919,7 +6919,7 @@
         "Weight":  "7.9 kg",
         "Height":  "0.5 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Cyndaquil candies",
                       "FamilyID":  155
                   },
         "Special Attack(s)":  [
@@ -6951,7 +6951,7 @@
         "Weight":  "19.0 kg",
         "Height":  "0.9 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Cyndaquil candies",
                       "FamilyID":  155
                   },
         "Previous evolution(s)":  [
@@ -6989,7 +6989,7 @@
         "Weight":  "79.5 kg",
         "Height":  "1.7 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Cyndaquil candies",
                       "FamilyID":  155
                   },
         "Previous evolution(s)":  [
@@ -7030,7 +7030,7 @@
         "Weight":  "9.5 kg",
         "Height":  "0.6 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Totodile candies",
                       "FamilyID":  158
                   },
         "Special Attack(s)":  [
@@ -7061,7 +7061,7 @@
         "Weight":  "25.0 kg",
         "Height":  "1.1 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Totodile candies",
                       "FamilyID":  158
                   },
         "Previous evolution(s)":  [
@@ -7098,7 +7098,7 @@
         "Weight":  "88.8 kg",
         "Height":  "2.3 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Totodile candies",
                       "FamilyID":  158
                   },
         "Previous evolution(s)":  [
@@ -7138,7 +7138,7 @@
         "Weight":  "6.0 kg",
         "Height":  "0.8 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Sentret candies",
                       "FamilyID":  161
                   },
         "Special Attack(s)":  [
@@ -7168,7 +7168,7 @@
         "Weight":  "32.5 kg",
         "Height":  "1.8 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Sentret candies",
                       "FamilyID":  161
                   },
         "Previous evolution(s)":  [
@@ -7209,7 +7209,7 @@
         "Weight":  "21.2 kg",
         "Height":  "0.7 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Hoothoot candies",
                       "FamilyID":  163
                   },
         "Special Attack(s)":  [
@@ -7244,7 +7244,7 @@
         "Weight":  "40.8 kg",
         "Height":  "1.6 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Hoothoot candies",
                       "FamilyID":  163
                   },
         "Previous evolution(s)":  [
@@ -7287,7 +7287,7 @@
         "Weight":  "10.8 kg",
         "Height":  "1.0 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Ledyba candies",
                       "FamilyID":  165
                   },
         "Special Attack(s)":  [
@@ -7324,7 +7324,7 @@
         "Weight":  "35.6 kg",
         "Height":  "1.4 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Ledyba candies",
                       "FamilyID":  165
                   },
         "Previous evolution(s)":  [
@@ -7366,7 +7366,7 @@
         "Weight":  "8.5 kg",
         "Height":  "0.5 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Spinarak candies",
                       "FamilyID":  167
                   },
         "Special Attack(s)":  [
@@ -7402,7 +7402,7 @@
         "Weight":  "33.5 kg",
         "Height":  "1.1 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Spinarak candies",
                       "FamilyID":  167
                   },
         "Previous evolution(s)":  [
@@ -7488,7 +7488,7 @@
         "Weight":  "12.0 kg",
         "Height":  "0.5 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Chinchou candies",
                       "FamilyID":  170
                   },
         "Special Attack(s)":  [
@@ -7522,7 +7522,7 @@
         "Weight":  "22.5 kg",
         "Height":  "1.2 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Chinchou candies",
                       "FamilyID":  170
                   },
         "Previous evolution(s)":  [
@@ -7799,7 +7799,7 @@
         "Weight":  "2.0 kg",
         "Height":  "0.2 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Natu candies",
                       "FamilyID":  177
                   },
         "Special Attack(s)":  [
@@ -7835,7 +7835,7 @@
         "Weight":  "15.0 kg",
         "Height":  "1.5 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Natu candies",
                       "FamilyID":  177
                   },
         "Previous evolution(s)":  [
@@ -7870,7 +7870,7 @@
         "Weight":  "7.8 kg",
         "Height":  "0.6 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Mareep candies",
                       "FamilyID":  179
                   },
         "Special Attack(s)":  [
@@ -7899,7 +7899,7 @@
         "Weight":  "13.3 kg",
         "Height":  "0.8 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Mareep candies",
                       "FamilyID":  179
                   },
         "Previous evolution(s)":  [
@@ -7934,7 +7934,7 @@
         "Weight":  "61.5 kg",
         "Height":  "1.4 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Mareep candies",
                       "FamilyID":  179
                   },
         "Previous evolution(s)":  [
@@ -8021,7 +8021,7 @@
         "Weight":  "8.5 kg",
         "Height":  "0.4 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Marill candies",
                       "FamilyID":  183
                   },
         "Special Attack(s)":  [
@@ -8055,7 +8055,7 @@
         "Weight":  "28.5 kg",
         "Height":  "0.8 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Marill candies",
                       "FamilyID":  183
                   },
         "Previous evolution(s)":  [
@@ -8094,7 +8094,7 @@
         "Weight":  "38.0 kg",
         "Height":  "1.2 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Sudowoodo candies",
                       "FamilyID":  185
                   },
         "Special Attack(s)":  [
@@ -8170,7 +8170,7 @@
         "Weight":  "0.5 kg",
         "Height":  "0.4 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Hoppip candies",
                       "FamilyID":  187
                   },
         "Special Attack(s)":  [
@@ -8206,7 +8206,7 @@
         "Weight":  "1.0 kg",
         "Height":  "0.6 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Hoppip candies",
                       "FamilyID":  187
                   },
         "Previous evolution(s)":  [
@@ -8248,7 +8248,7 @@
         "Weight":  "3.0 kg",
         "Height":  "0.8 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Hoppip candies",
                       "FamilyID":  187
                   },
         "Previous evolution(s)":  [
@@ -8287,7 +8287,7 @@
         "Weight":  "11.5 kg",
         "Height":  "0.8 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Aipom candies",
                       "FamilyID":  190
                   },
         "Special Attack(s)":  [
@@ -8320,7 +8320,7 @@
         "Weight":  "1.8 kg",
         "Height":  "0.3 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Sunkern candies",
                       "FamilyID":  191
                   },
         "Special Attack(s)":  [
@@ -8353,7 +8353,7 @@
         "Weight":  "8.5 kg",
         "Height":  "0.8 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Sunkern candies",
                       "FamilyID":  191
                   },
         "Previous evolution(s)":  [
@@ -8395,7 +8395,7 @@
         "Weight":  "38.0 kg",
         "Height":  "1.2 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Yanma candies",
                       "FamilyID":  193
                   },
         "Special Attack(s)":  [
@@ -8427,7 +8427,7 @@
         "Weight":  "8.5 kg",
         "Height":  "0.4 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Wooper candies",
                       "FamilyID":  194
                   },
         "Special Attack(s)":  [
@@ -8459,7 +8459,7 @@
         "Weight":  "75.0 kg",
         "Height":  "1.4 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Wooper candies",
                       "FamilyID":  194
                   },
         "Previous evolution(s)":  [
@@ -8576,7 +8576,7 @@
         "Weight":  "2.1 kg",
         "Height":  "0.5 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Murkrow candies",
                       "FamilyID":  198
                   },
         "Special Attack(s)":  [
@@ -8648,7 +8648,7 @@
         "Weight":  "1.0 kg",
         "Height":  "0.7 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Misdreavus candies",
                       "FamilyID":  200
                   },
         "Special Attack(s)":  [
@@ -8679,7 +8679,7 @@
         "Weight":  "5.0 kg",
         "Height":  "0.5 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Unown candies",
                       "FamilyID":  201
                   },
         "Special Attack(s)":  [
@@ -8710,7 +8710,7 @@
         "Weight":  "28.5 kg",
         "Height":  "1.3 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Wobbuffet candies",
                       "FamilyID":  202
                   },
         "Special Attack(s)":  [
@@ -8743,7 +8743,7 @@
         "Weight":  "41.5 kg",
         "Height":  "1.5 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Girafarig candies",
                       "FamilyID":  203
                   },
         "Special Attack(s)":  [
@@ -8774,7 +8774,7 @@
         "Weight":  "7.2 kg",
         "Height":  "0.6 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Pineco candies",
                       "FamilyID":  204
                   },
         "Special Attack(s)":  [
@@ -8806,7 +8806,7 @@
         "Weight":  "125.8 kg",
         "Height":  "1.2 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Pineco candies",
                       "FamilyID":  204
                   },
         "Previous evolution(s)":  [
@@ -8841,7 +8841,7 @@
         "Weight":  "14.0 kg",
         "Height":  "1.5 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Dunsparce candies",
                       "FamilyID":  206
                   },
         "Special Attack(s)":  [
@@ -8874,7 +8874,7 @@
         "Weight":  "64.8 kg",
         "Height":  "1.1 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Gligar candies",
                       "FamilyID":  207
                   },
         "Special Attack(s)":  [
@@ -8909,7 +8909,7 @@
         "Weight":  "400.0 kg",
         "Height":  "9.2 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Onix candies",
                       "FamilyID":  95
                   },
         "Previous evolution(s)":  [
@@ -8945,7 +8945,7 @@
         "Weight":  "7.8 kg",
         "Height":  "0.6 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Snubbull candies",
                       "FamilyID":  209
                   },
         "Special Attack(s)":  [
@@ -8975,7 +8975,7 @@
         "Weight":  "48.7 kg",
         "Height":  "1.4 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Snubbull candies",
                       "FamilyID":  209
                   },
         "Previous evolution(s)":  [
@@ -9015,7 +9015,7 @@
         "Weight":  "3.9 kg",
         "Height":  "0.5 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Qwilfish candies",
                       "FamilyID":  211
                   },
         "Special Attack(s)":  [
@@ -9047,7 +9047,7 @@
         "Weight":  "118.0 kg",
         "Height":  "1.8 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Scyther candies",
                       "FamilyID":  123
                   },
         "Previous evolution(s)":  [
@@ -9087,7 +9087,7 @@
         "Weight":  "20.5 kg",
         "Height":  "0.6 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Shuckle candies",
                       "FamilyID":  213
                   },
         "Special Attack(s)":  [
@@ -9122,7 +9122,7 @@
         "Weight":  "54.0 kg",
         "Height":  "1.5 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Heracross candies",
                       "FamilyID":  214
                   },
         "Special Attack(s)":  [
@@ -9159,7 +9159,7 @@
         "Weight":  "28.0 kg",
         "Height":  "0.9 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Sneasel candies",
                       "FamilyID":  215
                   },
         "Special Attack(s)":  [
@@ -9188,7 +9188,7 @@
         "Weight":  "8.8 kg",
         "Height":  "0.6 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Teddiursa candies",
                       "FamilyID":  216
                   },
         "Special Attack(s)":  [
@@ -9217,7 +9217,7 @@
         "Weight":  "125.8 kg",
         "Height":  "1.8 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Teddiursa candies",
                       "FamilyID":  216
                   },
         "Previous evolution(s)":  [
@@ -9254,7 +9254,7 @@
         "Weight":  "35.0 kg",
         "Height":  "0.7 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Slugma candies",
                       "FamilyID":  218
                   },
         "Special Attack(s)":  [
@@ -9289,7 +9289,7 @@
         "Weight":  "55.0 kg",
         "Height":  "0.8 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Slugma candies",
                       "FamilyID":  218
                   },
         "Previous evolution(s)":  [
@@ -9331,7 +9331,7 @@
         "Weight":  "6.5 kg",
         "Height":  "0.4 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Swinub candies",
                       "FamilyID":  220
                   },
         "Special Attack(s)":  [
@@ -9367,7 +9367,7 @@
         "Weight":  "55.8 kg",
         "Height":  "1.1 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Swinub candies",
                       "FamilyID":  220
                   },
         "Previous evolution(s)":  [
@@ -9408,7 +9408,7 @@
         "Weight":  "5.0 kg",
         "Height":  "0.6 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Corsola candies",
                       "FamilyID":  222
                   },
         "Special Attack(s)":  [
@@ -9438,7 +9438,7 @@
         "Weight":  "12.0 kg",
         "Height":  "0.6 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Remoraid candies",
                       "FamilyID":  223
                   },
         "Special Attack(s)":  [
@@ -9468,7 +9468,7 @@
         "Weight":  "28.5 kg",
         "Height":  "0.9 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Remoraid candies",
                       "FamilyID":  223
                   },
         "Previous evolution(s)":  [
@@ -9509,7 +9509,7 @@
         "Weight":  "16.0 kg",
         "Height":  "0.9 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Delibird candies",
                       "FamilyID":  225
                   },
         "Special Attack(s)":  [
@@ -9542,7 +9542,7 @@
         "Weight":  "220.0 kg",
         "Height":  "2.1 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Mantine candies",
                       "FamilyID":  226
                   },
         "Special Attack(s)":  [
@@ -9575,7 +9575,7 @@
         "Weight":  "50.5 kg",
         "Height":  "1.7 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Skarmory candies",
                       "FamilyID":  227
                   },
         "Special Attack(s)":  [
@@ -9610,7 +9610,7 @@
         "Weight":  "10.8 kg",
         "Height":  "0.6 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Houndour candies",
                       "FamilyID":  228
                   },
         "Special Attack(s)":  [
@@ -9645,7 +9645,7 @@
         "Weight":  "35.0 kg",
         "Height":  "1.4 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Houndour candies",
                       "FamilyID":  228
                   },
         "Previous evolution(s)":  [
@@ -9725,7 +9725,7 @@
         "Weight":  "33.5 kg",
         "Height":  "0.5 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Phanpy candies",
                       "FamilyID":  231
                   },
         "Special Attack(s)":  [
@@ -9756,7 +9756,7 @@
         "Weight":  "120.0 kg",
         "Height":  "1.1 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Phanpy candies",
                       "FamilyID":  231
                   },
         "Previous evolution(s)":  [
@@ -9791,7 +9791,7 @@
         "Weight":  "32.5 kg",
         "Height":  "0.6 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Porygon candies",
                       "FamilyID":  137
                   },
         "Previous evolution(s)":  [
@@ -9826,7 +9826,7 @@
         "Weight":  "71.2 kg",
         "Height":  "1.4 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Stantler candies",
                       "FamilyID":  234
                   },
         "Special Attack(s)":  [
@@ -9855,7 +9855,7 @@
         "Weight":  "58.0 kg",
         "Height":  "1.2 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Smeargle candies",
                       "FamilyID":  235
                   },
         "Special Attack(s)":  [
@@ -10113,7 +10113,7 @@
         "Weight":  "75.5 kg",
         "Height":  "1.2 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Miltank candies",
                       "FamilyID":  241
                   },
         "Special Attack(s)":  [
@@ -10142,7 +10142,7 @@
         "Weight":  "46.8 kg",
         "Height":  "1.5 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Chansey candies",
                       "FamilyID":  113
                   },
         "Previous evolution(s)":  [
@@ -10177,7 +10177,7 @@
         "Weight":  "178.0 kg",
         "Height":  "1.9 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Raikou candies",
                       "FamilyID":  243
                   },
         "Special Attack(s)":  [
@@ -10208,7 +10208,7 @@
         "Weight":  "198.0 kg",
         "Height":  "2.1 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Entei candies",
                       "FamilyID":  244
                   },
         "Special Attack(s)":  [
@@ -10238,7 +10238,7 @@
         "Weight":  "187.0 kg",
         "Height":  "2.0 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Suicune candies",
                       "FamilyID":  245
                   },
         "Special Attack(s)":  [
@@ -10275,7 +10275,7 @@
         "Weight":  "72.0 kg",
         "Height":  "0.6 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Larvitar candies",
                       "FamilyID":  246
                   },
         "Special Attack(s)":  [
@@ -10312,7 +10312,7 @@
         "Weight":  "152.0 kg",
         "Height":  "1.2 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Larvitar candies",
                       "FamilyID":  246
                   },
         "Previous evolution(s)":  [
@@ -10356,7 +10356,7 @@
         "Weight":  "202.0 kg",
         "Height":  "2.0 m",
         "Candy":  {
-                      "Name":  null,
+                      "Name":  "Larvitar candies",
                       "FamilyID":  246
                   },
         "Previous evolution(s)":  [
@@ -10402,7 +10402,7 @@
         "Weight":  "216.0 kg",
         "Height":  "5.2 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Lugia candies",
                       "FamilyID":  249
                   },
         "Special Attack(s)":  [
@@ -10436,7 +10436,7 @@
         "Weight":  "199.0 kg",
         "Height":  "3.8 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Ho oh candies",
                       "FamilyID":  250
                   },
         "Special Attack(s)":  [
@@ -10474,7 +10474,7 @@
         "Weight":  "5.0 kg",
         "Height":  "0.6 m",
         "Candy":  {
-                      "Name":  "",
+                      "Name":  "Celebi candies",
                       "FamilyID":  251
                   },
         "Special Attack(s)":  [

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -1326,7 +1326,7 @@
     },
     {
         "Number":  "029",
-        "Name":  "Nidoran",
+        "Name":  "Nidoran F",
         "Classification":  "Poison Pin Pokemon",
         "Type I":  [
                        "Poison"
@@ -1407,7 +1407,7 @@
         "Previous evolution(s)":  [
                                       {
                                           "Number":  "029",
-                                          "Name":  "Nidoran"
+                                          "Name":  "Nidoran F"
                                       }
                                   ],
         "Special Attack(s)":  [
@@ -1451,7 +1451,7 @@
         "Previous evolution(s)":  [
                                       {
                                           "Number":  "029",
-                                          "Name":  "Nidoran"
+                                          "Name":  "Nidoran F"
                                       },
                                       {
                                           "Number":  "030",
@@ -1472,7 +1472,7 @@
     },
     {
         "Number":  "032",
-        "Name":  "Nidoran",
+        "Name":  "Nidoran M",
         "Classification":  "Poison Pin Pokemon",
         "Type I":  [
                        "Poison"
@@ -1553,7 +1553,7 @@
         "Previous evolution(s)":  [
                                       {
                                           "Number":  "032",
-                                          "Name":  "Nidoran"
+                                          "Name":  "Nidoran M"
                                       }
                                   ],
         "Special Attack(s)":  [
@@ -1597,7 +1597,7 @@
         "Previous evolution(s)":  [
                                       {
                                           "Number":  "032",
-                                          "Name":  "Nidoran"
+                                          "Name":  "Nidoran M"
                                       },
                                       {
                                           "Number":  "033",
@@ -4923,8 +4923,8 @@
         "Weight":  "49.8 kg",
         "Height":  "1.5 m",
         "Candy":  {
-                      "Name":  "Tyrogue candies",
-                      "FamilyID":  236
+                      "Name":  "Hitmonlee candies",
+                      "FamilyID":  106
                   },
         "Previous evolution(s)":  [
                                       {
@@ -4963,8 +4963,8 @@
         "Weight":  "50.2 kg",
         "Height":  "1.4 m",
         "Candy":  {
-                      "Name":  "Tyrogue candies",
-                      "FamilyID":  236
+                      "Name":  "Hitmonchan candies",
+                      "FamilyID":  107
                   },
         "Previous evolution(s)":  [
                                       {
@@ -9939,8 +9939,8 @@
         "Weight":  "48.0 kg",
         "Height":  "1.4 m",
         "Candy":  {
-                      "Name":  "Tyrogue candies",
-                      "FamilyID":  236
+                      "Name":  "Hitmontop candies",
+                      "FamilyID":  237
                   },
         "Previous evolution(s)":  [
                                       {

--- a/pokecli.py
+++ b/pokecli.py
@@ -493,6 +493,15 @@ def init_config():
     add_config(
         parser,
         load,
+        short_flag="-hk",
+        long_flag="--hashkey",
+        help="Set Bossland hashing key",
+        type=str,
+        default=None
+    )
+    add_config(
+        parser,
+        load,
         short_flag="-e",
         long_flag="--show_events",
         help="Show events",

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -1416,7 +1416,7 @@ class PokemonGoBot(object):
                 i = 0
                 for badge in self._awarded_badges['awarded_badges']:
                     badgelevel = self._awarded_badges['awarded_badge_levels'][i]
-                    badgename = BadgeType_pb2._BADGETYPE.values_by_number[badge].name
+                    badgename = badge_type_pb2._BADGETYPE.values_by_number[badge].name
                     i += 1
                     self.event_manager.emit(
                         'badges',

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -40,7 +40,7 @@ from .tree_config_builder import MismatchTaskApiVersion
 from .tree_config_builder import TreeConfigBuilder
 from .inventory import init_inventory, player
 from sys import platform as _platform
-from pgoapi.protos.POGOProtos.Enums import BadgeType_pb2
+from pgoapi.protos.pogoprotos.enums import badge_type_pb2
 from pgoapi.exceptions import AuthException
 
 

--- a/pokemongo_bot/api_wrapper.py
+++ b/pokemongo_bot/api_wrapper.py
@@ -39,7 +39,8 @@ class ApiWrapper(PGoApi, object):
         }
 
         PGoApi.__init__(self, device_info=device_info)
-        PGoApi.activate_hash_server(self,self.config.hashkey)
+        if not self.config.hashkey is None:
+            PGoApi.activate_hash_server(self,self.config.hashkey)
         # Set to default, just for CI...
         self.actual_lat, self.actual_lng, self.actual_alt = PGoApi.get_position(self)
         self.teleporting = False

--- a/pokemongo_bot/api_wrapper.py
+++ b/pokemongo_bot/api_wrapper.py
@@ -11,7 +11,7 @@ from pgoapi.exceptions import (ServerSideRequestThrottlingException,
 from pgoapi.pgoapi import PGoApi
 from pgoapi.pgoapi import PGoApiRequest
 from pgoapi.pgoapi import RpcApi
-from pgoapi.protos.POGOProtos.Networking.Requests.RequestType_pb2 import RequestType
+from pgoapi.protos.pogoprotos.networking.requests.request_type_pb2 import RequestType
 from pgoapi.utilities import get_time
 from .human_behaviour import sleep, gps_noise_rng
 from pokemongo_bot.base_dir import _base_dir
@@ -39,7 +39,7 @@ class ApiWrapper(PGoApi, object):
         }
 
         PGoApi.__init__(self, device_info=device_info)
-
+        PGoApi.activate_hash_server(self,self.config.hashkey)
         # Set to default, just for CI...
         self.actual_lat, self.actual_lng, self.actual_alt = PGoApi.get_position(self)
         self.teleporting = False

--- a/pokemongo_bot/api_wrapper.py
+++ b/pokemongo_bot/api_wrapper.py
@@ -6,7 +6,7 @@ import hashlib
 import os
 from pgoapi.exceptions import (ServerSideRequestThrottlingException,
                                NotLoggedInException, ServerBusyOrOfflineException,
-                               NoPlayerPositionSetException, EmptySubrequestChainException,
+                               NoPlayerPositionSetException, 
                                UnexpectedResponseException)
 from pgoapi.pgoapi import PGoApi
 from pgoapi.pgoapi import PGoApiRequest

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -302,7 +302,7 @@ class Sniper(BaseTask):
             self._trace('{} is catchable!'.format(pokemon.get('pokemon_name')))
         else:
             # Not catchable. Having a good IV should suppress the not in catch/vip list (most important)
-            if pokemon.get('iv', 0) and pokemon.get('iv', 0) < self.special_iv:
+            if pokemon.get('iv', 0) and pokemon.get('iv', 0) <= self.special_iv:
                 self._trace('{} is not catchable, but has a decent IV!'.format(pokemon.get('pokemon_name')))
             else:
                 # Not catchable and IV is not good enough (if any). Check VIP list

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -344,7 +344,7 @@ class Sniper(BaseTask):
 
                 # If social is enabled and if no verification is needed, trust it. Otherwise, update IDs!
                 verify = not pokemon.get('encounter_id') or not pokemon.get('spawn_point_id')
-                exists = not verify and self.mode == SniperMode.SOCIAL
+                exists = not verify or self.mode == SniperMode.SOCIAL
                 success = exists
 
                 # If information verification have to be done, do so

--- a/pokemongo_bot/inventory.py
+++ b/pokemongo_bot/inventory.py
@@ -150,7 +150,7 @@ class Candies(_BaseInventoryComponent):
 
     @classmethod
     def family_id_for(cls, pokemon_id):
-        return Pokemons.first_evolution_id_for(pokemon_id)
+        return Pokemons.candyid_for(pokemon_id)
 
     def get(self, pokemon_id):
         family_id = self.family_id_for(pokemon_id)
@@ -450,6 +450,9 @@ class Pokemons(_BaseInventoryComponent):
     @classmethod
     def name_for(cls, pokemon_id):
         return cls.data_for(pokemon_id).name
+    @classmethod
+    def candyid_for(cls, pokemon_id):
+        return cls.data_for(pokemon_id).candyid
 
     @classmethod
     def id_for(cls, pokemon_name):
@@ -827,6 +830,9 @@ class PokemonInfo(object):
         self.last_evolution_ids = [self.id]
         # ids of the next possible evolutions (one level only)
         self.next_evolution_ids = []
+        #candies
+        self.candyid = int(data['Candy']['FamilyID'])
+        self.candyName = (data['Candy']['Name'])
         # ids of all available next evolutions in the family
         self.next_evolutions_all = []
         if self.has_next_evolution:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.11.0
 networkx==1.11
--e git+https://github.com/pogodevorg/pgoapi.git#egg=pgoapi
+git+https://github.com/pogodevorg/pgoapi.git@develop#egg=pgoapi
 geopy==1.11.0
 geographiclib==1.46.3
 protobuf==3.0.0b4


### PR DESCRIPTION
Added support for Bosslands hash service (https://hashing.pogodev.org ), therefore for 0.51 api and gen2 pokemons.

My first PR here.. :-)

## Fixes/Resolves/Closes: 
Fixes #5850 

I've also made a separate PR to PokemonGo-Web, which is merged now
-
-
-
