### PR TITLE
Improve handling of softban

### DIFF
--- a/pokemongo_bot/cell_workers/camp_fort.py
+++ b/pokemongo_bot/cell_workers/camp_fort.py
@@ -53,6 +53,15 @@ class CampFort(BaseTask):
         else:
             self.bot.camper_disabled_global_warning = False
 
+        if self.bot.softban:
+            if not hasattr(self.bot, "camper_softban_global_warning") or \
+                        (hasattr(self.bot, "camper_softban_global_warning") and not self.bot.camper_softban_global_warning):
+                self.logger.info("Possible softban! Not camping forts till fixed.")
+            self.bot.camper_softban_global_warning = True
+            return WorkerResult.SUCCESS
+        else:
+            self.bot.softban_global_warning = False
+
         now = time.time()
 
         if now < self.move_until:

--- a/pokemongo_bot/cell_workers/catch_pokemon.py
+++ b/pokemongo_bot/cell_workers/catch_pokemon.py
@@ -29,6 +29,15 @@ class CatchPokemon(BaseTask):
     [Item.ITEM_POKE_BALL, Item.ITEM_GREAT_BALL, Item.ITEM_ULTRA_BALL]]) <= 0:
             return WorkerResult.ERROR
 
+        if self.bot.softban:
+            if not hasattr(self.bot, "softban_global_warning") or \
+                        (hasattr(self.bot, "softban_global_warning") and not self.bot.softban_global_warning):
+                self.logger.info("Possible softban! Not trying to catch Pokemon.")
+            self.bot.softban_global_warning = True
+            return WorkerResult.SUCCESS
+        else:
+            self.bot.softban_global_warning = False
+
 	# Don't try to catch a Pokemon when catching is disabled.
         if self.bot.catch_disabled:
             if not hasattr(self.bot,"all_disabled_global_warning") or \

--- a/pokemongo_bot/cell_workers/move_to_fort.py
+++ b/pokemongo_bot/cell_workers/move_to_fort.py
@@ -107,7 +107,7 @@ class MoveToFort(BaseTask):
             else:
                 self.emit_event(
                     'arrived_at_fort',
-                    formatted='Arrived at fort.'
+                    formatted='Arrived at fort %s.' % fort_name
                 )
 
         return WorkerResult.RUNNING

--- a/pokemongo_bot/cell_workers/move_to_map_pokemon.py
+++ b/pokemongo_bot/cell_workers/move_to_map_pokemon.py
@@ -290,7 +290,7 @@ class MoveToMapPokemon(BaseTask):
                 self._emit_log("Not enough balls to start sniping (have {}, {} needed)".format(
                     pokeballs_quantity + superballs_quantity + ultraballs_quantity, self.min_ball))
             return WorkerResult.SUCCESS
-            
+
         if self.bot.catch_disabled:
             if not hasattr(self.bot,"mtmp_disabled_global_warning") or \
                         (hasattr(self.bot,"mtmp_disabled_global_warning") and not self.bot.mtmp_disabled_global_warning):
@@ -299,6 +299,15 @@ class MoveToMapPokemon(BaseTask):
             return WorkerResult.SUCCESS
         else:
             self.bot.mtmp_disabled_global_warning = False
+
+        if self.bot.softban:
+            if not hasattr(self.bot, "softban_global_warning") or \
+                        (hasattr(self.bot, "softban_global_warning") and not self.bot.softban_global_warning):
+                self.logger.info("Possible softban! Not trying to catch Pokemon.")
+            self.bot.softban_global_warning = True
+            return WorkerResult.SUCCESS
+        else:
+            self.bot.softban_global_warning = False
 
         # Retrieve pokemos
         self.dump_caught_pokemon()

--- a/pokemongo_bot/cell_workers/pokemon_hunter.py
+++ b/pokemongo_bot/cell_workers/pokemon_hunter.py
@@ -78,6 +78,15 @@ class PokemonHunter(BaseTask):
         else:
             self.bot.hunter_disabled_global_warning = False
 
+        if self.bot.softban:
+            if not hasattr(self.bot, "softban_global_warning") or \
+                        (hasattr(self.bot, "softban_global_warning") and not self.bot.softban_global_warning):
+                self.logger.info("Possible softban! Not trying to catch Pokemon.")
+            self.bot.softban_global_warning = True
+            return WorkerResult.SUCCESS
+        else:
+            self.bot.softban_global_warning = False
+
         if self.get_pokeball_count() <= 0:
             self.destination = None
             self.last_cell_id = None

--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -453,6 +453,16 @@ class Sniper(BaseTask):
             # Resume hunting
             self.no_hunt_until = None
 
+        if self.bot.softban:
+            if not hasattr(self.bot, "sniper_softban_global_warning") or \
+                        (hasattr(self.bot, "sniper_softban_global_warning") and not self.bot.sniper_softban_global_warning):
+                self.logger.info("Possible softban! Not sniping any targets.")
+            self.bot.sniper_softban_global_warning = True
+            return WorkerResult.SUCCESS
+        else:
+            self.bot.softban_global_warning = False
+
+        sniped = False
         # Do nothing if this task was invalidated
         if self.disabled:
             self._error("Sniper was disabled for some reason. Scroll up to find out.")


### PR DESCRIPTION
When being softbanned, stop all tasks that can lead to bad things. Like
sniper, catching Pokemon or hunting for Pokemon. This will disable those
tasks until the softban should be lifted. After fixing the softban,
still all catch tasks will be disabled for a minute. Hopefully you will
move toward another Pokestop then to check if we are still softbanned.
Niantic seems to have increased the number of spins required to lift a
softban, but it's unknown to me how many times is needed now.