### PR TITLE
Fix an error in getting award km

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_optimizer.py
+++ b/pokemongo_bot/cell_workers/pokemon_optimizer.py
@@ -264,6 +264,9 @@ class PokemonOptimizer(BaseTask):
 
         if distance_walked >= distance_needed:
             self.get_buddy_walked(pokemon)
+            # self.buddy["start_km_walked"] can be empty here
+            if 'start_km_walked' not in self.buddy:
+                self.buddy["start_km_walked"] = 0
             self.buddy["last_km_awarded"] = self.buddy["start_km_walked"] + distance_needed * int(distance_walked / distance_needed)
             self.lock_buddy = False
         else:
@@ -917,7 +920,7 @@ class PokemonOptimizer(BaseTask):
             action_delay(self.config_action_wait_min, self.config_action_wait_max)
 
         return True
-        
+
     def _get_buddyid(self):
         if self.buddy and'id' in self.buddy:
             return self.buddy['id']


### PR DESCRIPTION
## Short Description:
I noticed a crash when a buddy was already set, the start KM would be
zero, crashing this logic. Simple fix; check if present and set to 0
when not found. Seems to do the trick.

## Fixes/Resolves/Closes (please use correct syntax):
- A buddy crash I noticed :smile:
