### PR TITLE
Improved error when hash key is expired

### DIFF
--- a/pokemongo_bot/api_wrapper.py
+++ b/pokemongo_bot/api_wrapper.py
@@ -9,7 +9,7 @@ import sys
 from pgoapi.exceptions import (ServerSideRequestThrottlingException,
                                NotLoggedInException, ServerBusyOrOfflineException,
                                NoPlayerPositionSetException, HashingOfflineException,
-                               UnexpectedResponseException)
+                               UnexpectedResponseException, BadHashRequestException)
 from pgoapi.pgoapi import PGoApi
 from pgoapi.pgoapi import PGoApiRequest
 from pgoapi.pgoapi import RpcApi
@@ -29,7 +29,8 @@ class ApiWrapper(PGoApi, object):
     def __init__(self, config=None):
         self.config = config
         self.gen_device_id()
-        
+        self.logger = logging.getLogger(__name__)
+
         device_info = {
             "device_id": ApiWrapper.DEVICE_ID,
             "device_brand": 'Apple',
@@ -94,18 +95,25 @@ class ApiWrapper(PGoApi, object):
     def login(self, provider, username, password):
         # login needs base class "create_request"
         self.useVanillaRequest = True
-        
+
         try:
             PGoApi.set_authentication(
-                    self,
-                    provider,
-                    username=username,
-                    password=password
-                    )
+                self,
+                provider,
+                username=username,
+                password=password
+            )
         except:
             raise
-
-        response = PGoApi.app_simulation_login(self)
+        try:
+            response = PGoApi.app_simulation_login(self)
+        except BadHashRequestException:
+            self.logger.warning("You hashkey seems to have expired or is not accepted!")
+            self.logger.warning("Please set a valid hash key in your auth JSON file!")
+            exit(-3)
+            raise
+        except:
+            raise
         # cleanup code
         self.useVanillaRequest = False
         return response
@@ -158,7 +166,14 @@ class ApiRequest(PGoApiRequest):
         return True
 
     def _call(self):
-        return PGoApiRequest.call(self)
+        for _attempt in range(10):
+            try:
+                return PGoApiRequest.call(self)
+            except:
+                self.log.info('Request failed, retrying.')
+                sleep(1)
+            else:
+                break
 
     def _pop_request_callers(self):
         r = self.request_callers
@@ -210,7 +225,7 @@ class ApiRequest(PGoApiRequest):
             should_throttle_retry = False
             should_unexpected_response_retry = False
             hashing_offline = False
-            
+
             try:
                 result = self._call()
             except ServerSideRequestThrottlingException:
@@ -221,7 +236,7 @@ class ApiRequest(PGoApiRequest):
                 should_unexpected_response_retry = True
             except:
                 should_unexpected_response_retry = True
-            
+
             if hashing_offline:
                 self.logger.warning('Hashing server issue, retrying in 5 Secs...')
                 sleep(5)


### PR DESCRIPTION
This message will guide the user when they run the bot without a valid hash-key.
This is a better message than just erroring out.