### PR TITLE
Fixed Inappropriate Logical Expression

### DIFF
--- a/pokemongo_bot/event_handlers/telegram_handler.py
+++ b/pokemongo_bot/event_handlers/telegram_handler.py
@@ -406,7 +406,7 @@ class TelegramClass:
             for sub in conn.execute("select uid, event_type, parameters from telegram_subscriptions where uid = ?",
                                     [update.message.chat_id]).fetchall():
                 subs.append("{} -&gt; {}".format(sub[1], sub[2]))
-        if subs is []: subs.append(
+        if subs == []: subs.append(
             "No subscriptions found. Subscribe using /sub EVENTNAME. For a list of events, send /events")
         self.sendMessage(chat_id=update.message.chat_id, parse_mode='HTML', text="\n{}".join(subs))
 


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [telegram_handler.py](https://github.com/PokemonGoF/PokemonGo-Bot/blob/master/pokemongo_bot/event_handlers/telegram_handler.py#L409), method: showsubs, a logical expression uses the identity operator. A new object is created inside the identity check operation and then used for matching identity. Since this is a distinct, new object, it will not match with anything else. As a result, the identity check will have a logical short circuit and the program may have unintended behavior. iCR suggested that the logical operation should be reviewed for correctness.

#### Example
Running the program below will give the output-
```python
foo = []
print(foo is [])
print(foo == [])
```
```
False
True
```


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
