### PR TITLE
Hotfixing gympokemon. Application crahses when deploying a pokemon

### DIFF
--- a/pokemongo_bot/cell_workers/gym_pokemon.py
+++ b/pokemongo_bot/cell_workers/gym_pokemon.py
@@ -23,6 +23,8 @@ from pokemongo_bot.tree_config_builder import ConfigException
 from pokemongo_bot.walkers.walker_factory import walker_factory
 from pokemongo_bot.inventory import Pokemons
 
+from sys import stdout
+
 GYM_DETAIL_RESULT_SUCCESS = 1
 GYM_DETAIL_RESULT_OUT_OF_RANGE = 2
 GYM_DETAIL_RESULT_UNSET = 0


### PR DESCRIPTION
Fixing error:

[2017-07-23 16:21:49] [ cli] [INFO] Most Perfect Pokemon: Swinub [CP: 10] [IV: 14/14/15] Potential: 0.96
Traceback (most recent call last):
File "pokecli.py", line 884, in
main()
File "pokecli.py", line 206, in main
bot.tick()
File "/usr/src/app/pokemongo_bot/init.py", line 834, in tick
if worker.work() == WorkerResult.RUNNING:
File "/usr/src/app/pokemongo_bot/cell_workers/gym_pokemon.py", line 154, in work
result = self.move_to_destination()
File "/usr/src/app/pokemongo_bot/cell_workers/gym_pokemon.py", line 320, in move_to_destination
self.drop_pokemon_in_gym(self.destination, current_pokemons)
File "/usr/src/app/pokemongo_bot/cell_workers/gym_pokemon.py", line 438, in drop_pokemon_in_gym
stdout.write("\033[1A\033[0K\r")
NameError: global name 'stdout' is not defined