### PR TITLE
Forcing PGO Api upgrade

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -66,7 +66,7 @@ if sys.version_info >= (2, 7, 9):
 try:
     import pkg_resources
     pgoapi_version = pkg_resources.get_distribution("pgoapi").version
-    if pgoapi_version != '1.2.0':
+    if pgoapi_version != '1.2.1':
         print "Run following command to get latest update: `pip install -r requirements.txt --upgrade`"
         sys.exit(1)
 except pkg_resources.DistributionNotFound:

--- a/pokemongo_bot/event_manager.py
+++ b/pokemongo_bot/event_manager.py
@@ -52,7 +52,8 @@ class Event(object):
             self.sender = str(sender).encode('ascii', 'xmlcharrefreplace')
         
         self.level = str(level).encode('ascii', 'xmlcharrefreplace')
-        self.formatted = str(formatted).encode('ascii', 'xmlcharrefreplace')
+        #self.formatted = str(formatted).encode('ascii', 'xmlcharrefreplace')
+        self.formatted = str(formatted).encode('utf-8', 'xmlcharrefreplace')
         self.data = str(data).encode('ascii', 'xmlcharrefreplace')
         self.friendly_msg = ""
         


### PR DESCRIPTION
Because of most people don't upgrade pogoapi when updating bot, this makes sure they actually do. This commit will check for latest version of pogo api.