### PR TITLE
Correcting HP of Pokemon

### DIFF
--- a/pokemongo_bot/inventory.py
+++ b/pokemongo_bot/inventory.py
@@ -981,7 +981,7 @@ class Pokemon(object):
         # Maximum health points
         self.hp_max = data['stamina_max']
         # Current health points
-        self.hp = data.get('stamina', self.hp_max)
+        self.hp = data.get('stamina', 0) #self.hp_max)
         assert 0 <= self.hp <= self.hp_max
 
         # Individial Values of the current specific pokemon (different for each)


### PR DESCRIPTION
Before the change if a Pokemon has 0 HP, it will be set to the Max HP.
This corrects this, setting HP to 0 when a Pokemon is dead/fainted.