### PR TITLE
Optimizer fix

### DIFF
--- a/pokemongo_bot/cell_workers/pokemon_optimizer.py
+++ b/pokemongo_bot/cell_workers/pokemon_optimizer.py
@@ -129,27 +129,81 @@ class PokemonOptimizer(BaseTask):
         if self.lock_buddy and (self.get_pokemon_slot_left() > self.config_min_slots_left):
             return WorkerResult.SUCCESS
 
-        self.open_inventory()
+        if self.get_pokemon_slot_left() > self.config_min_slots_left:
+            return WorkerResult.SUCCESS
 
-        keep_all = []
-        try_evolve_all = []
-        try_upgrade_all = []
-        buddy_all = []
+        # Repeat the optimizer 2 times, to get rid of the trash evolved.
+        # Moved up from 227 to see if we fix issue #5999
+        for _ in itertools.repeat(None, 2):
+            self.open_inventory()
 
-        for rule in self.config_rules:
-            mode = rule.get("mode", "by_family")
-            names = rule.get("names", [])
-            whitelist, blacklist = self.get_colorlist(names)
+            keep_all = []
+            try_evolve_all = []
+            try_upgrade_all = []
+            buddy_all = []
 
-            if mode == "by_pokemon":
-                for pokemon_id, pokemon_list in self.group_by_pokemon_id(inventory.pokemons().all()):
-                    name = inventory.pokemons().name_for(pokemon_id)
+            for rule in self.config_rules:
+                mode = rule.get("mode", "by_family")
+                names = rule.get("names", [])
+                whitelist, blacklist = self.get_colorlist(names)
 
-                    if name in blacklist:
-                        continue
+                if mode == "by_pokemon":
+                    for pokemon_id, pokemon_list in self.group_by_pokemon_id(inventory.pokemons().all()):
+                        name = inventory.pokemons().name_for(pokemon_id)
 
-                    if whitelist and (name not in whitelist):
-                        continue
+                        if name in blacklist:
+                            continue
+
+                        if whitelist and (name not in whitelist):
+                            continue
+
+                        sorted_list = self.score_and_sort(pokemon_list, rule)
+
+                        if len(sorted_list) == 0:
+                            continue
+
+                        keep, try_evolve, try_upgrade, buddy = self.get_best_pokemon_for_rule(sorted_list, rule)
+                        keep_all += keep
+                        try_evolve_all += try_evolve
+                        try_upgrade_all += try_upgrade
+                        buddy_all += buddy
+                elif mode == "by_family":
+                    for family_id, pokemon_list in self.group_by_family_id(inventory.pokemons().all()):
+                        matching_names = self.get_family_names(family_id)
+
+                        if any(n in blacklist for n in matching_names):
+                            continue
+
+                        if whitelist and not any(n in whitelist for n in matching_names):
+                            continue
+
+                        sorted_list = self.score_and_sort(pokemon_list, rule)
+
+                        if len(sorted_list) == 0:
+                            continue
+
+                        if family_id == 133:  # "Eevee"
+                            keep, try_evolve, try_upgrade, buddy = self.get_multi_best_pokemon_for_rule(sorted_list, rule, 3)
+                        else:
+                            keep, try_evolve, try_upgrade, buddy = self.get_best_pokemon_for_rule(sorted_list, rule)
+
+                        keep_all += keep
+                        try_evolve_all += try_evolve
+                        try_upgrade_all += try_upgrade
+                        buddy_all += buddy
+                elif mode == "overall":
+                    pokemon_list = []
+
+                    for pokemon in inventory.pokemons().all():
+                        name = pokemon.name
+
+                        if name in blacklist:
+                            continue
+
+                        if whitelist and (name not in whitelist):
+                            continue
+
+                        pokemon_list.append(pokemon)
 
                     sorted_list = self.score_and_sort(pokemon_list, rule)
 
@@ -161,71 +215,23 @@ class PokemonOptimizer(BaseTask):
                     try_evolve_all += try_evolve
                     try_upgrade_all += try_upgrade
                     buddy_all += buddy
-            elif mode == "by_family":
-                for family_id, pokemon_list in self.group_by_family_id(inventory.pokemons().all()):
-                    matching_names = self.get_family_names(family_id)
 
-                    if any(n in blacklist for n in matching_names):
-                        continue
+            keep_all = self.unique_pokemon_list(keep_all)
+            try_evolve_all = self.unique_pokemon_list(try_evolve_all)
+            try_upgrade_all = self.unique_pokemon_list(try_upgrade_all)
+            buddy_all = self.unique_pokemon_list(buddy_all)
 
