### PR TITLE
Poke hunter lockon

### DIFF
--- a/configs/config.json.hunter.example
+++ b/configs/config.json.hunter.example
@@ -7,7 +7,8 @@
                 "max_distance": 1500,
                 "hunt_all": false,
                 "hunt_vip": true,
-                "hunt_pokedex": true
+                "hunt_pokedex": true,
+                "lock_on_target": false
             }
         },
         {

--- a/pokemongo_bot/cell_workers/pokemon_hunter.py
+++ b/pokemongo_bot/cell_workers/pokemon_hunter.py
@@ -93,9 +93,8 @@ class PokemonHunter(BaseTask):
 
             if self.lost_counter >= 3:
                 self.logger.info("I haven't found %(name)s", self.destination)
+                self.bot.hunter_locked_target = None
                 self.destination = None
-                if self.bot.hunter_locked_target != None:
-                    self.bot.hunter_locked_target = None
             else:
                 self.logger.info("Now searching for %(name)s", self.destination)
 
@@ -104,6 +103,8 @@ class PokemonHunter(BaseTask):
         elif self.no_log_until < now:
             distance = great_circle(self.bot.position, (self.walker.dest_lat, self.walker.dest_lng)).meters
             self.logger.info("Moving to destination at %s meters: %s", round(distance, 2), self.destination["name"])
+            if self.config_lock_on_target:
+                self.bot.hunter_locked_target = self.destination
             self.no_log_until = now + 30
 
         return WorkerResult.RUNNING

--- a/pokemongo_bot/cell_workers/pokemon_hunter.py
+++ b/pokemongo_bot/cell_workers/pokemon_hunter.py
@@ -94,6 +94,8 @@ class PokemonHunter(BaseTask):
             if self.lost_counter >= 3:
                 self.logger.info("I haven't found %(name)s", self.destination)
                 self.destination = None
+                if self.bot.hunter_locked_target != None:
+                    self.bot.hunter_locked_target = None
             else:
                 self.logger.info("Now searching for %(name)s", self.destination)
 

--- a/pokemongo_bot/cell_workers/pokemon_hunter.py
+++ b/pokemongo_bot/cell_workers/pokemon_hunter.py
@@ -33,7 +33,7 @@ class PokemonHunter(BaseTask):
         self.config_hunt_vip = self.config.get("hunt_vip", True)
         self.config_hunt_pokedex = self.config.get("hunt_pokedex", True)
         # Lock on Target; ignore all other Pokémon until we found our target.
-        self.config_lock_on_target = self.config.get("lock_on_target", True)
+        self.config_lock_on_target = self.config.get("lock_on_target", False)
         self.bot.hunter_locked_target = None
 
     def work(self):

--- a/pokemongo_bot/cell_workers/pokemon_hunter.py
+++ b/pokemongo_bot/cell_workers/pokemon_hunter.py
@@ -32,6 +32,9 @@ class PokemonHunter(BaseTask):
         self.config_hunt_all = self.config.get("hunt_all", False)
         self.config_hunt_vip = self.config.get("hunt_vip", True)
         self.config_hunt_pokedex = self.config.get("hunt_pokedex", True)
+        # Lock on Target; ignore all other Pokémon until we found our target.
+        self.config_lock_on_target = self.config.get("lock_on_target", True)
+        self.bot.hunter_locked_target = None
 
     def work(self):
         if not self.enabled:
@@ -63,6 +66,8 @@ class PokemonHunter(BaseTask):
 
                 self.logger.info("New destination at %(distance).2f meters: %(name)s", self.destination)
                 self.no_log_until = now + 60
+                if self.config_lock_on_target:
+                    self.bot.hunter_locked_target = self.destination
 
                 if self.destination["s2_cell_id"] != self.search_cell_id:
                     self.search_points = self.get_search_points(self.destination["s2_cell_id"])
@@ -87,6 +92,7 @@ class PokemonHunter(BaseTask):
                 self.lost_counter = 0
 
             if self.lost_counter >= 3:
+                self.logger.info("I haven't found %(name)s", self.destination)
                 self.destination = None
             else:
                 self.logger.info("Now searching for %(name)s", self.destination)


### PR DESCRIPTION
## Short Description:
In a Pokemon littered place (London, or where ever) the Pokemon Hunter sometimes doesn't get to a needed Pokemon, because there are all kind of trash pokemon (compaired to the missing one you're hunting) and the bot will catch those first.

Normally this isn't a problem. But because hunting is safer then sniping (no teleporting, just walking to a Pokemon) and I hope to catch those rares better.

Default setting is false (don't "Lock on") and when enabled the bot will notify you when skipping a Pokemon because of the lock on :smile: 
