### PR TITLE
Fix Markdown in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ If you need any help please don't create an issue as we have a great community o
 ## Discord
   - [Click here to join discord server](https://discord.gg/n3g5puF)
 
-###[Bugs / Issues](https://github.com/PokemonGoF/PokemonGo-Bot/issues?q=is%3Aissue+sort%3Aupdated-desc)
+### [Bugs / Issues](https://github.com/PokemonGoF/PokemonGo-Bot/issues?q=is%3Aissue+sort%3Aupdated-desc)
 If you discover a bug in the bot, please [search our issue tracker](https://github.com/PokemonGoF/PokemonGo-Bot/issues?q=is%3Aissue+sort%3Aupdated-desc) first. If it hasn't been reported, please [create a new issue](https://github.com/PokemonGoF/PokemonGo-Bot/issues/new) and ensure you follow the template guide so that our team can assist you as quickly as possible.
 
-###[Feature Requests](https://github.com/PokemonGoF/PokemonGo-Bot/labels/Feature%20Request)
+### [Feature Requests](https://github.com/PokemonGoF/PokemonGo-Bot/labels/Feature%20Request)
 If you have a great idea to improve the bot, please [search our feature tracker](https://github.com/PokemonGoF/PokemonGo-Bot/labels/Feature%20Request) first to ensure someone else hasn't already come up with the same great idea.  If it hasn't been requested, please [create a new request](https://github.com/PokemonGoF/PokemonGo-Bot/issues/new) and ensure you follow the template guide so that it doesnt get lost with the bug reports.
 While you're there vote on other feature requests to let the devs know what is most important to you.
 
-###[Pull Requests](https://github.com/PokemonGoF/PokemonGo-Bot/pulls)
+### [Pull Requests](https://github.com/PokemonGoF/PokemonGo-Bot/pulls)
 If you'd like to make your own changes, make sure you follow the pull request template, and ensure your PR is made against the 'dev' branch.
 
 If this is your first time making a PR or aren't sure of the standard practice of making a PR, here are some articles to get you started.

--- a/docs/google_map.md
+++ b/docs/google_map.md
@@ -1,6 +1,6 @@
 The webpage is a submodule to this repository and config related to that is in ./web folder
 
-[OpenPoGoWeb] (https://github.com/OpenPoGo/OpenPoGoWeb) uses Google Maps. Read their [README] (https://github.com/OpenPoGo/OpenPoGoWeb/blob/master/README.md) for how to configure web frontend
+[OpenPoGoWeb](https://github.com/OpenPoGo/OpenPoGoWeb) uses Google Maps. Read their [README](https://github.com/OpenPoGo/OpenPoGoWeb/blob/master/README.md) for how to configure web frontend
 
 ## How to set up a simple webserver with nginx
 ## SimpleHTTPServer

--- a/docs/manual_installation.md
+++ b/docs/manual_installation.md
@@ -8,13 +8,13 @@ Consider purchase of [hashing key](http://hashing.pogodev.org) - if you want use
 ### Linux and Mac
 Ubuntu will be used for the Linux Example
 
-####First install required packages
+#### First install required packages
 
-#####Linux - Ubuntu
+##### Linux - Ubuntu
 ```bash
 sudo apt-get install build-essential autoconf libtool pkg-config make python2.7-dev wget git
 ```
-#####Linux - Centos 7
+##### Linux - Centos 7
 ```bash
 sudo yum install -y epel-release
 sudo yum install -y git wget python python-pip
@@ -26,11 +26,11 @@ if you are on a different Linux OS you maybe have to adapt things like:
 - package manager (for example yum instead of apt-get)
 - package names
 
-#####Mac
+##### Mac
 ```bash
 brew install  autoconf libtool pkg-config wget git
 ```
-####Mac + Linux installation
+#### Mac + Linux installation
 make sure you installed everything above
 
 - get pip for python2.7


### PR DESCRIPTION
The GitHub Markdown interpreter has recently been changed to strictly enforce the [GFM spec](https://github.github.com/gfm/) which has caused some Markdown to no longer display as originally intended.