### PR TITLE
[CatchLimiter] Resume at X balls

### DIFF
--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -201,6 +201,7 @@ The behaviors of the bot are configured via the `tasks` key in the `config.json`
 * Catch Limiter
   * `enabled`: Default false | Enable/disable the task
   * `min_balls`: Default 20 | Minimum balls on hand before catch tasks enabled
+  * `resume_at_balls`: Default 100 | When this number of balls is reached, immediately resume catching
   * `duration`: Default 15 | Length of time to disable catch tasks
 * EvolvePokemon
   * `enable`: Disable or enable this task.


### PR DESCRIPTION
## Short Description:
CatchLimiter keeps us from running out of balls. But when botting in a PokeStop littered area (NYC) the number of balls can get high very fast.

## Fixes/Resolves/Closes (please use correct syntax):
This change lets you set a "resume catching when X balls reached" setting. When there are at least X (default 100) balls in the inventory, resume catching.