### PR TITLE
Hotfix 2 for gyms

### DIFF
--- a/pokemongo_bot/cell_workers/gym_pokemon.py
+++ b/pokemongo_bot/cell_workers/gym_pokemon.py
@@ -457,6 +457,7 @@ class GymPokemon(BaseTask):
 
             if lockout_time > datetime.now():
                 self.logger.info("Lockout time: %s" % lockout_time.strftime('%Y-%m-%d %H:%M:%S.%f'))
+                first_time = False
                 while lockout_time > datetime.now():
                     lockout_ending = (lockout_time-datetime.today()).seconds
                     sleep_m, sleep_s = divmod(lockout_ending, 60)


### PR DESCRIPTION
Fixes:

[2017-07-23 16:45:09] [ cli] [INFO] Most Perfect Pokemon: Goldeen [CP: 388] [IV: 15/7/14] Potential: 0.8
Traceback (most recent call last):
File "pokecli.py", line 884, in
main()
File "pokecli.py", line 206, in main
bot.tick()
File "/usr/src/app/pokemongo_bot/init.py", line 834, in tick
if worker.work() == WorkerResult.RUNNING:
File "/usr/src/app/pokemongo_bot/cell_workers/gym_pokemon.py", line 156, in work
result = self.move_to_destination()
File "/usr/src/app/pokemongo_bot/cell_workers/gym_pokemon.py", line 322, in move_to_destination
self.drop_pokemon_in_gym(self.destination, current_pokemons)
File "/usr/src/app/pokemongo_bot/cell_workers/gym_pokemon.py", line 465, in drop_pokemon_in_gym
if not first_time:
UnboundLocalError: local variable 'first_time' referenced before assignment