### PR TITLE
Eliminate error caused by typo

### DIFF
--- a/pokemongo_bot/cell_workers/update_live_inventory.py
+++ b/pokemongo_bot/cell_workers/update_live_inventory.py
@@ -41,7 +41,7 @@ class UpdateLiveInventory(BaseTask):
         'blukberries'
         'nanabberries'
         'wapabberries'
-        'pinabberries'
+        'pinapberries'
         'luckyegg'
         'incubator'
         'troydisk'
@@ -166,7 +166,7 @@ class UpdateLiveInventory(BaseTask):
             'blukberries': 'BlukBerries: {:,}'.format(self.inventory.get(702).count),
             'nanabberries': 'NanabBerries: {:,}'.format(self.inventory.get(703).count),
             'wepabberries': 'WeparBerries: {:,}'.format(self.inventory.get(704).count),
-            'pinabberries': 'PinapBerries: {:,}'.format(self.inventory.get(705).count),
+            'pinapberries': 'PinapBerries: {:,}'.format(self.inventory.get(705).count),
             'luckyegg': 'LuckyEgg: {:,}'.format(self.inventory.get(301).count),
             'incubator': 'Incubator: {:,}'.format(self.inventory.get(902).count),
             'troydisk': 'TroyDisk: {:,}'.format(self.inventory.get(501).count),


### PR DESCRIPTION
Currently when "pinapberries" is specified in the item list under `UpdateLiveInventory` in `config.json`, the following exception is raised:
```
File "./pokemongo_bot/cell_workers/update_live_inventory.py", line 200, in get_item
    raise ConfigException("item '{}' isn't available for displaying".format(item))
pokemongo_bot.tree_config_builder.ConfigException: item 'pinapberries' isn't available for displaying
```

It turns out "pinapberries" is misspelled as "pinabberries"; this update serves to eliminate the typo.