### PR TITLE
Killswitch changes

### DIFF
--- a/killswitch.json
+++ b/killswitch.json
@@ -1,5 +1,7 @@
 {
-    "killswitch": true,
+    "killswitch": false,
+	"show_warning": true,
+	"pause_bot": true,
     "activated_by": "MerlionRock",
-    "message": "Current API is unsafe.\nPlease visit our Discord Channel (Announcement) for more information.\nTo overwrite killswitch, add \"killswitch\": \"false\" to config.json"
+    "message": "Bot is now compatible with 0.73.1 API. There are noted issues with the current API and subsequent bans and warnings may very well be issued and you take the risk into your own hands if you follow through."
 }

--- a/pokecli.py
+++ b/pokecli.py
@@ -119,7 +119,19 @@ def main():
                 print "\033[91mKill Switch Activated By: \033[0m" + format(killswitch_data['activated_by'])
                 print "\033[91mMessage: \033[0m\n" + format(killswitch_data['message']) + "\n\n\n"
                 sys.exit(1)
-    
+            
+            if killswitch_data['show_warning']:
+                yn=None
+                while yn==None:
+                    if killswitch_data['pause_bot']:
+                        yn = yes_no("\033[91mMessage: " + format(killswitch_data['message'])+ "\033[0m\nDo you wish to continue? Y/N")
+                    else:
+                        print "\033[91mMessage: " + format(killswitch_data['message']) + "\033[0m\n"
+                        yn = True
+                        time.sleep(5)
+                if not yn:
+                    sys.exit(1)
+
         try:
             import pkg_resources
             pgoapi_version = pkg_resources.get_distribution("pgoapi").version


### PR DESCRIPTION
Change it to allow users to continue if they want to.
Also allows developers to add message without pausing the bot.
 
However, the ability to totally kill the bot is retained.