### PR TITLE
Remove error for empty reply in sniper feed

### DIFF
--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -144,8 +144,6 @@ class SniperSource(object):
                     # All wrong mappings were gathered at once for a better usability (instead of raising multiple exceptions)
                     if errors:
                         raise LookupError("The following params dont exist: {}".format(", ".join(errors)))
-                else:
-                    raise ValueError("Empty reply")
             else:
                 raise ValueError("Source is not enabled")
         except requests.exceptions.Timeout:


### PR DESCRIPTION
When starting up the bot, if the sniper feed has 0 items in it, it disables sniping for the rest of the session. This might make sense on the surface for something like a RocketMap feed, where there should always be at least something, but when using a custom feed with only amazing spawns, it's often empty. This isn't a problem - the sniper loops through all items in the feed, which in this case is zero, then moves on. Actual problems with the feed (404, invalid JSON, etc) will trigger a separate error. 

I've tested this with a valid feed with items, a valid feed with zero items, and invalid feeds - all work as expected.

# Please Note - You may remove this section before opening your PR
We receive lots of PRs and it is hard to give proper review to PRs. Please make it easy on us by following these guidelines:

1. We do not accept changes to `master`. Please make sure your pull request is aimed at `dev`.
2. If you changed a bunch of files (that aren't config files) or multiple workers to implement your feature, it probably won't get proper attention. Please split it up into multiple, smaller, more focused, and iterative PRs if you can.
3. If you are adding a config value to something, make sure you update the appropriate `config.json` example files.
4. If your pull request is fixing / resolving / or closing any of the issues, please ensure the [correct syntax](https://github.com/blog/1506-closing-issues-via-pull-requests) is used eg: Closes #X, Fixes#Y

## Short Description:

## Fixes/Resolves/Closes (please use correct syntax):
-
-
-
