### PR TITLE
Added dependency for urllib 1.18, telegram bot doesn't work with urll…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ paho-mqtt==1.2
 Geohash==1.0
 python-telegram-bot==5.0.0
 discord_simple==0.0.1.15
+urllib3==1.18


### PR DESCRIPTION
## Short Description:
The bot installs urllib3 version 1.20 by default.  This version of urllib3 doesn't work with the Telegram bot.  This change sets the urllib3 dependency version to 1.18 so that the Telegram bot can function correctly.

## Fixes/Resolves/Closes (please use correct syntax):
Fixes #5891 
