### PR TITLE
Fixing #6123

### DIFF
--- a/pokemongo_bot/event_manager.py
+++ b/pokemongo_bot/event_manager.py
@@ -52,8 +52,11 @@ class Event(object):
             self.sender = str(sender).encode('ascii', 'xmlcharrefreplace')
         
         self.level = str(level).encode('ascii', 'xmlcharrefreplace')
-        #self.formatted = str(formatted).encode('ascii', 'xmlcharrefreplace')
-        self.formatted = str(formatted).encode('utf-8', 'xmlcharrefreplace')
+
+        #Fixing issue 6123 for gym names that are in utf format.
+        self.formatted = str(formatted).encode('utf-8', 'ignore').decode('utf-8')
+        self.formatted = str(formatted).encode('ascii', 'xmlcharrefreplace')
+        
         self.data = str(data).encode('ascii', 'xmlcharrefreplace')
         self.friendly_msg = ""
         


### PR DESCRIPTION
When gym names have unicode names, bot crashes when using GymPokemon task. This fix makes the eventmanager more robust.