### PR TITLE
Changes to using berries

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -291,6 +291,8 @@
                 "mode": "social",
                 "bullets": 1,
                 "homing_shots": true,
+                "cooldown_enabled": false,
+                "loiter_after_snipe": false,
                 "special_iv": 100,
                 "order": [
                     "missing",
@@ -405,7 +407,7 @@
                 "berry_threshold": 0.35,
 		 "use_pinap_on_vip": false,
                 "vip_berry_threshold": 0.9,
-                "treat_unseen_as_vip": false,
+                "treat_unseen_as_vip": true,
                 "daily_catch_limit": 800,
                 "vanish_settings": {
                     "consecutive_vanish_limit": 10,

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -291,8 +291,6 @@
                 "mode": "social",
                 "bullets": 1,
                 "homing_shots": true,
-                "cooldown_enabled": false,
-                "loiter_after_snipe": false,
                 "special_iv": 100,
                 "order": [
                     "missing",
@@ -405,8 +403,9 @@
                 "catch_incensed_pokemon": true,
                 "min_ultraball_to_keep": 5,
                 "berry_threshold": 0.35,
+		 "use_pinap_on_vip": false,
                 "vip_berry_threshold": 0.9,
-                "treat_unseen_as_vip": true,
+                "treat_unseen_as_vip": false,
                 "daily_catch_limit": 800,
                 "vanish_settings": {
                     "consecutive_vanish_limit": 10,

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -603,6 +603,7 @@ The default settings are 'safe' settings intended to simulate human and app beha
 "catch_lured_pokemon": true,
 "min_ultraball_to_keep": 5,
 "berry_threshold": 0.35,
+"use_pinap_on_vip": false,
 "vip_berry_threshold": 0.9,
 "catch_throw_parameters": {
   "excellent_rate": 0.1,
@@ -631,6 +632,7 @@ Setting | Description
 ---- | ----
 `min_ultraball_to_keep` | Allows the bot to use ultraballs on non-VIP pokemon as long as number of ultraballs is above this setting
 `berry_threshold` | The ideal catch rate threshold before using a razz berry on normal pokemon (higher threshold means using razz berries more frequently, for example if we raise `berry_threshold` to 0.5, any pokemon that has an initial catch rate between 0 to 0.5 will initiate a berry throw)
+`use_pinap_on_vip` | Use pinap berry instead of razz berry on on VIP pokemon. The bot will use razz berry if pinap berry has run out
 `vip_berry_threshold` | The ideal catch rate threshold before using a razz berry on VIP pokemon
 `flee_count` | The maximum number of times catching animation will play before the pokemon breaks free
 `flee_duration` | The length of time for each animation

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -517,7 +517,7 @@ class PokemonGoBot(object):
         self.event_manager.register_event('skip_evolve')
         self.event_manager.register_event('threw_berry_failed', parameters=('status_code',))
         self.event_manager.register_event('vip_pokemon')
-        self.event_manager.register_event('gained_candy', parameters=('quantity', 'type'))
+        self.event_manager.register_event('gained_candy', parameters=('gained_candy', 'quantity', 'type'))
         self.event_manager.register_event('catch_limit')
         self.event_manager.register_event('spin_limit')
         self.event_manager.register_event('show_best_pokemon', parameters=('pokemons'))


### PR DESCRIPTION
Changes from using old API call to new API call

- Added Pinap Berry Support #5942
- Pinap berry will be used instead of Razz Berry if use_pinap_on_vip is set to true (Under ctach_pokemon task)
- Razz berry will still be used when running out of Pinap Berries
- Amount of candies gained will be reported as it is no longer fixed at 3
- Updated documenation
- Updated config examples