### PR TITLE
fix last_km_awarded error for new account

### DIFF
--- a/pokemongo_bot/cell_workers/buddy_pokemon.py
+++ b/pokemongo_bot/cell_workers/buddy_pokemon.py
@@ -132,6 +132,9 @@ class BuddyPokemon(BaseTask):
         if not self.buddy:
             return WorkerResult.SUCCESS
 
++        if not self.buddy.has_key('last_km_awarded'):
++            self.buddy['last_km_awarded'] = 0
+
         if self._km_walked() - self.buddy['last_km_awarded'] >= self.buddy_distance_needed:
             self.buddy['last_km_awarded'] += self.buddy_distance_needed
             if not self._get_award():

--- a/pokemongo_bot/cell_workers/buddy_pokemon.py
+++ b/pokemongo_bot/cell_workers/buddy_pokemon.py
@@ -132,8 +132,8 @@ class BuddyPokemon(BaseTask):
         if not self.buddy:
             return WorkerResult.SUCCESS
 
-+        if not self.buddy.has_key('last_km_awarded'):
-+            self.buddy['last_km_awarded'] = 0
+        if not self.buddy.has_key('last_km_awarded'):
+            self.buddy['last_km_awarded'] = 0
 
         if self._km_walked() - self.buddy['last_km_awarded'] >= self.buddy_distance_needed:
             self.buddy['last_km_awarded'] += self.buddy_distance_needed


### PR DESCRIPTION
## Short Description:

This PR fixes error  with `last_km_awarded`, which apears on newly created accounts. 

## Fixes/Resolves/Closes (please use correct syntax):
- Fixes #5778
and similar