-                    if whitelist and not any(n in whitelist for n in matching_names):
-                        continue
+            if (not self.lock_buddy) and (len(buddy_all) > 0):
+                new_buddy = buddy_all[0]
 
-                    sorted_list = self.score_and_sort(pokemon_list, rule)
+                if (not self.buddy) or (self.buddy["id"] != new_buddy.unique_id):
+                    self.set_buddy_pokemon(new_buddy)
 
-                    if len(sorted_list) == 0:
-                        continue
-
-                    if family_id == 133:  # "Eevee"
-                        keep, try_evolve, try_upgrade, buddy = self.get_multi_best_pokemon_for_rule(sorted_list, rule, 3)
-                    else:
-                        keep, try_evolve, try_upgrade, buddy = self.get_best_pokemon_for_rule(sorted_list, rule)
-
-                    keep_all += keep
-                    try_evolve_all += try_evolve
-                    try_upgrade_all += try_upgrade
-                    buddy_all += buddy
-            elif mode == "overall":
-                pokemon_list = []
-
-                for pokemon in inventory.pokemons().all():
-                    name = pokemon.name
-
-                    if name in blacklist:
-                        continue
-
-                    if whitelist and (name not in whitelist):
-                        continue
-
-                    pokemon_list.append(pokemon)
-
-                sorted_list = self.score_and_sort(pokemon_list, rule)
-
-                if len(sorted_list) == 0:
-                    continue
-
-                keep, try_evolve, try_upgrade, buddy = self.get_best_pokemon_for_rule(sorted_list, rule)
-                keep_all += keep
-                try_evolve_all += try_evolve
-                try_upgrade_all += try_upgrade
-                buddy_all += buddy
-
-        keep_all = self.unique_pokemon_list(keep_all)
-        try_evolve_all = self.unique_pokemon_list(try_evolve_all)
-        try_upgrade_all = self.unique_pokemon_list(try_upgrade_all)
-        buddy_all = self.unique_pokemon_list(buddy_all)
-
-        if (not self.lock_buddy) and (len(buddy_all) > 0):
-            new_buddy = buddy_all[0]
-
-            if (not self.buddy) or (self.buddy["id"] != new_buddy.unique_id):
-                self.set_buddy_pokemon(new_buddy)
-
-        if self.get_pokemon_slot_left() > self.config_min_slots_left:
-            return WorkerResult.SUCCESS
-
+<<<<<<< Updated upstream
         # Repeat the optimizer 2 times, to get rid of the trash evolved.
         for _ in itertools.repeat(None, 2):
+=======
+>>>>>>> Stashed changes
             transfer_all = []
             evolve_all = []
             upgrade_all = []

--- a/pokemongo_bot/cell_workers/pokemon_optimizer.py
+++ b/pokemongo_bot/cell_workers/pokemon_optimizer.py
@@ -227,11 +227,6 @@ class PokemonOptimizer(BaseTask):
                 if (not self.buddy) or (self.buddy["id"] != new_buddy.unique_id):
                     self.set_buddy_pokemon(new_buddy)
 
-<<<<<<< Updated upstream
-        # Repeat the optimizer 2 times, to get rid of the trash evolved.
-        for _ in itertools.repeat(None, 2):
-=======
->>>>>>> Stashed changes
             transfer_all = []
             evolve_all = []
             upgrade_all = []
@@ -725,13 +720,13 @@ class PokemonOptimizer(BaseTask):
                             return False
                 except Exception:
                     return False
-                
+
                 for pokemon in transfered:
                     candy = inventory.candies().get(pokemon.pokemon_id)
 
                     if self.config_transfer and (not self.bot.config.test):
                         candy.add(1)
-                        
+
                     self.emit_event("pokemon_release",
                                     formatted="Exchanged {pokemon} [IV {iv}] [CP {cp}] [{candy} candies]",
                                     data={"pokemon": pokemon.name,


### PR DESCRIPTION
## Short Description:
The getting rid of Pokemons after evolving trash seems to be bugged; it transfers Pokemon who just got evolved. This moves the 2 times loop up, so the loop will re-open the iventory (with the new pokemons) and it will re-evalutate the rules with the reloaded inventory.
I hope with this fix the transfer of good Pokemon will stop

## Fixes/Resolves/Closes (please use correct syntax):
- #5999 
- #6004 (no description given, I think this is related aswel? If not, please say so!)
