### PR TITLE
Pokemon Hunter - Mobster and Trash Hunter

### DIFF
--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -1408,13 +1408,23 @@ Hunts down nearby Pokemon. Searches for Pokemon to complete the Pokedex, or if a
 [[back to top](#table-of-contents)]
 
 * `max_distance`: `Default: 2000`. Maxium of meters for the "nearby" part.
+* `enable_cooldown`: `Default: true`. After a hunt (succesful or not) have a cool down (stops hunting for a bit)
 * `hunt_all`: `Default: false`. Should we hunt for ALL nearby Pokemon?
 * `hunt_vip`: `Default: true`. Should we hunt for VIP Pokemon?
 * `hunt_pokedex`: `Default: true`. Should we hunt for Pokemon we need to complete the Pokedex (make family complete)
 * `lock_on_target`: `Default: false`. Should we ignore all other Pokemon while hunting?
 * `lock_vip_only`: `Default: true`. Is the above only used for real VIPs? (Not to complete the Pokedex)
 * `disabled_while_camping`: `Default: true`. Should we stop hunting for nearby Pokemon while sitting at lures?
+* `hunt_closest_first`: `Default: false`. Prioritize by distance instead of number of candy?
 * `treat_unseen_as_vip`: `Default: true`. Should we treat unseen Pokemons as VIPs?
+* `target_family_of_vip`: `Default: true`. Should we treat family of a VIP as a valid target?
+* `treat_family_of_vip_as_vip`: `Default: false`. Should we see family of an VIP as a VIP (locking onto it if enabled)
+* `hunt_for_trash_to_fill_bag`: `Default: false`. Should we try to fill the bag with trash if a set amount of slots is left?
+* `trash_hunt_open_slots`: `Default: 25`. The amount of slots for the previous setting
+
+### Hunting for trash
+If enabled the hunter will start hunting down Pidgeys, Weedles and Caterpies when a set amount of slots (defaults to 25) are left in the bag to fill. The idea is simple; we are about to start evolving Pokemon. So the priority of the hunter shiftes. BUT when a VIP Pokemon is nearby, the Hunter will always start chasing that VIP first.
+Also hunting for trash does NOT lock the target, catching all Pokemon it find on the way to the target.
 
 ### Sample configuration
 [[back to top](#table-of-contents)]
@@ -1423,6 +1433,7 @@ Hunts down nearby Pokemon. Searches for Pokemon to complete the Pokedex, or if a
     "type": "PokemonHunter",
     "config": {
         "enabled": true,
+        "enable_cooldown": false,
         "max_distance": 1500,
         "hunt_all": false,
         "hunt_vip": true,
@@ -1430,7 +1441,10 @@ Hunts down nearby Pokemon. Searches for Pokemon to complete the Pokedex, or if a
         "lock_on_target": false,
         "lock_vip_only": true,
         "disabled_while_camping": true,
-        "treat_unseen_as_vip": true
+        "hunt_closest_first": true,
+        "treat_unseen_as_vip": true,
+        "hunt_for_trash_to_fill_bag": true,
+        "trash_hunt_open_slots": 30
     }
 }
 ```

--- a/pokemongo_bot/cell_workers/pokemon_hunter.py
+++ b/pokemongo_bot/cell_workers/pokemon_hunter.py
@@ -14,6 +14,7 @@ from pokemongo_bot.item_list import Item
 from pokemongo_bot.walkers.polyline_walker import PolylineWalker
 from pokemongo_bot.walkers.step_walker import StepWalker
 from pokemongo_bot.worker_result import WorkerResult
+from .utils import fort_details
 
 import random
 from random import uniform
@@ -25,6 +26,7 @@ class PokemonHunter(BaseTask):
         super(PokemonHunter, self).__init__(bot, config)
 
     def initialize(self):
+        self.max_pokemon_storage = inventory.get_pokemon_inventory_size()
         self.notified_second_gen = []
         self.destination = None
         self.walker = None
@@ -42,6 +44,9 @@ class PokemonHunter(BaseTask):
         self.config_hunt_all = self.config.get("hunt_all", False)
         self.config_hunt_vip = self.config.get("hunt_vip", True)
         self.config_hunt_pokedex = self.config.get("hunt_pokedex", True)
+        self.config_enable_cooldown = self.config.get("enable_cooldown", True)
+        # closest first?
+        self.config_hunt_closest_first = self.config.get("hunt_closest_first", False)
         # Lock on Target; ignore all other Pokémon until we found our target.
         self.config_lock_on_target = self.config.get("lock_on_target", False)
         # Lock only VIP Pokemon (unseen / VIP)
@@ -50,11 +55,46 @@ class PokemonHunter(BaseTask):
         self.config_disabled_while_camping = self.config.get("disabled_while_camping", True)
         # Hunt unseens as VIP?
         self.config_treat_unseen_as_vip = self.config.get("treat_unseen_as_vip", True)
+        self.config_target_family_of_vip = self.config.get("target_family_of_vip", True)
+        self.config_treat_family_of_vip_as_vip = self.config.get("treat_family_of_vip_as_vip", False)
         self.bot.hunter_locked_target = None
+        # Hunt for trash when bags are almost full
+        self.config_hunt_for_trash = self.config.get("hunt_for_trash_to_fill_bag", False)
+        self.config_trash_hunt_open_slots = self.config.get("trash_hunt_open_slots", 25)
+        self.hunting_trash = False
 
     def work(self):
         if not self.enabled:
             return WorkerResult.SUCCESS
+
+        if self.bot.catch_disabled:
+            # When catching is disabled, drop the target.
+            if self.destination is not None:
+                self.destination = None
+                self.last_cell_id = None
+
+            if not hasattr(self.bot, "hunter_disabled_global_warning") or \
+                        (hasattr(self.bot, "hunter_disabled_global_warning") and not self.bot.hunter_disabled_global_warning):
+                self.logger.info("All catching tasks are currently disabled until {}. Pokemon Hunter will resume when catching tasks are re-enabled".format(self.bot.catch_resume_at.strftime("%H:%M:%S")))
+            self.bot.hunter_disabled_global_warning = True
+            return WorkerResult.SUCCESS
+        else:
+            self.bot.hunter_disabled_global_warning = False
+
+        if self.bot.softban:
+            # At softban, drop target
+            if self.destination is not None:
+                self.destination = None
+                self.last_cell_id = None
+                self.hunting_trash = False
+
+            if not hasattr(self.bot, "softban_global_warning") or \
+                        (hasattr(self.bot, "softban_global_warning") and not self.bot.softban_global_warning):
+                self.logger.info("Possible softban! Not trying to catch Pokemon.")
+            self.bot.softban_global_warning = True
+            return WorkerResult.SUCCESS
+        else:
+            self.bot.softban_global_warning = False
 
         if self.config_disabled_while_camping and hasattr(self.bot, 'camping_forts') and self.bot.camping_forts:
             return WorkerResult.SUCCESS
@@ -69,50 +109,77 @@ class PokemonHunter(BaseTask):
             # Resume hunting
             self.no_hunt_until = None
 
-        if self.bot.catch_disabled:
-            if not hasattr(self.bot,"hunter_disabled_global_warning") or \
-                        (hasattr(self.bot,"hunter_disabled_global_warning") and not self.bot.hunter_disabled_global_warning):
-                self.logger.info("All catching tasks are currently disabled until {}. Pokemon Hunter will resume when catching tasks are re-enabled".format(self.bot.catch_resume_at.strftime("%H:%M:%S")))
-            self.bot.hunter_disabled_global_warning = True
-            return WorkerResult.SUCCESS
-        else:
-            self.bot.hunter_disabled_global_warning = False
-
-        if self.bot.softban:
-            if not hasattr(self.bot, "softban_global_warning") or \
-                        (hasattr(self.bot, "softban_global_warning") and not self.bot.softban_global_warning):
-                self.logger.info("Possible softban! Not trying to catch Pokemon.")
-            self.bot.softban_global_warning = True
-            return WorkerResult.SUCCESS
-        else:
-            self.bot.softban_global_warning = False
-
         if self.get_pokeball_count() <= 0:
             self.destination = None
             self.last_cell_id = None
+            self.hunting_trash = False
             return WorkerResult.SUCCESS
 
         if self.destination is not None:
             if self.destination_caught():
-                self.logger.info("We found a %(name)s while hunting. Aborting the current search.", self.destination)
+                self.logger.info("We found a %(name)s while hunting.", self.destination)
+                self.recent_tries.append(self.destination['pokemon_id'])
                 self.destination = None
-                wait = uniform(120, 600)
-                self.no_hunt_until = time.time() + wait
-                self.logger.info("Hunting on cooldown until {}.".format((datetime.now() + timedelta(seconds=wait)).strftime("%H:%M:%S")))
-                return WorkerResult.SUCCESS
+                self.hunting_trash = False
+                if self.config_enable_cooldown:
+                    wait = uniform(120, 600)
+                    self.no_hunt_until = time.time() + wait
+                    self.logger.info("Hunting on cooldown until {}.".format((datetime.now() + timedelta(seconds=wait)).strftime("%H:%M:%S")))
+                    return WorkerResult.SUCCESS
+                else:
+                    self.logger.info("Electing new target....")
+
+            if self.destination_vanished():
+                self.logger.info("Darn, target got away!")
+                self.recent_tries.append(self.destination['pokemon_id'])
+                self.destination = None
+                self.hunting_trash = False
+                if self.config_enable_cooldown:
+                    wait = uniform(120, 600)
+                    self.no_hunt_until = time.time() + wait
+                    self.logger.info("Hunting on cooldown until {}.".format((datetime.now() + timedelta(seconds=wait)).strftime("%H:%M:%S")))
+                    return WorkerResult.SUCCESS
+                else:
+                    self.logger.info("Electing new target....")
 
         now = time.time()
         pokemons = self.get_nearby_pokemons()
         pokemons = filter(lambda x: x["pokemon_id"] not in self.recent_tries, pokemons)
 
+        if self.config_hunt_for_trash and self.hunting_trash is False and (self.destination is None or self._is_vip_pokemon(self.destination) is False ):
+            # Okay, we should hunt for trash if the bag is almost full
+            trash_mons = ["Caterpie", "Weedle", "Pidgey", "Pidgeotto", "Pidgeot", "Kakuna", "Beedrill", "Metapod", "Butterfree"]
+            if self.pokemon_slots_left() <= self.config_trash_hunt_open_slots:
+                if self.no_log_until < now:
+                    self.logger.info("Less than %s slots left to fill, starting hunt for trash" % elf.config_trash_hunt_open_slots)
+                for pokemon in pokemons:
+                    if pokemon["name"] in trash_mons:
+                        self.hunting_trash = True
+                        self.destination = pokemon
+                        self.lost_counter = 0
+                        self.hunt_started_at = datetime.now()
+                        self.logger.info("Hunting for trash at %(distance).2f meters: %(name)s", self.destination)
+                        self.set_target()
+                        # We have a target
+                        return WorkerResult.SUCCESS
+
+        if self.config_hunt_for_trash and self.hunting_trash:
+            if self.pokemon_slots_left() > 20:
+                self.logger.info("No longer trying to fill the bag. Electing new target....")
+                self.hunting_trash = False
+                self.destination = None
+
         if self.destination is None:
-            worth_pokemons = self.get_worth_pokemons(pokemons)
+            worth_pokemons = self.get_worth_pokemons(pokemons, self.config_hunt_closest_first)
 
             if len(worth_pokemons) > 0:
                 # Pick a random target from the list
-                random.shuffle(worth_pokemons)
+                # random.shuffle(worth_pokemons)
+                # Priotize closer pokemon
+                worth_pokemons.sort(key=lambda p: p["distance"])
                 # Prevents the bot from looping the same Pokemon
                 self.destination = worth_pokemons[0]
+                self.set_target()
                 self.lost_counter = 0
                 self.hunt_started_at = datetime.now()
 
@@ -129,12 +196,8 @@ class PokemonHunter(BaseTask):
                         self.bot.hunter_locked_target = None
 
                 self.no_log_until = now + 60
-
-                if self.destination["s2_cell_id"] != self.search_cell_id:
-                    self.search_points = self.get_search_points(self.destination["s2_cell_id"])
-                    self.walker = PolylineWalker(self.bot, self.search_points[0][0], self.search_points[0][1])
-                    self.search_cell_id = self.destination["s2_cell_id"]
-                    self.search_points = self.search_points[1:] + self.search_points[:1]
+                # We have a target
+                return WorkerResult.SUCCESS
             else:
                 if self.no_log_until < now:
                     # Show like "Pidgey (12), Zubat(2)"
@@ -144,25 +207,60 @@ class PokemonHunter(BaseTask):
                     self.logger.info("There is no nearby pokemon worth hunting down [%s]", ", ".join('{}({})'.format(key, val) for key, val in names.items()))
                     self.no_log_until = now + 120
                     self.destination = None
-                    wait = uniform(120, 600)
-                    self.no_hunt_until = now + wait
-                    self.logger.info("Will look again around {}.".format((datetime.now() + timedelta(seconds=wait)).strftime("%H:%M:%S")))
+                    if self.config_enable_cooldown:
+                        wait = uniform(120, 360)
+                        self.no_hunt_until = now + wait
+                        self.logger.info("Will look again around {}.".format((datetime.now() + timedelta(seconds=wait)).strftime("%H:%M:%S")))
 
                 self.last_cell_id = None
 
                 return WorkerResult.SUCCESS
 
+        # Make sure a VIP is treated that way
+        if self.config_lock_on_target and self.destination is not None:
+            if self._is_vip_pokemon(self.destination) and self.bot.hunter_locked_target is None:
+                self.bot.hunter_locked_target = self.destination
+
+        # Check if there is a VIP around to hunt
+        if (self.destination is not None and
+                self.config_lock_on_target and
+                self.config_lock_vip_only and
+                self.bot.hunter_locked_target is None):
+            worth_pokemons = self.get_worth_pokemons(pokemons)
+            # We have a none VIP target set, check for VIP targets!
+            if len(worth_pokemons) > 0:
+                for pokemon in worth_pokemons:
+                    if self._is_vip_pokemon(pokemon):
+                        self.hunting_trash = False
+                        self.destination = pokemon
+                        self.lost_counter = 0
+                        self.hunt_started_at = datetime.now()
+                        self.set_target()
+                        if self.config_lock_on_target:
+                            self.bot.hunter_locked_target = self.destination
+                        self.logger.info("Found a VIP Pokemon! Looking for a %(name)s at %(distance).2f.", self.destination)
+                        return WorkerResult.SUCCESS
+            pass
+
+        if self.destination is None:
+            if self.no_log_until < now:
+                self.logger.info("Nothing to hunt.")
+            return WorkerResult.SUCCESS
+
         if self.config_lock_on_target and not self.config_lock_vip_only:
             if self.bot.hunter_locked_target == None:
                 self.logger.info("We found a %(name)s while hunting. Aborting the current search.", self.destination)
                 self.destination = None
-                wait = uniform(120, 600)
-                self.no_hunt_until = now + wait
-                self.logger.info("Hunting on cooldown until {}.".format((datetime.now() + timedelta(seconds=wait)).strftime("%H:%M:%S")))
+                self.hunting_trash = False
+                if self.config_enable_cooldown:
+                    wait = uniform(120, 600)
+                    self.no_hunt_until = time.time() + wait
+                    self.logger.info("Hunting on cooldown until {}.".format((datetime.now() + timedelta(seconds=wait)).strftime("%H:%M:%S")))
                 return WorkerResult.SUCCESS
 
         if any(self.destination["encounter_id"] == p["encounter_id"] for p in self.bot.cell["catchable_pokemons"] + self.bot.cell["wild_pokemons"]):
             self.destination = None
+            self.hunting_trash = False
         elif self.walker.step():
             if not any(self.destination["encounter_id"] == p["encounter_id"] for p in pokemons):
                 self.lost_counter += 1
@@ -173,9 +271,11 @@ class PokemonHunter(BaseTask):
                 self.logger.info("I haven't found %(name)s", self.destination)
                 self.bot.hunter_locked_target = None
                 self.destination = None
-                wait = uniform(120, 600)
-                self.no_hunt_until = now + wait
-                self.logger.info("Hunting on cooldown until {}.".format((datetime.now() + timedelta(seconds=wait)).strftime("%H:%M:%S")))
+                self.hunting_trash = False
+                if self.config_enable_cooldown:
+                    wait = uniform(120, 600)
+                    self.no_hunt_until = time.time() + wait
+                    self.logger.info("Hunting on cooldown until {}.".format((datetime.now() + timedelta(seconds=wait)).strftime("%H:%M:%S")))
             else:
                 self.logger.info("Now searching for %(name)s", self.destination)
 
@@ -196,11 +296,13 @@ class PokemonHunter(BaseTask):
 
                 self.recent_tries.append(self.destination['pokemon_id'])
                 self.logger.info("I cant move toward %(name)s! Aborting search.", self.destination)
+                self.hunting_trash = False
                 self.bot.hunter_locked_target = None
                 self.destination = None
-                wait = uniform(120, 600)
-                self.no_hunt_until = now + wait
-                self.logger.info("Hunting on cooldown until {}.".format((datetime.now() + timedelta(seconds=wait)).strftime("%H:%M:%S")))
+                if self.config_enable_cooldown:
+                    wait = uniform(120, 600)
+                    self.no_hunt_until = time.time() + wait
+                    self.logger.info("Hunting on cooldown until {}.".format((datetime.now() + timedelta(seconds=wait)).strftime("%H:%M:%S")))
                 return WorkerResult.ERROR
             else:
                 self.logger.info("Moving to destination at %s meters: %s", round(distance, 2), self.destination["name"])
@@ -216,15 +318,41 @@ class PokemonHunter(BaseTask):
     def get_pokeball_count(self):
         return sum([inventory.items().get(ball.value).count for ball in [Item.ITEM_POKE_BALL, Item.ITEM_GREAT_BALL, Item.ITEM_ULTRA_BALL]])
 
+    def set_target(self):
+        self.search_points = self.get_search_points(self.destination["s2_cell_id"])
+        self.walker = PolylineWalker(self.bot, self.search_points[0][0], self.search_points[0][1])
+        self.search_cell_id = self.destination["s2_cell_id"]
+        self.search_points = self.search_points[1:] + self.search_points[:1]
+
+        if "fort_id" in self.destination:
+            # The Pokemon is hding at a POkestop, so move to that Pokestop!
+            # Get forts
+            forts = self.bot.get_forts(order_by_distance=True)
+            for fort in forts:
+                if fort['id'] == self.destination['fort_id']:
+                    # Found our fort!
+                    lat = fort['latitude']
+                    lng = fort['longitude']
+                    details = fort_details(self.bot, fort['id'], lat, lng)
+                    fort_name = details.get('name', 'Unknown')
+                    self.logger.info("%s is hiding at %s, going there first!" % (self.destination["name"], fort_name))
+                    self.walker = PolylineWalker(self.bot, lat, lng)
+
+    def pokemon_slots_left(self):
+        left = self.max_pokemon_storage - inventory.Pokemons.get_space_used()
+        return left
+
     def get_nearby_pokemons(self):
         radius = self.config_max_distance
 
         pokemons = [p for p in self.bot.cell["nearby_pokemons"] if self.get_distance(self.bot.start_position, p) <= radius]
 
         for pokemon in pokemons:
-            pokemon["distance"] = self.get_distance(self.bot.position, p)
+            pokemon["distance"] = self.get_distance(self.bot.position, pokemon)
             pokemon["name"] = inventory.pokemons().name_for(pokemon["pokemon_id"])
             pokemon["candies"] = inventory.candies().get(pokemon["pokemon_id"]).quantity
+            # Pokemon also has a fort_id of the PokeStop the Pokemon is hiding at.
+            # We should set our first destination at that Pokestop.
 
         pokemons.sort(key=lambda p: p["distance"])
 
@@ -235,6 +363,17 @@ class PokemonHunter(BaseTask):
         # Not seen pokemons also will become vip if it's not disabled in config
         if self.bot.config.vips.get(pokemon["name"]) == {} or (self.config_treat_unseen_as_vip and not inventory.pokedex().seen(pokemon["pokemon_id"])):
             return True
+        # If we must treat the family of the Pokemon as a VIP, also return true!
+        if self.config_treat_family_of_vip_as_vip and self._is_family_of_vip(pokemon):
+            return True
+
+    def _is_family_of_vip(self, pokemon):
+        for fid in self.get_family_ids(pokemon):
+            name = inventory.pokemons().name_for(fid)
+            if self.bot.config.vips.get(name) == {}:
+                return True
+        # No, not a family member of the VIP
+        return False
 
     def _is_needed_pokedex(self, pokemon):
         candies = inventory.candies().get(pokemon["pokemon_id"]).quantity
@@ -259,7 +398,7 @@ class PokemonHunter(BaseTask):
         if any(not inventory.pokedex().seen(fid) for fid in ids):
             return True
 
-    def get_worth_pokemons(self, pokemons):
+    def get_worth_pokemons(self, pokemons, closest_first=False):
         if self.config_hunt_all:
             worth_pokemons = pokemons
         else:
@@ -268,10 +407,16 @@ class PokemonHunter(BaseTask):
             if self.config_hunt_vip:
                 worth_pokemons += [p for p in pokemons if p["name"] in self.bot.config.vips]
 
+            if self.config_target_family_of_vip or self.config_treat_family_of_vip_as_vip:
+                worth_pokemons += [p for p in pokemons if (p not in worth_pokemons) and self._is_family_of_vip(p)]
+
             if self.config_hunt_pokedex:
                 worth_pokemons += [p for p in pokemons if (p not in worth_pokemons) and self._is_needed_pokedex(p)]
 
-        worth_pokemons.sort(key=lambda p: inventory.candies().get(p["pokemon_id"]).quantity)
+        if closest_first:
+            worth_pokemons.sort(key=lambda p: p["distance"])
+        else:
+            worth_pokemons.sort(key=lambda p: inventory.candies().get(p["pokemon_id"]).quantity)
 
         return worth_pokemons
 
@@ -279,7 +424,7 @@ class PokemonHunter(BaseTask):
         family_id = inventory.pokemons().data_for(pokemon["pokemon_id"]).first_evolution_id
         ids = [family_id]
         ids += inventory.pokemons().data_for(family_id).next_evolutions_all[:]
-
+        # ids have now all family ids
         return ids
 
     def get_distance(self, location, pokemon):
@@ -308,7 +453,8 @@ class PokemonHunter(BaseTask):
         return points[index:] + points[:index]
 
     def destination_caught(self):
-        # self.logger.info("Searching for a {} since {}".format(self.destination["name"], self.hunt_started_at.strftime("%Y-%m-%d %H:%M:%S")))
+        if self.destination is None:
+            return False
 
         with self.bot.database as conn:
             c = conn.cursor()
@@ -321,3 +467,19 @@ class PokemonHunter(BaseTask):
             self.logger.info("We caught {} {}(s) since {}".format(amount, self.destination["name"], self.hunt_started_at.strftime("%Y-%m-%d %H:%M:%S")))
 
         return caught
+
+    def destination_vanished(self):
+        if self.destination is None:
+            return False
+
+        with self.bot.database as conn:
+            c = conn.cursor()
+            c.execute(
+                "SELECT COUNT(pokemon) FROM vanish_log where pokemon = '{}' and  datetime(dated, 'localtime') > Datetime('{}')".format(self.destination["name"], self.hunt_started_at.strftime("%Y-%m-%d %H:%M:%S")))
+        # Now check if there is 1 or more caught
+        amount = c.fetchone()[0]
+        vanished = amount > 0
+        if vanished:
+            self.logger.info("We lost {} {}(s) since {}".format(amount, self.destination["name"], self.hunt_started_at.strftime("%Y-%m-%d %H:%M:%S")))
+
+        return vanished


### PR DESCRIPTION
In this version of the Pokemon Hunter, we can select if we want to hunt
down family members of VIPs (Like a mobster) and if we want to hunt for
certain "trash" Pokemon.

If a Pokemon is found to be hunted down, now the Hunter also checks
if the Pokemon is near a Pokestop. If so, it will start hunting there first.

Mobster
When setting "target_family_of_vip"to true, the Hunter will also mark
family of the VIPs you set as a valid target.
If you have "lock_on" enabled, and want to be sure you catch every last
family member of the VIPs, you can enable "treat_family_of_vip_as_vip".
This effectively means that the whole family of a VIP needs to be hunted
down as VIP Pokemons.

Trash Hunting
Trash hunting will trigger when a set amount of space is left in the
bag. If triggered, the Hunter will start hunting down Caterpies, Weedles
and Pidgeys. These only take 12 candy to evolve, so are useful for mass
evolving.

If a VIP Pokemon is detected nearby while hunting for trash, the Hunter
will change the target to the VIP (and locking onto it if enabled)
